### PR TITLE
Ensure that pretty JSON is valid

### DIFF
--- a/build/ci-cd/copy-and-convert-content.sh
+++ b/build/ci-cd/copy-and-convert-content.sh
@@ -59,7 +59,7 @@ while IFS="|" read path format model converttoformats || [[ -n "$path" ]]; do
         json)
           # produce pretty JSON
           dest_pretty="$working_dir/${newpath}.${altformat}"
-          jsome -c false -s 2 "$dest" > "$dest_pretty"
+          jsome -r -c false -s 2 "$dest" > "$dest_pretty"
 
           # produce yaml
           newpath="${newpath/\/json\///yaml/}" # change path 


### PR DESCRIPTION
# Committer Notes

The prettified JSON produced by the CI/CD workflow is missing quoting in JSON keys. This PR fixes this.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
