### PR TITLE
Metaschema improvement with OSCAL schema adjustments

### DIFF
--- a/build/metaschema/json/json-schema-metamap.xsl
+++ b/build/metaschema/json/json-schema-metamap.xsl
@@ -74,6 +74,15 @@
             <map key="properties">
                 <xsl:apply-templates select="." mode="properties"/>
             </map>
+            <xsl:for-each-group select="(flag[@required='yes'] | model/*[@required='yes'])" group-by="true()">
+                <array key="required">
+                    <xsl:for-each select="current-group()">
+                        <string>
+                            <xsl:value-of select="@name | @named"/>
+                        </string>
+                    </xsl:for-each>
+                </array>
+            </xsl:for-each-group>
             <boolean key="additionalProperties">false</boolean>
             <map key="propertyNames">
                 <array key="enum">
@@ -177,8 +186,6 @@
         </map>
     </xsl:template>
 
-    
-    <!-- How to express a required attribute or element in JSON schema? -->
     <xsl:template mode="declaration" match="flag">
         <map key="{@name}">
             <string key="type">string</string>

--- a/build/metaschema/lib/metaschema.xsd
+++ b/build/metaschema/lib/metaschema.xsd
@@ -154,6 +154,7 @@
         <xs:element minOccurs="0" ref="m:remarks"/>
       </xs:sequence>
       <xs:attribute name="named" use="required" type="xs:NCName"/>
+      <xs:attribute name="required" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="assemblies">
@@ -164,6 +165,7 @@
       </xs:sequence>
       <xs:attribute name="address" type="xs:NCName"/>
       <xs:attribute name="named" use="required" type="xs:NCName"/>
+      <xs:attribute name="required" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="field">
@@ -183,6 +185,7 @@
         <xs:element minOccurs="0" ref="m:remarks"/>
       </xs:sequence>
       <xs:attribute name="named" use="required" type="xs:NCName"/>
+      <xs:attribute name="required" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
   

--- a/build/metaschema/xml/oscal-prose-module.xsd
+++ b/build/metaschema/xml/oscal-prose-module.xsd
@@ -139,6 +139,7 @@
         <xs:element ref="oscal-prose:b"/>
         <xs:element ref="oscal-prose:sub"/>
         <xs:element ref="oscal-prose:sup"/>
+        <xs:element ref="oscal-prose:img"/>
       </xs:choice>
     </xs:sequence>
   </xs:group>
@@ -207,6 +208,12 @@
   <xs:element name="sup">
     <xs:complexType mixed="true">
       <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="img">
+    <xs:complexType>
+      <xs:attribute name="alt"/>
+      <xs:attribute name="src" use="required" type="xs:anyURI"/>
     </xs:complexType>
   </xs:element>
   <!-- Using HTML for this -->

--- a/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_HIGH-baseline_profile.xml
+++ b/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_HIGH-baseline_profile.xml
@@ -1,9 +1,8 @@
 <!-- Produced by SP800-53-profile-with-filter.xsl 2018-05-14-04:00
-        runtime parameter settings: $baseline='HIGH'-->
+        runtime parameter settings: $baseline='HIGH'
+     Adjusted by hand 2019-05-28. -->
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         id="uuid-599a7728-a154-4035-a556-1f03223120eb">
-   <title>SP800-53 HIGH IMPACT BASELINE</title>
-
+   id="uuid-56285eb5-54a4-4b56-ba03-45d1b78e9dfc">
    <metadata>
       <title>NIST Special Publication 800-53 Revision 4 HIGH IMPACT BASELINE</title>
       <publication-date>September 2018</publication-date>

--- a/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_LOW-baseline_profile.xml
+++ b/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_LOW-baseline_profile.xml
@@ -1,8 +1,7 @@
 <!-- Produced by SP800-53-profile-with-filter.xsl 2018-05-14-04:00
         runtime parameter settings: $baseline='LOW'-->
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         id="uuid-435213cf-dd85-451f-a3f1-2c110a1b0c70">
-   <title>SP800-53 LOW IMPACT BASELINE</title>
+   id="uuid-818283dc-f635-4d36-9352-2349f09881cf">
    <metadata>
       <title>NIST Special Publication 800-53 Revision 4 LOW IMPACT BASELINE</title>
       <publication-date>September 2018</publication-date>

--- a/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_MODERATE-baseline_profile.xml
+++ b/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_MODERATE-baseline_profile.xml
@@ -1,9 +1,7 @@
 <!-- Produced by SP800-53-profile-with-filter.xsl 2018-05-14-04:00
         runtime parameter settings: $baseline='MODERATE'-->
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         id="uuid-ad080a41-8219-4dcf-8140-2e8c2163b0c9">
-   <title>SP800-53 MODERATE IMPACT BASELINE</title>
-   
+   id="uuid-f0bf2c99-ed39-4cb4-88b7-dc673098c671">
    <metadata>
       <title>NIST Special Publication 800-53 Revision 4 MODERATE IMPACT BASELINE</title>
       <publication-date>September 2018</publication-date>

