### PR TITLE
Added skip step for skipping CI deploy builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,7 @@ jobs: # a collection of
     steps: 
       - *checkout
       - *attach_build_workspace
+      - check-skip-build
       - install-maven
       - install-saxon
       - install-lxml


### PR DESCRIPTION
# Committer Notes

Repair for skipping CI deploy builds.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
