### PR TITLE
Update layout.erb to improve positioning of GitHub link in left navigation

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -136,11 +136,11 @@ under the License.
             <li><%= link_to "Roadmap", "/OSCAL/roadmap", class: 'toc-h1 toc-link' %></li>
             <% if current_page.url == "/roadmap/" %><%= @saved_output %><% end %>
           <% end %>
+          <li><a class="toc-h1 toc-link" href="https://github.com/usnistgov/OSCAL" target="_blank">GitHub Repository</a></li>
          <% end %>
       </div>
       <ul class="toc-footer">
           <li><a href="https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md" target="_blank">Contributing</a></li>
-          <li><a href="https://github.com/usnistgov/OSCAL" target="_blank">GitHub</a></li>
           <li><a href="https://www.nist.gov/" target="_blank">NIST.gov</a></li>
       </ul>
     </div>


### PR DESCRIPTION
# Committer Notes

Moved the GitHub link to a a more prominent place in the left navigation.