--- a/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml
+++ b/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml
@@ -1,10 +1,9 @@
 <!-- XML produced by extraction/mapping from NVD XML :2018-11-02T16:55:46.916-04:00 -->
-<!-- Then modified by hand (2018-12-10, 2018-05-16) to add metadata and align with current schema -->
+<!-- Then modified by hand (2018-12-10, 2019-05-16, 2019-05-28) to add metadata and align with current schema -->
 <!-- Valid against the OSCAL catalog schema (project path schema/xml/oscal-catalog-schema.xsd) -->
 <catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-   id="uuid-5e231d91-f57e-4f18-81e2-c7e3bcc9ed5"
+   id="uuid-20adaaec-6c75-47ba-ba6c-da589e1e5598"
          model-version="0.9.14">
-   <title>NIST SP800-53</title>
    <metadata>
       <title>NIST Special Publication 800-53 Revision 4: Security and Privacy Controls for Federal Information Systems and Organizations</title>
       <publication-date>April 2013</publication-date>

--- a/src/content/fedramp.gov/xml/FedRAMP_HIGH-baseline_profile.xml
+++ b/src/content/fedramp.gov/xml/FedRAMP_HIGH-baseline_profile.xml
@@ -1,6 +1,5 @@
 <!-- Created: 5/16/2019 9:05:15 PM -->
-<profile id="uuid-fedramp-high-20190516-210515" xmlns="http://csrc.nist.gov/ns/oscal/1.0">
-	<title>FedRAMP HIGH Baseline PROFILE</title>
+<profile id="uuid-fedramp-high-20190528-125555" xmlns="http://csrc.nist.gov/ns/oscal/1.0">
 	<metadata>
 		<title>FedRAMP High Baseline</title>
 		<author>FedRAMP PMO</author>

--- a/src/content/fedramp.gov/xml/FedRAMP_LOW-baseline_profile.xml
+++ b/src/content/fedramp.gov/xml/FedRAMP_LOW-baseline_profile.xml
@@ -1,6 +1,5 @@
 <!-- Created: 5/16/2019 9:05:20 PM -->
-<profile id="uuid-fedramp-low-20190516-210520" xmlns="http://csrc.nist.gov/ns/oscal/1.0">
-	<title>FedRAMP LOW Baseline PROFILE</title>
+<profile id="uuid-fedramp-low-20190528-125757" xmlns="http://csrc.nist.gov/ns/oscal/1.0">
 	<metadata>
 		<title>FedRAMP Low Baseline</title>
 		<author>FedRAMP PMO</author>

--- a/src/content/fedramp.gov/xml/FedRAMP_MODERATE-baseline_profile.xml
+++ b/src/content/fedramp.gov/xml/FedRAMP_MODERATE-baseline_profile.xml
@@ -1,6 +1,5 @@
 <!-- Created: 5/16/2019 9:05:18 PM -->
-<profile id="uuid-fedramp-moderate-20190516-210518" xmlns="http://csrc.nist.gov/ns/oscal/1.0">
-	<title>FedRAMP MODERATE Baseline PROFILE</title>
+<profile id="uuid-fedramp-moderate-20190528-125656" xmlns="http://csrc.nist.gov/ns/oscal/1.0">
 	<metadata>
 		<title>FedRAMP Moderate Baseline</title>
 		<author>FedRAMP PMO</author>

--- a/src/content/mini-testing/oscal_testing_dinosaur_catalog.xml
+++ b/src/content/mini-testing/oscal_testing_dinosaur_catalog.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/css" href="../../lib/CSS/oscal.css"?>
-<?xml-model href="../../schema/xml/Schematron/oscal-links.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 ../../schema/xml/oscal-catalog-schema.xsd"
+ xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 ../../../xml/schema/oscal-catalog-schema.xsd"
  xmlns="http://csrc.nist.gov/ns/oscal/1.0" id="xyz" model-version="abc">
-    <title>Skeleton catalog</title>
+    <metadata>
+        <title>Dinosaur Testing Catalog</title>
+    </metadata>
     <section>
         <title>This catalog</title>
         <p>For use in testing, especially structural transformations.</p>
@@ -45,14 +46,25 @@
                     <prop class="trans">King Tyrant Lizard</prop>
                 </subcontrol>
             </control>
-            <control id="velociraptor"/>
+            <control id="velociraptor">
+                <title>Velociraptor</title>
+            </control>
         </group>
         <group><title>Herbivores</title>
