### PR TITLE
Malformed $refs in JSON schemas

### DIFF
--- a/schema/json/oscal-catalog-schema.json
+++ b/schema/json/oscal-catalog-schema.json
@@ -834,7 +834,7 @@
             "$ref" : "#/definitions/title" },
           "parameters" : 
           { "type" : "object",
-            "$ref" : "#/definitions/" },
+            "$ref" : "#/definitions/parameters" },
           "properties" : 
           { "type" : "array",
             "items" : 
@@ -881,7 +881,7 @@
             "$ref" : "#/definitions/title" },
           "parameters" : 
           { "type" : "object",
-            "$ref" : "#/definitions/" },
+            "$ref" : "#/definitions/parameters" },
           "properties" : 
           { "type" : "array",
             "items" : 
@@ -896,7 +896,7 @@
             { "$ref" : "#/definitions/part" } },
           "subcontrols" : 
           { "type" : "object",
-            "$ref" : "#/definitions/" },
+            "$ref" : "#/definitions/subcontrols" },
           "ref-list" : 
           { "type" : "object",
             "$ref" : "#/definitions/ref-list" } },
@@ -933,7 +933,7 @@
             "$ref" : "#/definitions/title" },
           "parameters" : 
           { "type" : "object",
-            "$ref" : "#/definitions/" },
+            "$ref" : "#/definitions/parameters" },
           "properties" : 
           { "type" : "array",
             "items" : 

--- a/schema/json/oscal-profile-schema.json
+++ b/schema/json/oscal-profile-schema.json
@@ -1294,7 +1294,7 @@
             "$ref" : "#/definitions/title" },
           "parameters" : 
           { "type" : "object",
-            "$ref" : "#/definitions/" },
+            "$ref" : "#/definitions/parameters" },
           "properties" : 
           { "type" : "array",
             "items" : 


### PR DESCRIPTION
# Committer Notes

Fixes a few malformed `$ref`'s in the catalog and profile JSON schemas. These fixes will result in successful compilation of the JSON schemas using the `ajv` tool and SDK.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you included examples of how to use your new feature(s)?
