### PR TITLE
Fix json schema escaping

### DIFF
--- a/build/metaschema/json/json-schema-metamap.xsl
+++ b/build/metaschema/json/json-schema-metamap.xsl
@@ -140,7 +140,7 @@
 
     <xsl:template match="description">
         <string key="description">
-            <xsl:value-of select="normalize-space(.)"/>
+            <xsl:value-of select="replace(normalize-space(.),'&quot;','\\&quot;')"/>
         </string>
     </xsl:template>
 

--- a/build/metaschema/json/json-schema-metamap.xsl
+++ b/build/metaschema/json/json-schema-metamap.xsl
@@ -140,7 +140,7 @@
 
     <xsl:template match="description">
         <string key="description">
-            <xsl:value-of select="replace(normalize-space(.),'&quot;','\\&quot;')"/>
+            <xsl:value-of select="normalize-space(.)"/>
         </string>
     </xsl:template>
 


### PR DESCRIPTION
# Committer Notes

Addressing issue in escaping quote marks in JSON schema generation.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you included examples of how to use your new feature(s)?
