### PR TITLE
Correction to JSON Schema generation pipeline

### DIFF
--- a/build/metaschema/json/json-schema-metamap.xsl
+++ b/build/metaschema/json/json-schema-metamap.xsl
@@ -195,9 +195,10 @@
     </xsl:template>
 
     <xsl:template mode="declaration" match="assemblies[matches(@address,'\S')] | fields[matches(@address,'\S')]">
-        <map key="{ key('definition-by-name',@named)/@group-as }">
+        <xsl:variable name="group-name" select="key('definition-by-name',@named)/@group-as"/>
+        <map key="{ $group-name }">
             <string key="type">object</string>
-            <string key="$ref">#/definitions/{ @group-as }</string>
+            <string key="$ref">#/definitions/{ $group-name }</string>
         </map>
     </xsl:template>
 


### PR DESCRIPTION
Correction to JSON Schema generation bug Malformed $refs #361.

Bug was introduced with a syntax optimization for users of Metaschema.

# Committer Notes

{Please provide a brief description of what this PR accomplishes. Be sure to reference any issues addressed. If the PR is a work-in-progress submitted for early review, please include [WIP] at the beginning of the title.}

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you included examples of how to use your new feature(s)?