-            <control id="stegosaur"/>
-            <control id="triceratops"/>
+            <control id="stegosaur">
+                <title>Stegosaurus</title>
+            </control>
+            <control id="triceratops">
+                <title>Triceratops</title>
+            </control>
         </group>
         <group><title>Proto-avians</title>
-            <control id="archeopteryx"/>
+            <control id="archeopteryx">
+                <title>Archaeopteryx</title>
+                <part>
+                    <p><img src="unoh" /></p>
+                </part>
+            </control>
         </group>
     </group>
     

--- a/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_HIGH-baseline_profile.xml
+++ b/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_HIGH-baseline_profile.xml
@@ -1,9 +1,8 @@
 <!-- Produced by SP800-53-profile-with-filter.xsl 2018-05-14-04:00
-        runtime parameter settings: $baseline='HIGH'-->
+        runtime parameter settings: $baseline='HIGH'
+     Adjusted by hand 2019-05-28. -->
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         id="uuid-599a7728-a154-4035-a556-1f03223120eb">
-   <title>SP800-53 HIGH IMPACT BASELINE</title>
-
+   id="uuid-56285eb5-54a4-4b56-ba03-45d1b78e9dfc">
    <metadata>
       <title>NIST Special Publication 800-53 Revision 4 HIGH IMPACT BASELINE</title>
       <publication-date>September 2018</publication-date>

--- a/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_LOW-baseline_profile.xml
+++ b/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_LOW-baseline_profile.xml
@@ -1,8 +1,7 @@
 <!-- Produced by SP800-53-profile-with-filter.xsl 2018-05-14-04:00
         runtime parameter settings: $baseline='LOW'-->
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         id="uuid-435213cf-dd85-451f-a3f1-2c110a1b0c70">
-   <title>SP800-53 LOW IMPACT BASELINE</title>
+   id="uuid-818283dc-f635-4d36-9352-2349f09881cf">
    <metadata>
       <title>NIST Special Publication 800-53 Revision 4 LOW IMPACT BASELINE</title>
       <publication-date>September 2018</publication-date>

--- a/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_MODERATE-baseline_profile.xml
+++ b/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_MODERATE-baseline_profile.xml
@@ -1,9 +1,7 @@
 <!-- Produced by SP800-53-profile-with-filter.xsl 2018-05-14-04:00
         runtime parameter settings: $baseline='MODERATE'-->
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         id="uuid-ad080a41-8219-4dcf-8140-2e8c2163b0c9">
-   <title>SP800-53 MODERATE IMPACT BASELINE</title>
-   
+   id="uuid-f0bf2c99-ed39-4cb4-88b7-dc673098c671">
    <metadata>
       <title>NIST Special Publication 800-53 Revision 4 MODERATE IMPACT BASELINE</title>
       <publication-date>September 2018</publication-date>

--- a/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml
+++ b/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml
@@ -1,10 +1,9 @@
 <!-- XML produced by extraction/mapping from NVD XML :2018-11-02T16:55:46.916-04:00 -->
-<!-- Then modified by hand (2018-12-10, 2018-05-16) to add metadata and align with current schema -->
+<!-- Then modified by hand (2018-12-10, 2019-05-16, 2019-05-28) to add metadata and align with current schema -->
 <!-- Valid against the OSCAL catalog schema (project path schema/xml/oscal-catalog-schema.xsd) -->
 <catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-   id="uuid-5e231d91-f57e-4f18-81e2-c7e3bcc9ed5"
+   id="uuid-20adaaec-6c75-47ba-ba6c-da589e1e5598"
          model-version="0.9.14">
-   <title>NIST SP800-53</title>
    <metadata>
       <title>NIST Special Publication 800-53 Revision 4: Security and Privacy Controls for Federal Information Systems and Organizations</title>
       <publication-date>April 2013</publication-date>

--- a/src/metaschema/oscal-catalog-metaschema.xml
+++ b/src/metaschema/oscal-catalog-metaschema.xml
@@ -14,8 +14,8 @@
   <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
 
   <remarks>
-    <p>The OSCAL Control Catalog format can be used to describe a collection of security controls and related sub-controls, along with a variety of control metadata. The root of the Control Catalog format is <code>catalog</code>.</p>
-    <p>An XML Schema is <a href="https://raw.githubusercontent.com/usnistgov/OSCAL/master/schema/xml/oscal-catalog-schema.xsd">provided</a> for the OSCAL Catalog XML model.</p>
+    <p>The OSCAL Control Catalog format can be used to describe a collection of security controls and related control enhancements (subcontrols), along with contextualizing documentation and metadata. The root of the Control Catalog format is <code>catalog</code>.</p>
+    <p>An XML Schema is <a href="https://raw.githubusercontent.com/usnistgov/OSCAL/master/xml/schema/oscal-catalog-schema.xsd">provided</a> for the OSCAL Catalog XML model.</p>
   </remarks>
   
   <import href="oscal-metadata-metaschema.xml"/>
