### PR TITLE
Tweaked cross-linking paths between XML and JSON docs

### DIFF
--- a/build/metaschema/lib/metaschema-jsondocs-jekyll-uswds.xsl
+++ b/build/metaschema/lib/metaschema-jsondocs-jekyll-uswds.xsl
@@ -109,7 +109,7 @@
    <xsl:template name="cross-links">
       <xsl:variable name="alt-schema" select="replace($metaschema-code,'-json$','-xml')"/>
       <div style="float:right">
-         <a href="/docs/schemas/{ $alt-schema }/#{ $alt-schema }_{ @name}">
+         <a href="/OSCAL/docs/schemas/{ $alt-schema }/#{ $alt-schema }_{ @name}">
             <button>XML</button>
          </a>
          <button disabled="disabled">JSON</button>

--- a/build/metaschema/lib/metaschema-xmldocs-jekyll-uswds.xsl
+++ b/build/metaschema/lib/metaschema-xmldocs-jekyll-uswds.xsl
@@ -118,7 +118,7 @@
       <xsl:variable name="alt-schema" select="replace($metaschema-code,'-xml$','-json')"/>
       <div style="float:right">
          <button disabled="disabled">XML</button>
-         <a href="/docs/schemas/{ $alt-schema }/#{ $alt-schema }_{ @name}">
+         <a href="/OSCAL/docs/schemas/{ $alt-schema }/#{ $alt-schema }_{ @name}">
             <button>JSON</button>
          </a>
       </div>


### PR DESCRIPTION
# Committer Notes

Addressing @anweiss reported cross-linking bug in XML/JSON docs pages.
