### PR TITLE
Extending prose to permit HTML headers h1-h6 plus simple tables

### DIFF
--- a/build/metaschema/xml/oscal-prose-module.xsd
+++ b/build/metaschema/xml/oscal-prose-module.xsd
@@ -3,12 +3,49 @@
   <xs:element name="prose" type="oscal-prose:prose"/>
   <xs:complexType name="prose">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="oscal-prose:h1"/>
+      <xs:element ref="oscal-prose:h2"/>
+      <xs:element ref="oscal-prose:h3"/>
+      <xs:element ref="oscal-prose:h4"/>
+      <xs:element ref="oscal-prose:h5"/>
+      <xs:element ref="oscal-prose:h6"/>
       <xs:element ref="oscal-prose:p"/>
       <xs:element ref="oscal-prose:ul"/>
       <xs:element ref="oscal-prose:ol"/>
       <xs:element ref="oscal-prose:pre"/>
+      <xs:element ref="oscal-prose:table"/>
     </xs:choice>
   </xs:complexType>
+  <xs:element name="h1">
+    <xs:complexType mixed="true">
+      <xs:group ref="oscal-prose:inlines"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="h2">
+    <xs:complexType mixed="true">
+      <xs:group ref="oscal-prose:inlines"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="h3">
+    <xs:complexType mixed="true">
+      <xs:group ref="oscal-prose:inlines"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="h4">
+    <xs:complexType mixed="true">
+      <xs:group ref="oscal-prose:inlines"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="h5">
+    <xs:complexType mixed="true">
+      <xs:group ref="oscal-prose:inlines"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="h6">
+    <xs:complexType mixed="true">
+      <xs:group ref="oscal-prose:inlines"/>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="p">
     <xs:complexType mixed="true">
       <xs:group ref="oscal-prose:everything-inline"/>
@@ -47,7 +84,31 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <!-- whatnot includes 'semantical' elements along with the inline mix -->
+  <xs:element name="table">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="oscal-prose:tr"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tr">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element maxOccurs="unbounded" ref="oscal-prose:td"/>
+        <xs:element maxOccurs="unbounded" ref="oscal-prose:th"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="th">
+    <xs:complexType mixed="true">
+      <xs:group ref="oscal-prose:everything-inline"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="td">
+    <xs:complexType mixed="true">
+      <xs:group ref="oscal-prose:everything-inline"/>
+    </xs:complexType>
+  </xs:element>
   <xs:group name="everything-inline">
     <xs:sequence>
       <xs:choice minOccurs="0" maxOccurs="unbounded">

--- a/build/metaschema/xml/produce-xsd.xsl
+++ b/build/metaschema/xml/produce-xsd.xsl
@@ -48,10 +48,17 @@
 
             <xs:group name="prose">
                 <xs:choice>
-                    <xs:element ref="{$declaration-prefix}:p"/>
-                    <xs:element ref="{$declaration-prefix}:ul"/>
-                    <xs:element ref="{$declaration-prefix}:ol"/>
-                    <xs:element ref="{$declaration-prefix}:pre"/>
+                    <xs:element ref="oscal-prose:h1"/>
+                    <xs:element ref="oscal-prose:h2"/>
+                    <xs:element ref="oscal-prose:h3"/>
+                    <xs:element ref="oscal-prose:h4"/>
+                    <xs:element ref="oscal-prose:h5"/>
+                    <xs:element ref="oscal-prose:h6"/>
+                    <xs:element ref="oscal-prose:p"/>
+                    <xs:element ref="oscal-prose:ul"/>
+                    <xs:element ref="oscal-prose:ol"/>
+                    <xs:element ref="oscal-prose:pre"/>
+                    <xs:element ref="oscal-prose:table"/>
                 </xs:choice>
             </xs:group>
 
@@ -195,8 +202,8 @@
             <xsl:apply-templates mode="#current"/>
     </xsl:template>
     
-<!-- dropping placeholder 'prose' element declaration -->
-    <xsl:template match="xs:schema/xs:element[@name='prose']" mode="acquire-prose"/>
+<!-- dropping top level (placeholder) 'prose' element declaration and its complexType -->
+    <xsl:template match="xs:schema/xs:element[@name='prose'] | xs:schema/xs:complexType[@name='prose']" mode="acquire-prose"/>
     
     <xsl:template match="comment()" mode="wire-ns">
         <xsl:copy-of select="."/>

--- a/schema/demo/base-example.xml
+++ b/schema/demo/base-example.xml
@@ -7,5 +7,15 @@
         <single-required-field>Required</single-required-field>
         <acquired-model/>
         <single-mixed-field>Mixed content? <i>here be content?</i></single-mixed-field>
