### PR TITLE
[WIP] Interim corrections and maintenance prior to Sprint 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ vault
 */working/**/*.pdf
 
 # Working files
+scratch
 wendell
 
 # Production outputs

--- a/examples/FedRAMP/FedRAMP-HIGH-edited.xml
+++ b/examples/FedRAMP/FedRAMP-HIGH-edited.xml
@@ -441,7 +441,7 @@
       <!-- - - - - - -->
       <set-param param-id="ac-1_a">
          <desc>organization-defined personnel or roles</desc>
-         <value>organization-defined personnel or roles</value>
+         <value>at least annually</value>
       </set-param>
       <set-param param-id="ac-1_b">
          <desc>organization-defined frequency</desc>

--- a/examples/FedRAMP/pub/oscal-html-fancy.css
+++ b/examples/FedRAMP/pub/oscal-html-fancy.css
@@ -32,6 +32,7 @@
       .unassigned { border: thin solid red; background-color: pink}
       .desc { color: darkgreen }
       .insert .desc { font-size: 90% }
+      .label { font-size: 90%; font-weight: bold }
       .value { font-style: italic; text-decoration: underline }
       
       .param-id { font-size: 90%; font-family: sans-serif; font-weight: bold;
@@ -66,7 +67,7 @@ overflow: auto
 .toc .toc { margin-left: 2ex; border-left: thin dotted black; padding-left: 0.5em }
 .toc-line { padding-left: 1em; text-indent: -1em }
 
-.default { text-decoration: line-through }
+.label { font-weight: bold; font-size: 85% }
 .invoking { margin-left: 0.2ex; margin-right: 0.2ex; padding: 0.1ex;
 border: thin dashed grey; background-color: azure }
 

--- a/examples/mini-testing/dinosaur-profile.xml
+++ b/examples/mini-testing/dinosaur-profile.xml
@@ -24,13 +24,13 @@
     
   </import>
   <!--<merge combine="merge"/>-->
-  <merge>
+  <!--<merge>
     <combine method="keep"/>
-<!-- semantics of 'merge' combination should be specified (and tested!)   -->
-    <!--<as-is/>-->
+<!-\- semantics of 'merge' combination should be specified (and tested!)   -\->
+    <!-\-<as-is/>-\->
     
     
-  </merge>
+  </merge>-->
   <!--<import href="something-else.xml"/>-->
    
    <!--<merge>
@@ -47,38 +47,38 @@
      -\-><!-\-</custom>-\->
      
    </merge>-->
-   <modify>
+   <!--<modify>
       <set-param param-id="scary">
          <value>claws, tail, huge jackhammer jaws with sharp teeth</value>
       </set-param>
       
-<!-- make examples of all/any remove and add formations
-      showing deep as well as shallow alterations -->
+<!-\- make examples of all/any remove and add formations
+      showing deep as well as shallow alterations -\->
       <alter control-id="allosaur">
         <remove class-ref="trans"/>
         <remove id-ref="allosaur-desc"/>
         <remove item-name="title"/>
         <remove item-name="prop" class-ref="trans"/>
         
-        <!--      add[empty(@id|@class)] will be added at the end   -->
-<!--      add/@position defaults in processing to 'after' -->
-          <!-- @position w/o @where means added first (after titles and parameters)
-          or last (after everything) -->
-<!-- Empty @target is understood to be the control or subcontrol itself, not a descendant; in these cases position='before' and 'after' are inoperative ... you're not permitted to patch before or after controls, only inside them. -->
-<!--         -->
-<!-- Schematron: when empty(@target) then @position=('starting','ending')        -->
+        <!-\-      add[empty(@id|@class)] will be added at the end   -\->
+<!-\-      add/@position defaults in processing to 'after' -\->
+          <!-\- @position w/o @where means added first (after titles and parameters)
+          or last (after everything) -\->
+<!-\- Empty @target is understood to be the control or subcontrol itself, not a descendant; in these cases position='before' and 'after' are inoperative ... you're not permitted to patch before or after controls, only inside them. -\->
+<!-\-         -\->
+<!-\- Schematron: when empty(@target) then @position=('starting','ending')        -\->
          
          
-         <!--<add target="@id|@class" position="starting|ending|before|after">-->
+         <!-\-<add target="@id|@class" position="starting|ending|before|after">-\->
          <add position="ending">
             <part  class="new">
                <title>My new part</title>
             </part>
          </add>
-         <!--</add>-->
+         <!-\-</add>-\->
       </alter>
    </modify>
-  
+  -->
 <!-- Errors and warning conditions:
   Duplicate or clashing controls in final results
   Orphan subcontrols in final results

--- a/lib/XSLT/HTML/oscal-html-fancy.css
+++ b/lib/XSLT/HTML/oscal-html-fancy.css
@@ -32,6 +32,7 @@
       .unassigned { border: thin solid red; background-color: pink}
       .desc { color: darkgreen }
       .insert .desc { font-size: 90% }
+      .label { font-size: 90%; font-weight: bold }
       .value { font-style: italic; text-decoration: underline }
       
       .param-id { font-size: 90%; font-family: sans-serif; font-weight: bold;
@@ -66,7 +67,7 @@ overflow: auto
 .toc .toc { margin-left: 2ex; border-left: thin dotted black; padding-left: 0.5em }
 .toc-line { padding-left: 1em; text-indent: -1em }
 
-.default { text-decoration: line-through }
+.label { font-weight: bold; font-size: 85% }
 .invoking { margin-left: 0.2ex; margin-right: 0.2ex; padding: 0.1ex;
 border: thin dashed grey; background-color: azure }
 

--- a/lib/XSLT/HTML/oscal-with-nav-display.xsl
+++ b/lib/XSLT/HTML/oscal-with-nav-display.xsl
@@ -21,9 +21,9 @@
         <link rel="stylesheet" type="text/css" href="oscal-html-fancy.css"/>
       </head>
       <body class="{local-name(/*)}">
-        <!--<div id="directory">
-          
-        </div>-->
+        <div id="directory">
+          <xsl:apply-templates mode="toc" select="$catalog-or-resolution"/>
+        </div>
         <div id="main">
           <xsl:apply-templates select="$catalog-or-resolution"/>
         </div>
@@ -382,7 +382,7 @@
           </xsl:when>
           <!-- Link not broken -->
           <xsl:when test="$target">
-            <xsl:apply-templates select="$target" mode="link-text"/>
+            <xsl:apply-templates select="$target[last()]" mode="link-text"/>
           </xsl:when>
           <xsl:otherwise>
             <xsl:value-of select="@href"/>
@@ -486,7 +486,11 @@
     <xsl:value-of select="generate-id(.)"/>
   </xsl:template>
   
-  <xsl:template match="oscal:catalog | oscal:framework | oscal:section | oscal:group | oscal:control | oscal:subcontrol | oscal:component" mode="toc">
+  <xsl:template match="oscal:importing | oscal:merged | oscal:modified | oscal:catalog | oscal:group[oscal:catalog]" mode="toc">
+    <xsl:apply-templates mode="toc"/>
+  </xsl:template>
+  
+  <xsl:template match="/oscal:catalog | oscal:framework | oscal:section | oscal:group | oscal:control | oscal:subcontrol | oscal:component" mode="toc">
     <xsl:variable name="new-id">
       <xsl:apply-templates select="." mode="new-id"/>
     </xsl:variable>
@@ -497,8 +501,9 @@
           <xsl:text> </xsl:text>
         </xsl:for-each>
         <xsl:apply-templates select="oscal:title" mode="inline"/>
+        <xsl:if test="not(oscal:title)"><xsl:value-of select="local-name()"/></xsl:if>
       </a></p>
-      <xsl:apply-templates mode="toc" select="oscal:section | oscal:group | oscal:control | oscal:subcontrol | oscal:component"/>
+      <xsl:apply-templates mode="toc" select="oscal:catalog | oscal:section | oscal:group | oscal:control | oscal:subcontrol | oscal:component"/>
     </div>
   </xsl:template>
   

--- a/lib/XSLT/HTML/oscal-with-nav-display.xsl
+++ b/lib/XSLT/HTML/oscal-with-nav-display.xsl
@@ -6,7 +6,10 @@
   xmlns:oscal="http://csrc.nist.gov/ns/oscal/1.0"
   exclude-result-prefixes="oscal">
 
-
+  <xsl:variable name="catalog-or-resolution" select="/oscal:catalog | /oscal:framework | /oscal:worksheet |
+    /oscal:resolution/oscal:modified |
+    /oscal:resolution/oscal:merged[not(../oscal:modified)] |
+    /oscal:resolution/oscal:imported[not(../oscal:merged | ../oscal:modified)]"/>
 
   <xsl:template match="/">
     <html>
@@ -18,11 +21,11 @@
         <link rel="stylesheet" type="text/css" href="oscal-html-fancy.css"/>
       </head>
       <body class="{local-name(/*)}">
-        <div id="directory">
-          <xsl:apply-templates mode="toc" select="//oscal:catalog | //oscal:framework"/>
-        </div>
+        <!--<div id="directory">
+          
+        </div>-->
         <div id="main">
-          <xsl:apply-templates/>
+          <xsl:apply-templates select="$catalog-or-resolution"/>
         </div>
         
       </body>
@@ -34,25 +37,13 @@
   </xsl:template>
 
 
-  <xsl:template match="oscal:profile">
+  <xsl:template match="oscal:resolution">
     <div class="profile">
-      <xsl:apply-templates select="oscal:title, oscal:import"/>
-    </div>
-  </xsl:template>
-  
-  <xsl:template match="oscal:import">
-    <div class="invoking">
-    <xsl:apply-templates select="." mode="display-invocation"/>
-    <xsl:apply-templates select="oscal:import | oscal:framework"/>
-    </div>
-  </xsl:template>
-      
-  <xsl:template match="oscal:import/oscal:framework">
-    <div class="framework" id="{generate-id(.)}">
-      <xsl:copy-of select="@id"/>
       <xsl:apply-templates/>
     </div>
   </xsl:template>
+  
+ 
   
   <xsl:template match="oscal:title">
     <h2 class="title">
@@ -196,6 +187,14 @@
     </p>
   </xsl:template>
   
+  <xsl:template match="oscal:param/oscal:label">
+    <p class="label">
+      <span class="subst">Label:</span>
+      <xsl:text> </xsl:text>
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+  
   <xsl:template match="oscal:param/oscal:value">
     <p class="value">
       <span class="subst">Value:</span>
@@ -212,11 +211,7 @@
     </p>
   </xsl:template>
   
-  <xsl:template mode="inline" match="oscal:param/oscal:desc">
-    <span class="desc">
-      <xsl:apply-templates/>
-    </span>
-  </xsl:template>
+  <xsl:template mode="inline" match="oscal:param/oscal:desc"/>
   
   <xsl:template mode="inline" match="oscal:param/oscal:value">
     <span class="value">
@@ -224,13 +219,9 @@
     </span>
   </xsl:template>
   
-  <xsl:template mode="inline" match="oscal:param/oscal:default">
-    <span class="default">
-      <xsl:text>(</xsl:text>
-      <span class="subst">Default:</span>
-      <xsl:text> </xsl:text>
+  <xsl:template mode="inline" match="oscal:param/oscal:label">
+    <span class="label">
       <xsl:apply-templates/>
-      <xsl:text>)</xsl:text>
     </span>
   </xsl:template>
   
@@ -318,7 +309,7 @@
           <xsl:apply-templates select="." mode="param-id-block"/>
         </a>
         <xsl:apply-templates mode="inline"/>
-        <xsl:if test="not(oscal:value | oscal:default)">
+        <xsl:if test="not(oscal:value)">
           <span class="value">
             <xsl:apply-templates select="oscal:value" mode="param-value"/>
             <xsl:if test="not(oscal:value)">[NO PARAMETER VALUE GIVEN]</xsl:if>

--- a/lib/XSLT/framework-enhance.xsl
+++ b/lib/XSLT/framework-enhance.xsl
@@ -7,7 +7,8 @@
     exclude-result-prefixes="xs math"
     version="3.0">
     
-<!-- Framework enhancement XSLT   -->
+<!-- Purpose: Enhances OSCAL tagging with *purported* links by performing lookups
+     in a catalog and rewriting the links as resolved. A demonstration. -->
     
     <xsl:mode on-no-match="shallow-copy"/>
     

--- a/lib/XSLT/manifest.md
+++ b/lib/XSLT/manifest.md
@@ -6,11 +6,11 @@ XSLT stylesheet version 3.0 (2 templates)
 
 Purpose: Enhances OSCAL tagging with *purported* links by performing lookups in a catalog and rewriting the links as resolved. A demonstration.
 
-Runtime parameter ``catalog-path`` as xs:string
+Runtime parameter `catalog-path` as xs:string
 
-Runtime parameter ``frameworkURI`` as xs:string
+Runtime parameter `frameworkURI` as xs:string
 
-Runtime parameter ``key-property`` as xs:string
+Runtime parameter `key-property` as xs:string
 
 #### profile-resolver.xsl
 
@@ -32,9 +32,9 @@ XSLT stylesheet version 3.0 (1 template)
 
 Compile-time dependency (xsl:include) `oscal-functions.xsl`
 
-Runtime parameter ``selector`` as xs:string
+Runtime parameter `selector` as xs:string
 
-Runtime parameter ``value`` as xs:string
+Runtime parameter `value` as xs:string
 
 #### oscal-write-declarations.xsl
 
@@ -60,7 +60,7 @@ XSLT stylesheet version 2.0 (0 templates)
 
 XSLT stylesheet version 3.0 (3 templates)
 
-Runtime parameter ``xslt-process`` as xs:string
+Runtime parameter `xslt-process` as xs:string
 
 #### cast-JSON-to-XML/OpenControl/param-insert.xsl
 
@@ -68,13 +68,13 @@ XSLT stylesheet version 3.0 (3 templates)
 
 Compile-time dependency (xsl:import) `../lib/XSLT/profile-resolver.xsl`
 
-Runtime parameter ``resource-file`` as xs:string
+Runtime parameter `resource-file` as xs:string
 
 #### cast-JSON-to-XML/OpenControl/json-reader.xsl
 
 XSLT stylesheet version 3.0 (1 template)
 
-Runtime parameter ``json-file`` as xs:string
+Runtime parameter `json-file` as xs:string
 
 #### cast-JSON-to-XML/OpenControl/map-refine.xsl
 
@@ -86,13 +86,13 @@ XSLT stylesheet version 3.0 (3 templates)
 
 Compile-time dependency (xsl:import) `../lib/XSLT/profile-resolver.xsl`
 
-Runtime parameter ``resource-file`` as xs:string
+Runtime parameter `resource-file` as xs:string
 
 #### cast-JSON-to-XML/OpenControl/analysis.xsl
 
 XSLT stylesheet version 3.0 (1 template)
 
-Runtime parameter ``json-file`` 
+Runtime parameter `json-file` 
 
 #### cast-JSON-to-XML/OpenControl/enhance.xsl
 
@@ -124,7 +124,7 @@ XSLT stylesheet version 3.0 (1 template)
 
 XSLT stylesheet version 3.0 (1 template)
 
-Runtime parameter ``json-file`` as xs:string
+Runtime parameter `json-file` as xs:string
 
 #### cast-XML-to-JSON/analysis/json-abstract-map.xsl
 
@@ -146,7 +146,7 @@ XSLT stylesheet version 1.0 (29 templates)
 
 XSLT stylesheet version 3.0 (2 templates)
 
-Runtime parameter ``xslt-process`` as xs:string
+Runtime parameter `xslt-process` as xs:string
 
 #### HTML/oscal-with-nav-display.xsl
 

--- a/lib/XSLT/manifest.md
+++ b/lib/XSLT/manifest.md
@@ -1,0 +1,227 @@
+
+
+#### framework-enhance.xsl
+
+XSLT stylesheet version 3.0 (2 templates)
+
+Runtime parameter ``catalog-path`` as xs:string
+
+Runtime parameter ``frameworkURI`` as xs:string
+
+Runtime parameter ``key-property`` as xs:string
+
+#### profile-resolver.xsl
+
+XSLT stylesheet version 3.0 (32 templates)
+
+#### profile-basic-display.xsl
+
+XSLT stylesheet version 1.0 (1 template)
+
+Compile-time dependency (xsl:import) `oscal-basic-display.xsl`
+
+#### generic-filter-by-prop.xsl
+
+XSLT stylesheet version 3.0 (1 template)
+
+Compile-time dependency (xsl:include) `oscal-functions.xsl`
+
+Runtime parameter ``selector`` as xs:string
+
+Runtime parameter ``value`` as xs:string
+
+#### oscal-write-declarations.xsl
+
+XSLT stylesheet version 3.0 (5 templates)
+
+#### oscal-digest.xsl
+
+XSLT stylesheet version 2.0 (4 templates)
+
+#### html-to-markdown.xsl
+
+XSLT stylesheet version 3.0 (18 templates)
+
+#### literalizer.xsl
+
+XSLT stylesheet version 3.0 (3 templates)
+
+#### oscal-functions.xsl
+
+XSLT stylesheet version 2.0 (0 templates)
+
+#### OSCAL-finalize.xsl
+
+XSLT stylesheet version 3.0 (3 templates)
+
+Runtime parameter ``xslt-process`` as xs:string
+
+#### cast-JSON-to-XML/OpenControl/param-insert.xsl
+
+XSLT stylesheet version 3.0 (3 templates)
+
+Compile-time dependency (xsl:import) `../lib/XSLT/profile-resolver.xsl`
+
+Runtime parameter ``resource-file`` as xs:string
+
+#### cast-JSON-to-XML/OpenControl/json-reader.xsl
+
+XSLT stylesheet version 3.0 (1 template)
+
+Runtime parameter ``json-file`` as xs:string
+
+#### cast-JSON-to-XML/OpenControl/map-refine.xsl
+
+XSLT stylesheet version 3.0 (18 templates)
+
+#### cast-JSON-to-XML/OpenControl/index-to-catalog.xsl
+
+XSLT stylesheet version 3.0 (3 templates)
+
+Compile-time dependency (xsl:import) `../lib/XSLT/profile-resolver.xsl`
+
+Runtime parameter ``resource-file`` as xs:string
+
+#### cast-JSON-to-XML/OpenControl/analysis.xsl
+
+XSLT stylesheet version 3.0 (1 template)
+
+Runtime parameter ``json-file`` 
+
+#### cast-JSON-to-XML/OpenControl/enhance.xsl
+
+XSLT stylesheet version 3.0 (9 templates)
+
+#### cast-JSON-to-XML/OpenControl/json-abstract-map.xsl
+
+XSLT stylesheet version 3.0 (2 templates)
+
+#### cast-XML-to-JSON/oscal-json-write.xsl
+
+XSLT stylesheet version 3.0 (1 template)
+
+Compile-time dependency (xsl:import) `oscal-json-map.xsl`
+
+#### cast-XML-to-JSON/oscal-json-map.xsl
+
+XSLT stylesheet version 3.0 (35 templates)
+
+#### cast-XML-to-JSON/tinkering.xsl
+
+XSLT stylesheet version 3.0 (1 template)
+
+#### cast-XML-to-JSON/json-write.xsl
+
+XSLT stylesheet version 3.0 (1 template)
+
+#### cast-XML-to-JSON/analysis/json-reader.xsl
+
+XSLT stylesheet version 3.0 (1 template)
+
+Runtime parameter ``json-file`` as xs:string
+
+#### cast-XML-to-JSON/analysis/json-abstract-map.xsl
+
+XSLT stylesheet version 3.0 (2 templates)
+
+#### HTML/oscal-browser-display.xsl
+
+XSLT stylesheet version 1.0 (60 templates)
+
+#### HTML/oscal-for-bootstrap-html.xsl
+
+XSLT stylesheet version 1.0 (84 templates)
+
+#### HTML/oscal-basic-display.xsl
+
+XSLT stylesheet version 1.0 (29 templates)
+
+#### HTML/html-finalize.xsl
+
+XSLT stylesheet version 3.0 (2 templates)
+
+Runtime parameter ``xslt-process`` as xs:string
+
+#### HTML/oscal-with-nav-display.xsl
+
+XSLT stylesheet version 1.0 (71 templates)
+
+#### XSL-FO/OSCAL-simple-fo.xsl
+
+XSLT stylesheet version 2.0 (22 templates)
+
+#### cast-JSON-to-XML/OpenControl/acquire-JSON.xpl
+
+XProc pipeline version 1.0 (8 steps)
+
+Runtime dependency: `../lib/XSLT/profile-resolver.xsl`
+
+Runtime dependency: `json-reader.xsl`
+
+Runtime dependency: `json-abstract-map.xsl`
+
+Runtime dependency: `map-refine.xsl`
+
+Runtime dependency: `enhance.xsl`
+
+Runtime dependency: `index-to-catalog.xsl`
+
+Runtime dependency: `param-insert.xsl`
+
+Runtime dependency: `analysis.xsl`
+
+#### cast-XML-to-JSON/jsonify-oscal-xml.xpl
+
+XProc pipeline version 1.0 (3 steps)
+
+Input: OSCAL XML
+
+Output: JSON rendition of same (*except*)
+
+Runtime dependency: `oscal-json-map.xsl`
+
+XSLT stylesheet version 3.0 (1 template)
+
+#### cast-XML-to-JSON/analysis/acquire-JSON.xpl
+
+XProc pipeline version 1.0 (2 steps)
+
+Runtime dependency: `json-reader.xsl`
+
+Runtime dependency: `json-abstract-map.xsl`
+
+#### cast-JSON-to-XML/
+
+#### cast-XML-to-JSON/
+
+#### HTML/
+
+#### XSL-FO/
+
+#### cast-JSON-to-XML/OpenControl/
+
+#### cast-XML-to-JSON/fragment.xml
+
+#### cast-XML-to-JSON/dino-profile-temp.xml
+
+#### cast-XML-to-JSON/SP800-53-3controls-json.xml
+
+#### cast-XML-to-JSON/json-sample.xml
+
+#### cast-XML-to-JSON/31-patched-messy-target.xml
+
+#### cast-XML-to-JSON/SP800-53-3controls.xml
+
+#### cast-XML-to-JSON/xpath-xml-to-json.sh
+
+#### cast-XML-to-JSON/oscal-xml-to-json.sh
+
+#### cast-XML-to-JSON/SP800-53-3controls.json
+
+#### cast-XML-to-JSON/analysis/fragment.json
+
+#### cast-XML-to-JSON/analysis/
+
+#### cast-XML-to-JSON/analysis/xml-json.xsd
+
+#### HTML/oscal-html-fancy.css

--- a/lib/XSLT/manifest.md
+++ b/lib/XSLT/manifest.md
@@ -4,6 +4,8 @@
 
 XSLT stylesheet version 3.0 (2 templates)
 
+Purpose: Enhances OSCAL tagging with *purported* links by performing lookups in a catalog and rewriting the links as resolved. A demonstration.
+
 Runtime parameter ``catalog-path`` as xs:string
 
 Runtime parameter ``frameworkURI`` as xs:string
@@ -13,6 +15,10 @@ Runtime parameter ``key-property`` as xs:string
 #### profile-resolver.xsl
 
 XSLT stylesheet version 3.0 (32 templates)
+
+Purpose: from OSCAL profile input, produce a representation of all controls called with insertions, alterations, modifications and settings applied.
+
+Dependencies: working links to valid control catalogs in OSCAL XML.
 
 #### profile-basic-display.xsl
 
@@ -173,6 +179,8 @@ Runtime dependency: `analysis.xsl`
 #### cast-XML-to-JSON/jsonify-oscal-xml.xpl
 
 XProc pipeline version 1.0 (3 steps)
+
+Purpose: From XML OSCAL, produces equivalent JSON OSCAL.
 
 Input: OSCAL XML
 

--- a/lib/XSLT/profile-resolver.xsl
+++ b/lib/XSLT/profile-resolver.xsl
@@ -8,6 +8,9 @@
   xpath-default-namespace="http://csrc.nist.gov/ns/oscal/1.0"
   exclude-result-prefixes="#all">
 
+  <!-- Purpose: from OSCAL profile input, produce a representation of all controls called with insertions, alterations, modifications and settings applied. -->
+  <!-- Dependencies: working links to valid control catalogs in OSCAL XML. -->
+  
   <xsl:strip-space elements="group control subcontrol part section component"/>
   
   <xsl:output indent="yes"/>

--- a/lib/XSLT/profile-resolver.xsl
+++ b/lib/XSLT/profile-resolver.xsl
@@ -153,7 +153,7 @@
   </xsl:template>
 
   <xsl:template match="profile" mode="import">
-    <xsl:message terminate="yes">Bah! matched profile unexpectedly</xsl:message>
+    <xsl:message terminate="yes">Matched profile unexpectedly</xsl:message>
   </xsl:template>
   
   <xsl:template match="section" mode="import"/>
@@ -478,6 +478,7 @@
         <xsl:apply-templates select="merged" mode="patch">
           <xsl:with-param name="modifications" tunnel="yes" select="$modifications"/>
     </xsl:apply-templates>
+        
       </xsl:copy>
     </xsl:for-each>
     
@@ -502,6 +503,7 @@
       <xsl:copy-of select="key('alteration-by-target',@id,$modifications)/add[empty(@target)][@position='starting']/*"/>
       
       <xsl:apply-templates select="* except title" mode="#current"/>
+      <!--<xsl:message expand-text="true">{ string-join((* except title)/(name() || '#' || @id), ', ') }</xsl:message>-->
       
       <xsl:copy-of select="key('alteration-by-target',@id,$modifications)/add[empty(@target)][@position='ending']/*"/>
       
@@ -573,6 +575,28 @@
   
   <!-- When a catalog is filtered through a profile, its parameters are overwritten
        by parameters passed in from the invocation. -->
+  
+<!-- @priority 12 overrides the template above (matching anything inside controls for patching) -->
+  <xsl:template match="param" mode="patch" priority="12">
+    <xsl:param name="modifications" tunnel="yes" as="element(modify)" required="yes"/>
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:apply-templates mode="patch" select="desc"/>
+      <xsl:if test="empty(desc)">
+        <xsl:copy-of select="key('param-settings',@id,$modifications)/desc"/>
+      </xsl:if>
+      <xsl:apply-templates mode="patch" select="label"/>
+      <xsl:if test="empty(label)">
+        <xsl:copy-of select="key('param-settings',@id,$modifications)/label"/>
+      </xsl:if>
+      <xsl:apply-templates mode="patch" select="value"/>
+      <xsl:if test="empty(value)">
+        <xsl:copy-of select="key('param-settings',@id,$modifications)/value"/>
+      </xsl:if>
+    </xsl:copy>
+    
+  </xsl:template>
+  
   <!-- set-param/desc overrides param/desc -->
   <xsl:template match="param/desc"  mode="patch" priority="10">
     <xsl:param name="modifications" tunnel="yes" as="element(modify)" required="yes"/>
@@ -580,10 +604,9 @@
     <xsl:copy-of select="(key('param-settings',parent::param/@id,$modifications)/desc,.)[1]"/>
   </xsl:template>
   
-  <!-- set-param/label overrides param/label -->
-  <xsl:template match="param/value" mode="patch" priority="10">
+  <xsl:template match="param/label" mode="patch" priority="10">
     <xsl:param name="modifications" tunnel="yes" as="element(modify)" required="yes"/>
-    <xsl:copy-of select="(key('param-settings',parent::param/@id,$modifications)/value,.)[1]"/>
+    <xsl:copy-of select="(key('param-settings',parent::param/@id,$modifications)/label,.)[1]"/>
   </xsl:template>
   
   <!-- same for param/value -->

--- a/lib/util/directory-manifest.xsl
+++ b/lib/util/directory-manifest.xsl
@@ -70,7 +70,7 @@
   </xsl:template>
   
   <xsl:template match="xsl:stylesheet/xsl:param" mode="report">
-    <p>Runtime parameter <code>{ '`' || @name || '`' }</code> { @as/(' as ' || .) }</p>
+    <p>Runtime parameter <code>{ @name }</code> { @as/(' as ' || .) }</p>
     <xsl:apply-templates mode="#current"/>
   </xsl:template>
   

--- a/lib/util/directory-manifest.xsl
+++ b/lib/util/directory-manifest.xsl
@@ -74,7 +74,7 @@
     <xsl:apply-templates mode="#current"/>
   </xsl:template>
   
-  <xsl:template match="comment()[matches(.,'^\s*(XSweet|Input|Output|Note|Limitations?):')]"  mode="report">
+  <xsl:template match="comment()[matches(.,'^\s*(OSCAL|Purpose|Dependencies|Input|Output|Note|Limitations?):')]"  mode="report">
     <p>
       <xsl:value-of select="normalize-space(.)"/>
     </p>

--- a/lib/util/produce-directory-manifest.xpl
+++ b/lib/util/produce-directory-manifest.xpl
@@ -24,7 +24,7 @@
   
   <p:xslt name="produce-manifest-html">
     <p:input port="source">
-      <p:document href="directory-manifest.xsl"/>
+      <p:inline><oscal:empty/></p:inline>
     </p:input>
     <p:input port="stylesheet">
       <p:document href="directory-manifest.xsl"/>


### PR DESCRIPTION
Sprint 9 was accepted at the end of the week followed by about a week of "interregnum" before work began on Sprint 10. This PR represents bug fixes and repairs made during that period.

They fall into two categories:
1. Two commits related to repairs made to profile resolution and display supporting @david-waltermire-nist RSA demo
1. Three other commits relate to an XSLT that produces directory documentation (in markdown for Github) per Issue #138

This work was prior to establishing the new feature-branch based git maintenance strategy, i.e. working under the old model. Which is why it is in this branch.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you squashed any non-relevant commits and commit messages?

### Changes to Core Features:

Commits include updates of XSLTs including bug fixes in view of Apr 2018 demo.