@@ -158,6 +158,11 @@
   <define-field name="title" as="mixed">
     <formal-name>Title</formal-name>
     <description>A title for display and navigation, exclusive of more specific properties</description>
+    <remarks>
+      <p>A title given to a control or subcontrol will be its name or whatever
+      human-readable string it is known by. Given to other objects (sections,
+      groups, parts) it is the title as it should appear in a formatted document.</p>
+    </remarks>
   </define-field>
 
   <define-field name="prop" group-as="properties">

--- a/src/metaschema/oscal-catalog-metaschema.xml
+++ b/src/metaschema/oscal-catalog-metaschema.xml
@@ -30,8 +30,7 @@
       <p>Catalogs may use <code>section</code> to subdivide the textual contents of a catalog.</p>
     </remarks>
     <model>
-      <field named="title" required="yes"/>
-      <assembly named="metadata"/>
+      <assembly named="metadata" required="yes"/>
       <!--<field named="declarations"/>-->
       <assemblies named="section"/>
       <choice>

--- a/src/metaschema/oscal-profile-metaschema.xml
+++ b/src/metaschema/oscal-profile-metaschema.xml
@@ -31,11 +31,10 @@
           modification in and by other profiles, that import them.</p>
       </remarks>
       <model>
-            <field    named="title" required="yes"/>
-            <assembly named="metadata"/>
+            <assembly   named="metadata" required="yes"/>
             <assemblies named="import"/>
-            <assembly named="merge"/>
-            <assembly named="modify"/>
+            <assembly   named="merge"/>
+            <assembly   named="modify"/>
       </model>
    </define-assembly>
 

--- a/xml/schema/oscal-catalog-schema.xsd
+++ b/xml/schema/oscal-catalog-schema.xsd
@@ -582,8 +582,7 @@
       </xs:annotation>
       <xs:complexType>
          <xs:sequence>
-            <xs:element minOccurs="1" ref="oscal-catalog:title"/>
-            <xs:element minOccurs="0" ref="oscal-catalog:metadata"/>
+            <xs:element minOccurs="1" ref="oscal-catalog:metadata"/>
             <xs:element maxOccurs="unbounded" minOccurs="0" ref="oscal-catalog:section"/>
             <xs:choice>
                <xs:element maxOccurs="unbounded" minOccurs="0" ref="oscal-catalog:group"/>

--- a/xml/schema/oscal-catalog-schema.xsd
+++ b/xml/schema/oscal-catalog-schema.xsd
@@ -1047,6 +1047,7 @@
             <xs:element ref="oscal-prose:b"/>
             <xs:element ref="oscal-prose:sub"/>
             <xs:element ref="oscal-prose:sup"/>
+            <xs:element ref="oscal-prose:img"/>
          </xs:choice>
       </xs:sequence>
    </xs:group>
@@ -1113,6 +1114,12 @@
    <xs:element name="sup">
       <xs:complexType mixed="true">
          <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="img">
+      <xs:complexType>
+         <xs:attribute name="alt"/>
+         <xs:attribute name="src" use="required" type="xs:anyURI"/>
       </xs:complexType>
    </xs:element>
    <xs:element name="a">

--- a/xml/schema/oscal-profile-schema.xsd
+++ b/xml/schema/oscal-profile-schema.xsd
@@ -760,8 +760,7 @@
       </xs:annotation>
       <xs:complexType>
          <xs:sequence>
-            <xs:element minOccurs="1" ref="oscal-profile:title"/>
-            <xs:element minOccurs="0" ref="oscal-profile:metadata"/>
+            <xs:element minOccurs="1" ref="oscal-profile:metadata"/>
             <xs:element maxOccurs="unbounded" minOccurs="0" ref="oscal-profile:import"/>
             <xs:element minOccurs="0" ref="oscal-profile:merge"/>
             <xs:element minOccurs="0" ref="oscal-profile:modify"/>


### PR DESCRIPTION
# Committer Notes

Addresses the modeling refinement described in #243 - **title** is no longer permitted at the top (of a catalog or profile) but is required at the top of its **metadata** -- while **metadata** is also required.

Includes fresh copies of the NIST SP800-53 examples (catalog and profiles), now valid XML.

@brianrufgsa please note that FedRAMP examples need their top-level titles removed to be valid to the schemas in this PR.

This PR includes changes made in the branch behind PR #375.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you included examples of how to use your new feature(s)?