+        <chunk-among-chunks>
+            <single-required-field></single-required-field>
+            <h4></h4>
+            <table>
+                <tr>
+                    <th></th>
+                    <td></td>
+                </tr>
+            </table>
+        </chunk-among-chunks>
     </thing>
 </kit>

--- a/schema/demo/oscal-test-metaschema.xml
+++ b/schema/demo/oscal-test-metaschema.xml
@@ -6,7 +6,7 @@
 <?xml-stylesheet type="text/css" href="../../build/metaschema/lib/metaschema-author.css"?>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/lib/metaschema.xsd"
- xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" top="kit-thing" use="kit">
+ xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" root="kit">
 
   <schema-name>FAKEUP Testing Schema</schema-name>
   <short-name>oscal-test</short-name>
@@ -106,7 +106,7 @@
     </model>
   </define-assembly>
   
-  <define-assembly name="chunk-among-chunks" show-docs="xml json">
+  <define-assembly name="chunk-among-chunks" group-as="chunks-together" show-docs="xml json">
     <formal-name>Chunk among chunks</formal-name>
     <description>As it says</description>
     <model>

--- a/schema/demo/oscal-test-schema.xsd
+++ b/schema/demo/oscal-test-schema.xsd
@@ -151,20 +151,49 @@
    </xs:element>
    <xs:group name="prose">
       <xs:choice>
-         <xs:element ref="oscal-test:p"/>
-         <xs:element ref="oscal-test:ul"/>
-         <xs:element ref="oscal-test:ol"/>
-         <xs:element ref="oscal-test:pre"/>
-      </xs:choice>
-   </xs:group>
-   <xs:complexType name="prose">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element ref="oscal-prose:h1"/>
+         <xs:element ref="oscal-prose:h2"/>
+         <xs:element ref="oscal-prose:h3"/>
+         <xs:element ref="oscal-prose:h4"/>
+         <xs:element ref="oscal-prose:h5"/>
+         <xs:element ref="oscal-prose:h6"/>
          <xs:element ref="oscal-prose:p"/>
          <xs:element ref="oscal-prose:ul"/>
          <xs:element ref="oscal-prose:ol"/>
          <xs:element ref="oscal-prose:pre"/>
+         <xs:element ref="oscal-prose:table"/>
       </xs:choice>
-   </xs:complexType>
+   </xs:group>
+   <xs:element name="h1">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="h2">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="h3">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="h4">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="h5">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="h6">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
    <xs:element name="p">
       <xs:complexType mixed="true">
          <xs:group ref="oscal-prose:everything-inline"/>
@@ -201,6 +230,31 @@
          <xs:sequence>
             <xs:element maxOccurs="unbounded" ref="oscal-prose:li"/>
          </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="table">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="oscal-prose:tr"/>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="tr">
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element maxOccurs="unbounded" ref="oscal-prose:td"/>
+            <xs:element maxOccurs="unbounded" ref="oscal-prose:th"/>
+         </xs:choice>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="th">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:everything-inline"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="td">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:everything-inline"/>
       </xs:complexType>
    </xs:element>
    <xs:group name="everything-inline">

--- a/util/convert/md-oscal-converter.xsl
+++ b/util/convert/md-oscal-converter.xsl
@@ -8,7 +8,7 @@
     <xsl:output indent="yes"/>
 
     <xsl:param name="target-ns" as="xs:string?">urn:booya</xsl:param>
-<!-- TO DO: Paragraphs, lists and 'pre' blocks...   -->
+    <!-- TO DO: Headers, tables and numbered lists   -->
 
     <!-- Markdown pseudoparser in XSLT  -->
 


### PR DESCRIPTION
# Committer Notes

This PR addresses the first half of Issue #284, extending support for prose in the metaschema. With this extension, OSCAL documents will allow simple HTML-style headers in prose and simple tables, along with paragraphs and lists. 

This was pushed forward because it has become a blocker for @brianrufgsa cf Issues #267 and others dependent on it (#270 #271 etc.) It is a backward-compatible change; all documents valid to the old OSCAL schemas will be valid to newer schemas as well. (The schemas do have to be rebuilt before prose is permitted in the documents.)

NB the XML<->markdown pathway has *not* been extended with this support, so conversion scripts are going to break on these elements until we do that.

Also: this change raises the question of whether at lower levels such as catalog and profile, the new elements should not be forbidden after all (since they are really needed only at higher levels) -- if so, we could flag them with a Schematron.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable? **See changes in `demo` subdirectory**
* [x] Have you included examples of how to use your new feature(s)? **Likewise**
