### PR TITLE
Add OSCAL content validator

### DIFF
--- a/util/oscal-content-validator.py
+++ b/util/oscal-content-validator.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+
+import sys
+import io
+import json
+import argparse
+from jsonschema import validate
+import json
+import xmlschema
+
+
+def _get_oscal_file_type(filename):
+    if filename.endswith("json"):
+        return "json"
+    elif filename.endswith("xml") or filename.endswith("xsd"):
+        return "xml"
+    else:
+        raise("Not a valid OSCAL file.")
+
+
+def read_file(filename, ftype):
+    with io.open(filename, 'r', encoding="utf-8") as f:
+        if ftype is "json":
+            filedata = json.load(f)
+        else:
+            filedata = f.read()
+    return filedata, ftype
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--oscal-schema", default=False, required=True,
+                        action="store", dest="oscal_schema",
+                        help="An OSCAL schema file.")
+    parser.add_argument("-f", "--oscal-file", default=False, required=True,
+                        action="store", dest="oscal_file",
+                        help="An OSCAL data file.")
+    return parser.parse_args()
+
+
+def oscal_validator(oscal_schema, oscal_data):
+    schema, stype = read_file(oscal_schema, _get_oscal_file_type(oscal_schema))
+    data, ftype = read_file(oscal_data, _get_oscal_file_type(oscal_data))
+
+    if ftype is 'json':
+        validate(data, schema)
+    if ftype is 'xml':
+        xmlschema.validate(data, schema)
+
+
+def main():
+    args = parse_args()
+
+    oscal_validator(args.oscal_schema, args.oscal_file)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Script that easily validates XML and JSON OSCAL files against OSCAL schema. This allows any
OSCAL user to validate (maybe certify at one point?) their content against the OSCAL schema.

Interestingly enough, there are numerous errors in the JSON catalog schema vs. the generated JSON catalog content. I haven't tested any others.

JSON example:
```
$ ./oscal-schema-validator.py -s oscal-catalog-schema.json -f NIST_SP-800-53_rev4_catalog.json
Traceback (most recent call last):
  File "./oscal-schema-validator.py", line 58, in <module>
    main()
  File "./oscal-schema-validator.py", line 54, in main
    oscal_validator(args.oscal_schema, args.oscal_file)
  File "./oscal-schema-validator.py", line 46, in oscal_validator
    validate(data, schema)
  File "/usr/lib/python2.7/site-packages/jsonschema/validators.py", line 541, in validate
    cls(schema, *args, **kwargs).validate(instance)
  File "/usr/lib/python2.7/site-packages/jsonschema/validators.py", line 130, in validate
    raise error
jsonschema.exceptions.ValidationError: Additional properties are not allowed (u'value' was unexpected)

Failed validating u'additionalProperties' in schema[u'properties'][u'catalog'][u'properties'][u'references'][u'properties'][u'refs'][u'items'][u'properties'][u'citations'][u'items']:
    {u'$id': u'#/definitions/citation',
     u'additionalProperties': False,
     u'description': u'Citation of a resource',
     u'properties': {u'RICHTEXT': {u'type': u'string'},
                     u'href': {u'type': u'string'},
                     u'id': {u'type': u'string'}},
     u'propertyNames': {u'enum': [u'RICHTEXT', u'id', u'href']},
     u'title': u'Citation',
     u'type': u'object'}

On instance[u'catalog'][u'references'][u'refs'][0][u'citations'][0]:
    {u'href': u'http://www.gpo.gov/fdsys/granule/CFR-2012-title5-vol2/CFR-2012-title5-vol2-sec731-106/content-detail.html',
     u'value': u'5 C.F.R. 731.106'}
```

XML example:
```
$ ./oscal-schema-validator.py --oscal-schema oscal-catalog-schema.xsd --oscal-file NIST_SP-800-53_rev4_catalog.xml
Traceback (most recent call last):
  File "./oscal-schema-validator.py", line 58, in <module>
    main()
  File "./oscal-schema-validator.py", line 54, in main
    oscal_validator(args.oscal_schema, args.oscal_file)
  File "./oscal-schema-validator.py", line 48, in oscal_validator
    xmlschema.validate(data, schema)
  File "/home/ralford/.local/lib/python2.7/site-packages/xmlschema/documents.py", line 44, in validate
    schema.validate(xml_document, use_defaults, namespaces)
  File "/home/ralford/.local/lib/python2.7/site-packages/xmlschema/validators/xsdbase.py", line 495, in validate
    raise error
xmlschema.validators.exceptions.XMLSchemaChildrenValidationError: failed validating <Element '{http://csrc.nist.gov/ns/oscal/1.0}part' at 0x7f6bdb6873b8> with XsdGroup(model='sequence', occurs=[1, 1]):

Reason: Unexpected child with tag 'oscal:stuff' at position 1.

Schema:

  <xs:complexType xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:sequence>
        <xs:element minOccurs="0" ref="oscal:title" />
        <xs:element maxOccurs="unbounded" minOccurs="0" ref="oscal:prop" />
        <xs:group maxOccurs="unbounded" minOccurs="0" ref="oscal:prose" />
        <xs:element maxOccurs="unbounded" minOccurs="0" ref="oscal:part" />
        <xs:element maxOccurs="unbounded" minOccurs="0" ref="oscal:link" />
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID">
        <xs:annotation>
           <xs:documentation>
              <b>ID / identifier: </b>Unique identifier</xs:documentation>
        </xs:annotation>
     </xs:attribute>
     <xs:attribute name="class" type="xs:string">
        <xs:annotation>
           <xs:documentation>
              <b>Class: </b>Identifies the property or object within the control; a semantic hint</xs:documentation>
        </xs:annotation>
     </xs:attribute>
  </xs:complexType>

Instance:

  <part xmlns="http://csrc.nist.gov/ns/oscal/1.0" class="assessment">
     <stuff class="method">EXAMINE</stuff>
     <part class="objects">
        <p>Access control policy</p>
        <p>procedures addressing account management</p>
        <p>security plan</p>
        <p>information system design documentation</p>
        <p>information system configuration settings and associated documentation</p>
        <p>list of active system accounts along with the name of the individual associated with each account</p>
        <p>list of conditions for group and role membership</p>
        <p>notifications or records of recently transferred, separated, or terminated employees</p>
        <p>list of recently disabled information system accounts along with the name of the individual associated with each account</p>
        <p>access authorization records</p>
        <p>account management compliance reviews</p>
        <p>information system monitoring records</p>
        <p>information system audit records</p>
        <p>other relevant documents or records</p>
     </part>
  </part>

Path: /catalog/group[1]/control/part
```

