### PR TITLE
Adjustments in catalog model

### DIFF
--- a/build/metaschema/lib/metaschema-check.sch
+++ b/build/metaschema/lib/metaschema-check.sch
@@ -39,7 +39,8 @@
     <sch:pattern>
         
         <sch:rule context="m:define-assembly | m:define-field | m:define-flag">
-            <sch:assert role="warning" test="count(key('definition-by-name',@name)) = 1">Definition for '<sch:value-of select="@name"/>' is not unique in this metaschema module (only the last one found will be used)</sch:assert>
+            <!-- $compleat assembles all definitions from all modules (in metaschema-compose.xsl)  -->
+            <sch:assert test="count(key('definition-by-name',@name,$compleat)) = 1">Definition for '<sch:value-of select="@name"/>' is not unique in this metaschema module.</sch:assert>
             <sch:assert test="exists(m:formal-name)">formal-name missing from <sch:name/></sch:assert>
             <sch:assert test="exists(m:description)">description missing from <sch:name/></sch:assert>
             <sch:assert test="empty(self::m:define-assembly) or exists(m:model)">model missing from <sch:name/></sch:assert>

--- a/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml
+++ b/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- XML produced by extraction/mapping from NVD XML 2018-11-02T16:55:46.916-04:00 -->
-<!-- Subsequently updated by hand (2018-12-10, 2019-05-16, 2019-05-29, 2019-08-17) -->
+<!-- Subsequently updated by hand (2018-12-10, 2019-05-16, 2019-05-29, 2019-08-17, 2019-08-23) -->
 <!-- Valid against the OSCAL catalog schema (project path /xml/schema/oscal-catalog-schema.xsd) -->
 <catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-   id="uuid-f3de8b2b-dc8e-4b17-9653-e83b708a6663">
+   id="uuid-164e503d-1a64-4373-8926-7c51b8ba2913">
    <metadata>
       <title>NIST Special Publication 800-53 Revision 4: Security and Privacy Controls for Federal Information Systems and Organizations</title>
       
@@ -486,7 +486,7 @@
                <p>automated mechanisms for implementing account management</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.1">
+         <control class="SP800-53-enhancement" id="ac-2.1">
             <title>Automated System Account Management</title>
             <prop name="label">AC-2(1)</prop>
             <part id="ac-2.1_smt" name="statement">
@@ -524,8 +524,8 @@
                   <p>Automated mechanisms implementing account management functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.2">
             <title>Removal of Temporary / Emergency Accounts</title>
             <param id="ac-2.2_prm_1">
                <select>
@@ -583,8 +583,8 @@
                   <p>Automated mechanisms implementing account management functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.3">
             <title>Disable Inactive Accounts</title>
             <param id="ac-2.3_prm_1">
                <label>organization-defined time period</label>
@@ -633,8 +633,8 @@
                   <p>Automated mechanisms implementing account management functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.4">
             <title>Automated Audit Actions</title>
             <param id="ac-2.4_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -748,8 +748,8 @@
                   <p>Automated mechanisms implementing account management functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.5">
             <title>Inactivity Logout</title>
             <param id="ac-2.5_prm_1">
                <label>organization-defined time-period of expected inactivity or description of when to log out</label>
@@ -794,8 +794,8 @@
                   <p>users that must comply with inactivity logout policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.6">
             <title>Dynamic Privilege Management</title>
             <param id="ac-2.6_prm_1">
                <label>organization-defined list of dynamic privilege management capabilities</label>
@@ -846,8 +846,8 @@
                   <p>Information system implementing dynamic privilege management capabilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.7">
             <title>Role-based Schemes</title>
             <param id="ac-2.7_prm_1">
                <label>organization-defined actions</label>
@@ -926,8 +926,8 @@
                   <p>automated mechanisms monitoring privileged role assignments</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.8">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.8">
             <title>Dynamic Account Creation</title>
             <param id="ac-2.8_prm_1">
                <label>organization-defined information system accounts</label>
@@ -978,8 +978,8 @@
                   <p>Automated mechanisms implementing account management functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.9">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.9">
             <title>Restrictions On Use of Shared / Group Accounts</title>
             <param id="ac-2.9_prm_1">
                <label>organization-defined conditions for establishing shared/group accounts</label>
@@ -1025,8 +1025,8 @@
                   <p>Automated mechanisms implementing management of shared/group accounts</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.10">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.10">
             <title>Shared / Group Account Credential Termination</title>
             <prop name="label">AC-2(10)</prop>
             <part id="ac-2.10_smt" name="statement">
@@ -1062,8 +1062,8 @@
                   <p>Automated mechanisms implementing account management functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.11">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.11">
             <title>Usage Conditions</title>
             <param id="ac-2.11_prm_1">
                <label>organization-defined circumstances and/or usage conditions</label>
@@ -1120,8 +1120,8 @@
                   <p>Automated mechanisms implementing account management functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.12">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.12">
             <title>Account Monitoring / Atypical Usage</title>
             <param id="ac-2.12_prm_1">
                <label>organization-defined atypical usage</label>
@@ -1199,8 +1199,8 @@
                   <p>Automated mechanisms implementing account management functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-2.13">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-2.13">
             <title>Disable Accounts for High-risk Individuals</title>
             <param id="ac-2.13_prm_1">
                <label>organization-defined time period</label>
@@ -1251,7 +1251,7 @@
                   <p>Automated mechanisms implementing account management functions</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-3">
          <title>Access Enforcement</title>
@@ -1311,13 +1311,13 @@
                <p>Automated mechanisms implementing access control policy</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-3.1">
+         <control class="SP800-53-enhancement" id="ac-3.1">
             <title>Restricted Access to Privileged Functions</title>
             <prop name="label">AC-3(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ac-6">AC-6</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-3.2">
             <title>Dual Authorization</title>
             <param id="ac-3.2_prm_1">
                <label>organization-defined privileged commands and/or other organization-defined actions</label>
@@ -1371,8 +1371,8 @@
                   <p>Dual authorization mechanisms implementing access control policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-3.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-3.3">
             <title>Mandatory Access Control</title>
             <param id="ac-3.3_prm_1">
                <label>organization-defined mandatory access control policy</label>
@@ -1536,8 +1536,8 @@
                   <p>Automated mechanisms implementing mandatory access control</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-3.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-3.4">
             <title>Discretionary Access Control</title>
             <param id="ac-3.4_prm_1">
                <label>organization-defined discretionary access control policy</label>
@@ -1650,8 +1650,8 @@
                   <p>Automated mechanisms implementing discretionary access control policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-3.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-3.5">
             <title>Security-relevant Information</title>
             <param id="ac-3.5_prm_1">
                <label>organization-defined security-relevant information</label>
@@ -1702,15 +1702,15 @@
                   <p>Automated mechanisms preventing access to security-relevant information within the information system</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-3.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-3.6">
             <title>Protection of User and System Information</title>
             <prop name="label">AC-3(6)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-4">MP-4</link>
             <link rel="incorporated-into" href="#sc-28">SC-28</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-3.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-3.7">
             <title>Role-based Access Control</title>
             <param id="ac-3.7_prm_1">
                <label>organization-defined roles and users authorized to assume such roles</label>
@@ -1777,8 +1777,8 @@
                   <p>Automated mechanisms implementing role-based access control policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-3.8">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-3.8">
             <title>Revocation of Access Authorizations</title>
             <param id="ac-3.8_prm_1">
                <label>organization-defined rules governing the timing of revocations of access authorizations</label>
@@ -1827,8 +1827,8 @@
                   <p>Automated mechanisms implementing access enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-3.9">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-3.9">
             <title>Controlled Release</title>
             <param id="ac-3.9_prm_1">
                <label>organization-defined information system or system component</label>
@@ -1911,8 +1911,8 @@
                   <p>Automated mechanisms implementing access enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-3.10">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-3.10">
             <title>Audited Override of Access Control Mechanisms</title>
             <param id="ac-3.10_prm_1">
                <label>organization-defined conditions</label>
@@ -1962,7 +1962,7 @@
                   <p>Automated mechanisms implementing access enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-4">
          <title>Information Flow Enforcement</title>
@@ -2026,7 +2026,7 @@
                <p>Automated mechanisms implementing information flow enforcement policy</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.1">
+         <control class="SP800-53-enhancement" id="ac-4.1">
             <title>Object Security Attributes</title>
             <param id="ac-4.1_prm_1">
                <label>organization-defined security attributes</label>
@@ -2103,8 +2103,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.2">
             <title>Processing Domains</title>
             <param id="ac-4.2_prm_1">
                <label>organization-defined information flow control policies</label>
@@ -2153,8 +2153,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.3">
             <title>Dynamic Information Flow Control</title>
             <param id="ac-4.3_prm_1">
                <label>organization-defined policies</label>
@@ -2205,8 +2205,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.4">
             <title>Content Check Encrypted Information</title>
             <param id="ac-4.4_prm_1">
                <select how-many="one or more">
@@ -2279,8 +2279,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.5">
             <title>Embedded Data Types</title>
             <param id="ac-4.5_prm_1">
                <label>organization-defined limitations</label>
@@ -2329,8 +2329,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.6">
             <title>Metadata</title>
             <param id="ac-4.6_prm_1">
                <label>organization-defined metadata</label>
@@ -2382,8 +2382,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.7">
             <title>One-way Flow Mechanisms</title>
             <param id="ac-4.7_prm_1">
                <label>organization-defined one-way information flows</label>
@@ -2430,8 +2430,8 @@
                   <p>Hardware mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.8">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.8">
             <title>Security Policy Filters</title>
             <param id="ac-4.8_prm_1">
                <label>organization-defined security policy filters</label>
@@ -2488,8 +2488,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.9">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.9">
             <title>Human Reviews</title>
             <param id="ac-4.9_prm_1">
                <label>organization-defined information flows</label>
@@ -2548,8 +2548,8 @@
                   <p>Automated mechanisms enforcing the use of human reviews</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.10">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.10">
             <title>Enable / Disable Security Policy Filters</title>
             <param id="ac-4.10_prm_1">
                <label>organization-defined security policy filters</label>
@@ -2607,8 +2607,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.11">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.11">
             <title>Configuration of Security Policy Filters</title>
             <param id="ac-4.11_prm_1">
                <label>organization-defined security policy filters</label>
@@ -2659,8 +2659,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.12">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.12">
             <title>Data Type Identifiers</title>
             <param id="ac-4.12_prm_1">
                <label>organization-defined data type identifiers</label>
@@ -2710,8 +2710,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.13">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.13">
             <title>Decomposition into Policy-relevant Subcomponents</title>
             <param id="ac-4.13_prm_1">
                <label>organization-defined policy-relevant subcomponents</label>
@@ -2760,8 +2760,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.14">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.14">
             <title>Security Policy Filter Constraints</title>
             <param id="ac-4.14_prm_1">
                <label>organization-defined security policy filters</label>
@@ -2812,8 +2812,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.15">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.15">
             <title>Detection of Unsanctioned Information</title>
             <param id="ac-4.15_prm_1">
                <label>organized-defined unsanctioned information</label>
@@ -2870,14 +2870,14 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.16">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.16">
             <title>Information Transfers On Interconnected Systems</title>
             <prop name="label">AC-4(16)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ac-4">AC-4</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.17">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.17">
             <title>Domain Authentication</title>
             <param id="ac-4.17_prm_1">
                <select how-many="one or more">
@@ -2956,8 +2956,8 @@
                   <p>Automated mechanisms implementing information flow enforcement policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.18">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.18">
             <title>Security Attribute Binding</title>
             <param id="ac-4.18_prm_1">
                <label>organization-defined binding techniques</label>
@@ -3010,8 +3010,8 @@
                   <p>Automated mechanisms implementing information flow enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.19">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.19">
             <title>Validation of Metadata</title>
             <prop name="label">AC-4(19)</prop>
             <part id="ac-4.19_smt" name="statement">
@@ -3051,8 +3051,8 @@
                   <p>Automated mechanisms implementing information flow enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.20">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.20">
             <title>Approved Solutions</title>
             <param id="ac-4.20_prm_1">
                <label>organization-defined solutions in approved configurations</label>
@@ -3110,8 +3110,8 @@
                   <p>Automated mechanisms implementing information flow enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.21">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.21">
             <title>Physical / Logical Separation of Information Flows</title>
             <param id="ac-4.21_prm_1">
                <label>organization-defined mechanisms and/or techniques</label>
@@ -3170,8 +3170,8 @@
                   <p>Automated mechanisms implementing information flow enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-4.22">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-4.22">
             <title>Access Only</title>
             <prop name="label">AC-4(22)</prop>
             <part id="ac-4.22_smt" name="statement">
@@ -3208,7 +3208,7 @@
                   <p>Automated mechanisms implementing information flow enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-5">
          <title>Separation of Duties</title>
@@ -3331,7 +3331,7 @@
                <p>Automated mechanisms implementing least privilege functions</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-6.1">
+         <control class="SP800-53-enhancement" id="ac-6.1">
             <title>Authorize Access to Security Functions</title>
             <param id="ac-6.1_prm_1">
                <label>organization-defined security functions (deployed in hardware, software, and firmware) and security-relevant information</label>
@@ -3406,8 +3406,8 @@
                   <p>Automated mechanisms implementing least privilege functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-6.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-6.2">
             <title>Non-privileged Access for Nonsecurity Functions</title>
             <param id="ac-6.2_prm_1">
                <label>organization-defined security functions or security-relevant information</label>
@@ -3456,8 +3456,8 @@
                   <p>Automated mechanisms implementing least privilege functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-6.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-6.3">
             <title>Network Access to Privileged Commands</title>
             <param id="ac-6.3_prm_1">
                <label>organization-defined privileged commands</label>
@@ -3517,8 +3517,8 @@
                   <p>Automated mechanisms implementing least privilege functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-6.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-6.4">
             <title>Separate Processing Domains</title>
             <prop name="label">AC-6(4)</prop>
             <part id="ac-6.4_smt" name="statement">
@@ -3559,8 +3559,8 @@
                   <p>Automated mechanisms implementing least privilege functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-6.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-6.5">
             <title>Privileged Accounts</title>
             <param id="ac-6.5_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -3610,8 +3610,8 @@
                   <p>Automated mechanisms implementing least privilege functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-6.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-6.6">
             <title>Privileged Access by Non-organizational Users</title>
             <prop name="label">AC-6(6)</prop>
             <part id="ac-6.6_smt" name="statement">
@@ -3649,8 +3649,8 @@
                   <p>Automated mechanisms prohibiting privileged access to the information system</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-6.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-6.7">
             <title>Review of User Privileges</title>
             <param id="ac-6.7_prm_1">
                <label>organization-defined frequency</label>
@@ -3726,8 +3726,8 @@
                   <p>Automated mechanisms implementing review of user privileges</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-6.8">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-6.8">
             <title>Privilege Levels for Code Execution</title>
             <param id="ac-6.8_prm_1">
                <label>organization-defined software</label>
@@ -3777,8 +3777,8 @@
                   <p>Automated mechanisms implementing least privilege functions for software execution</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-6.9">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-6.9">
             <title>Auditing Use of Privileged Functions</title>
             <prop name="label">AC-6(9)</prop>
             <part id="ac-6.9_smt" name="statement">
@@ -3819,8 +3819,8 @@
                   <p>Automated mechanisms auditing the execution of least privilege functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-6.10">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-6.10">
             <title>Prohibit Non-privileged Users from Executing Privileged Functions</title>
             <prop name="label">AC-6(10)</prop>
             <part id="ac-6.10_smt" name="statement">
@@ -3870,7 +3870,7 @@
                   <p>Automated mechanisms implementing least privilege functions for non-privileged users</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-7">
          <title>Unsuccessful Logon Attempts</title>
@@ -3979,13 +3979,13 @@
                <p>Automated mechanisms implementing access control policy for unsuccessful logon attempts</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-7.1">
+         <control class="SP800-53-enhancement" id="ac-7.1">
             <title>Automatic Account Lock</title>
             <prop name="label">AC-7(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ac-7">AC-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-7.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-7.2">
             <title>Purge / Wipe Mobile Device</title>
             <param id="ac-7.2_prm_1">
                <label>organization-defined mobile devices</label>
@@ -4052,7 +4052,7 @@
                   <p>Automated mechanisms implementing access control policy for unsuccessful device logon attempts</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-8">
          <title>System Use Notification</title>
@@ -4235,7 +4235,7 @@
                <p>Automated mechanisms implementing access control policy for previous logon notification</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-9.1">
+         <control class="SP800-53-enhancement" id="ac-9.1">
             <title>Unsuccessful Logons</title>
             <prop name="label">AC-9(1)</prop>
             <part id="ac-9.1_smt" name="statement">
@@ -4269,8 +4269,8 @@
                   <p>Automated mechanisms implementing access control policy for previous logon notification</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-9.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-9.2">
             <title>Successful / Unsuccessful Logons</title>
             <param id="ac-9.2_prm_1">
                <select>
@@ -4338,8 +4338,8 @@
                   <p>Automated mechanisms implementing access control policy for previous logon notification</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-9.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-9.3">
             <title>Notification of Account Changes</title>
             <param id="ac-9.3_prm_1">
                <label>organization-defined security-related characteristics/parameters of the user’s account</label>
@@ -4391,8 +4391,8 @@
                   <p>Automated mechanisms implementing access control policy for previous logon notification</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-9.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-9.4">
             <title>Additional Logon Information</title>
             <param id="ac-9.4_prm_1">
                <label>organization-defined information to be included in addition to the date and time of the last logon (access)</label>
@@ -4440,7 +4440,7 @@
                   <p>Automated mechanisms implementing access control policy for previous logon notification</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-10">
          <title>Concurrent Session Control</title>
@@ -4564,7 +4564,7 @@
                <p>Automated mechanisms implementing access control policy for session lock</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-11.1">
+         <control class="SP800-53-enhancement" id="ac-11.1">
             <title>Pattern-hiding Displays</title>
             <prop name="label">AC-11(1)</prop>
             <part id="ac-11.1_smt" name="statement">
@@ -4601,7 +4601,7 @@
                   <p>Information system session lock mechanisms</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-12">
          <title>Session Termination</title>
@@ -4654,7 +4654,7 @@
                <p>Automated mechanisms implementing user session termination</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-12.1">
+         <control class="SP800-53-enhancement" id="ac-12.1">
             <title>User-initiated Logouts / Message Displays</title>
             <param id="ac-12.1_prm_1">
                <label>organization-defined information resources</label>
@@ -4720,7 +4720,7 @@
                   <p>Information system session lock mechanisms</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-13">
          <title>Supervision and Review - Access Control</title>
@@ -4788,12 +4788,12 @@
                <p>organizational personnel with information security responsibilities</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-14.1">
+         <control class="SP800-53-enhancement" id="ac-14.1">
             <title>Necessary Uses</title>
             <prop name="label">AC-14(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ac-14">AC-14</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-15">
          <title>Automated Marking</title>
@@ -4946,7 +4946,7 @@
                <p>Organizational capability supporting and maintaining the association of security attributes to information in storage, in process, and in transmission</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-16.1">
+         <control class="SP800-53-enhancement" id="ac-16.1">
             <title>Dynamic Attribute Association</title>
             <param id="ac-16.1_prm_1">
                <label>organization-defined subjects and objects</label>
@@ -5002,8 +5002,8 @@
                   <p>Automated mechanisms implementing dynamic association of security attributes to information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-16.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-16.2">
             <title>Attribute Value Changes by Authorized Individuals</title>
             <prop name="label">AC-16(2)</prop>
             <part id="ac-16.2_smt" name="statement">
@@ -5043,8 +5043,8 @@
                   <p>Automated mechanisms permitting changes to values of security attributes</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-16.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-16.3">
             <title>Maintenance of Attribute Associations by Information System</title>
             <param id="ac-16.3_prm_1">
                <label>organization-defined security attributes</label>
@@ -5097,8 +5097,8 @@
                   <p>Automated mechanisms maintaining association and integrity of security attributes to information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-16.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-16.4">
             <title>Association of Attributes by Authorized Individuals</title>
             <param id="ac-16.4_prm_1">
                <label>organization-defined security attributes</label>
@@ -5154,8 +5154,8 @@
                   <p>Automated mechanisms supporting user associations of security attributes to information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-16.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-16.5">
             <title>Attribute Displays for Output Devices</title>
             <param id="ac-16.5_prm_1">
                <label>organization-identified special dissemination, handling, or distribution instructions</label>
@@ -5211,8 +5211,8 @@
                   <p>System output devices displaying security attributes in human-readable form on each object</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-16.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-16.6">
             <title>Maintenance of Attribute Association by Organization</title>
             <param id="ac-16.6_prm_1">
                <label>organization-defined security attributes</label>
@@ -5271,8 +5271,8 @@
                   <p>Automated mechanisms supporting associations of security attributes to subjects and objects</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-16.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-16.7">
             <title>Consistent Attribute Interpretation</title>
             <prop name="label">AC-16(7)</prop>
             <part id="ac-16.7_smt" name="statement">
@@ -5311,8 +5311,8 @@
                   <p>Automated mechanisms implementing access enforcement and information flow enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-16.8">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-16.8">
             <title>Association Techniques / Technologies</title>
             <param id="ac-16.8_prm_1">
                <label>organization-defined techniques or technologies</label>
@@ -5367,8 +5367,8 @@
                   <p>Automated mechanisms implementing techniques or technologies associating security attributes to information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-16.9">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-16.9">
             <title>Attribute Reassignment</title>
             <param id="ac-16.9_prm_1">
                <label>organization-defined techniques or procedures</label>
@@ -5416,8 +5416,8 @@
                   <p>Automated mechanisms implementing techniques or procedures for reassigning association of security attributes to information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-16.10">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-16.10">
             <title>Attribute Configuration by Authorized Individuals</title>
             <prop name="label">AC-16(10)</prop>
             <part id="ac-16.10_smt" name="statement">
@@ -5454,7 +5454,7 @@
                   <p>Automated mechanisms implementing capability for defining or changing security attributes</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-17">
          <title>Remote Access</title>
@@ -5567,7 +5567,7 @@
                <p>Remote access management capability for the information system</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-17.1">
+         <control class="SP800-53-enhancement" id="ac-17.1">
             <title>Automated Monitoring / Control</title>
             <prop name="label">AC-17(1)</prop>
             <part id="ac-17.1_smt" name="statement">
@@ -5607,8 +5607,8 @@
                   <p>Automated mechanisms monitoring and controlling remote access methods</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-17.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-17.2">
             <title>Protection of Confidentiality / Integrity Using Encryption</title>
             <prop name="label">AC-17(2)</prop>
             <part id="ac-17.2_smt" name="statement">
@@ -5649,8 +5649,8 @@
                   <p>Cryptographic mechanisms protecting confidentiality and integrity of remote access sessions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-17.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-17.3">
             <title>Managed Access Control Points</title>
             <param id="ac-17.3_prm_1">
                <label>organization-defined number</label>
@@ -5699,8 +5699,8 @@
                   <p>Automated mechanisms routing all remote accesses through managed network access control points</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-17.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-17.4">
             <title>Privileged Commands / Access</title>
             <param id="ac-17.4_prm_1">
                <label>organization-defined needs</label>
@@ -5764,14 +5764,14 @@
                   <p>Automated mechanisms implementing remote access management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-17.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-17.5">
             <title>Monitoring for Unauthorized Connections</title>
             <prop name="label">AC-17(5)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-4">SI-4</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-17.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-17.6">
             <title>Protection of Information</title>
             <prop name="label">AC-17(6)</prop>
             <part id="ac-17.6_smt" name="statement">
@@ -5801,20 +5801,20 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-17.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-17.7">
             <title>Additional Protection for Security Function Access</title>
             <prop name="label">AC-17(7)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ac-3.10">AC-3 (10)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-17.8">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-17.8">
             <title>Disable Nonsecure Network Protocols</title>
             <prop name="label">AC-17(8)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#cm-7">CM-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-17.9">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-17.9">
             <title>Disconnect / Disable Access</title>
             <param id="ac-17.9_prm_1">
                <label>organization-defined time period</label>
@@ -5862,7 +5862,7 @@
                   <p>Automated mechanisms implementing capability to disconnect or disable remote access to information system</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-18">
          <title>Wireless Access</title>
@@ -5946,7 +5946,7 @@
                <p>Wireless access management capability for the information system</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-18.1">
+         <control class="SP800-53-enhancement" id="ac-18.1">
             <title>Authentication and Encryption</title>
             <param id="ac-18.1_prm_1">
                <select how-many="one or more">
@@ -5998,14 +5998,14 @@
                   <p>Automated mechanisms implementing wireless access protections to the information system</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-18.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-18.2">
             <title>Monitoring Unauthorized Connections</title>
             <prop name="label">AC-18(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-4">SI-4</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-18.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-18.3">
             <title>Disable Wireless Networking</title>
             <prop name="label">AC-18(3)</prop>
             <part id="ac-18.3_smt" name="statement">
@@ -6041,8 +6041,8 @@
                   <p>Automated mechanisms managing the disabling of wireless networking capabilities internally embedded within information system components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-18.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-18.4">
             <title>Restrict Configurations by Users</title>
             <prop name="label">AC-18(4)</prop>
             <part id="ac-18.4_smt" name="statement">
@@ -6088,8 +6088,8 @@
                   <p>Automated mechanisms authorizing independent user configuration of wireless networking capabilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-18.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-18.5">
             <title>Antennas / Transmission Power Levels</title>
             <prop name="label">AC-18(5)</prop>
             <part id="ac-18.5_smt" name="statement">
@@ -6134,7 +6134,7 @@
                   <p>Wireless access capability protecting usable signals from unauthorized access outside organization-controlled boundaries</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-19">
          <title>Access Control for Mobile Devices</title>
@@ -6224,25 +6224,25 @@
                <p>Access control capability authorizing mobile device connections to organizational information systems</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-19.1">
+         <control class="SP800-53-enhancement" id="ac-19.1">
             <title>Use of Writable / Portable Storage Devices</title>
             <prop name="label">AC-19(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-7">MP-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-19.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-19.2">
             <title>Use of Personally Owned Portable Storage Devices</title>
             <prop name="label">AC-19(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-7">MP-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-19.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-19.3">
             <title>Use of Portable Storage Devices with No Identifiable Owner</title>
             <prop name="label">AC-19(3)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-7">MP-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-19.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-19.4">
             <title>Restrictions for Classified Information</title>
             <param id="ac-19.4_prm_1">
                <label>organization-defined security officials</label>
@@ -6371,8 +6371,8 @@
                   <p>Automated mechanisms prohibiting the use of internal or external modems or wireless interfaces with mobile devices</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-19.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-19.5">
             <title>Full Device / Container-based Encryption</title>
             <param id="ac-19.5_prm_1">
                <select>
@@ -6430,7 +6430,7 @@
                   <p>Encryption mechanisms protecting confidentiality and integrity of information on mobile devices</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-20">
          <title>Use of External Information Systems</title>
@@ -6493,7 +6493,7 @@
                <p>Automated mechanisms implementing terms and conditions on use of external information systems</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-20.1">
+         <control class="SP800-53-enhancement" id="ac-20.1">
             <title>Limits On Authorized Use</title>
             <prop name="label">AC-20(1)</prop>
             <part id="ac-20.1_smt" name="statement">
@@ -6548,8 +6548,8 @@
                   <p>Automated mechanisms implementing limits on use of external information systems</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-20.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-20.2">
             <title>Portable Storage Devices</title>
             <param id="ac-20.2_prm_1">
                <select>
@@ -6593,8 +6593,8 @@
                   <p>Automated mechanisms implementing restrictions on use of portable storage devices</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-20.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-20.3">
             <title>Non-organizationally Owned Systems / Components / Devices</title>
             <param id="ac-20.3_prm_1">
                <select>
@@ -6639,8 +6639,8 @@
                   <p>Automated mechanisms implementing restrictions on the use of non-organizationally owned systems/components/devices</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-20.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-20.4">
             <title>Network Accessible Storage Devices</title>
             <param id="ac-20.4_prm_1">
                <label>organization-defined network accessible storage devices</label>
@@ -6690,7 +6690,7 @@
                   <p>Automated mechanisms prohibiting the use of network accessible storage devices in external information systems</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-21">
          <title>Information Sharing</title>
@@ -6767,7 +6767,7 @@
                <p>Automated mechanisms or manual process implementing access authorizations supporting information sharing/user collaboration decisions</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-21.1">
+         <control class="SP800-53-enhancement" id="ac-21.1">
             <title>Automated Decision Support</title>
             <prop name="label">AC-21(1)</prop>
             <part id="ac-21.1_smt" name="statement">
@@ -6811,8 +6811,8 @@
                   <p>Automated mechanisms implementing access authorizations supporting information sharing/user collaboration decisions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-21.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-21.2">
             <title>Information Search and Retrieval</title>
             <param id="ac-21.2_prm_1">
                <label>organization-defined information sharing restrictions</label>
@@ -6860,7 +6860,7 @@
                   <p>Information system search and retrieval services enforcing information sharing restrictions</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-22">
          <title>Publicly Accessible Content</title>
@@ -7058,7 +7058,7 @@
                <p>Automated mechanisms applying established access control decisions and procedures</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ac-24.1">
+         <control class="SP800-53-enhancement" id="ac-24.1">
             <title>Transmit Access Authorization Information</title>
             <param id="ac-24.1_prm_1">
                <label>organization-defined access authorization information</label>
@@ -7121,8 +7121,8 @@
                   <p>Automated mechanisms implementing access enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ac-24.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ac-24.2">
             <title>No User or Process Identity</title>
             <param id="ac-24.2_prm_1">
                <label>organization-defined security attributes</label>
@@ -7171,7 +7171,7 @@
                   <p>Automated mechanisms implementing access enforcement functions</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ac-25">
          <title>Reference Monitor</title>
@@ -7460,7 +7460,7 @@
                <p>Automated mechanisms managing security awareness training</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="at-2.1">
+         <control class="SP800-53-enhancement" id="at-2.1">
             <title>Practical Exercises</title>
             <prop name="label">AT-2(1)</prop>
             <part id="at-2.1_smt" name="statement">
@@ -7501,8 +7501,8 @@
                   <p>Automated mechanisms implementing cyber attack simulations in practical exercises</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="at-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="at-2.2">
             <title>Insider Threat</title>
             <prop name="label">AT-2(2)</prop>
             <part id="at-2.2_smt" name="statement">
@@ -7537,7 +7537,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="at-3">
          <title>Role-based Security Training</title>
@@ -7621,7 +7621,7 @@
                <p>Automated mechanisms managing role-based security training</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="at-3.1">
+         <control class="SP800-53-enhancement" id="at-3.1">
             <title>Environmental Controls</title>
             <param id="at-3.1_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -7678,8 +7678,8 @@
                   <p>organizational personnel with responsibilities for employing and operating environmental controls</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="at-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="at-3.2">
             <title>Physical Security Controls</title>
             <param id="at-3.2_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -7736,8 +7736,8 @@
                   <p>organizational personnel with responsibilities for employing and operating physical security controls</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="at-3.3">
+         </control>
+         <control class="SP800-53-enhancement" id="at-3.3">
             <title>Practical Exercises</title>
             <prop name="label">AT-3(3)</prop>
             <part id="at-3.3_smt" name="statement">
@@ -7767,8 +7767,8 @@
                   <p>organizational personnel that participate in security awareness training</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="at-3.4">
+         </control>
+         <control class="SP800-53-enhancement" id="at-3.4">
             <title>Suspicious Communications and Anomalous System Behavior</title>
             <param id="at-3.4_prm_1">
                <label>organization-defined indicators of malicious code</label>
@@ -7810,7 +7810,7 @@
                   <p>organizational personnel that participate in security awareness training</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="at-4">
          <title>Security Training Records</title>
@@ -8162,19 +8162,19 @@
                <p>Automated mechanisms implementing information system auditing</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-2.1">
+         <control class="SP800-53-enhancement" id="au-2.1">
             <title>Compilation of Audit Records from Multiple Sources</title>
             <prop name="label">AU-2(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#au-12">AU-12</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-2.2">
             <title>Selection of Audit Events by Component</title>
             <prop name="label">AU-2(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#au-12">AU-12</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-2.3">
+         </control>
+         <control class="SP800-53-enhancement" id="au-2.3">
             <title>Reviews and Updates</title>
             <param id="au-2.3_prm_1">
                <label>organization-defined frequency</label>
@@ -8223,13 +8223,13 @@
                   <p>Automated mechanisms supporting review and update of auditable events</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-2.4">
+         </control>
+         <control class="SP800-53-enhancement" id="au-2.4">
             <title>Privileged Functions</title>
             <prop name="label">AU-2(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ac-6.9">AC-6 (9)</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-3">
          <title>Content of Audit Records</title>
@@ -8298,7 +8298,7 @@
                <p>Automated mechanisms implementing information system auditing of auditable events</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-3.1">
+         <control class="SP800-53-enhancement" id="au-3.1">
             <title>Additional Audit Information</title>
             <param id="au-3.1_prm_1">
                <label>organization-defined additional, more detailed information</label>
@@ -8348,8 +8348,8 @@
                   <p>Information system audit capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-3.2">
             <title>Centralized Management of Planned Audit Record Content</title>
             <param id="au-3.2_prm_1">
                <label>organization-defined information system components</label>
@@ -8401,7 +8401,7 @@
                   <p>Information system capability implementing centralized management and configuration of audit record content</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-4">
          <title>Audit Storage Capacity</title>
@@ -8460,7 +8460,7 @@
                <p>Audit record storage capacity and related configuration settings</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-4.1">
+         <control class="SP800-53-enhancement" id="au-4.1">
             <title>Transfer to Alternate Storage</title>
             <param id="au-4.1_prm_1">
                <label>organization-defined frequency</label>
@@ -8510,7 +8510,7 @@
                   <p>Automated mechanisms supporting transfer of audit records onto a different system</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-5">
          <title>Response to Audit Processing Failures</title>
@@ -8590,7 +8590,7 @@
                <p>Automated mechanisms implementing information system response to audit processing failures</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-5.1">
+         <control class="SP800-53-enhancement" id="au-5.1">
             <title>Audit Storage Capacity</title>
             <param id="au-5.1_prm_1">
                <label>organization-defined personnel, roles, and/or locations</label>
@@ -8666,8 +8666,8 @@
                   <p>Automated mechanisms implementing audit storage limit warnings</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-5.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-5.2">
             <title>Real-time Alerts</title>
             <param id="au-5.2_prm_1">
                <label>organization-defined real-time period</label>
@@ -8744,8 +8744,8 @@
                   <p>Automated mechanisms implementing real-time audit alerts when organization-defined audit failure events occur</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-5.3">
+         </control>
+         <control class="SP800-53-enhancement" id="au-5.3">
             <title>Configurable Traffic Volume Thresholds</title>
             <param id="au-5.3_prm_1">
                <select>
@@ -8811,8 +8811,8 @@
                   <p>Information system capability implementing configurable traffic volume thresholds</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-5.4">
+         </control>
+         <control class="SP800-53-enhancement" id="au-5.4">
             <title>Shutdown On Failure</title>
             <param id="au-5.4_prm_1">
                <select>
@@ -8886,7 +8886,7 @@
                   <p>Information system capability invoking system shutdown or degraded operational mode in the event of an audit processing failure</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-6">
          <title>Audit Review, Analysis, and Reporting</title>
@@ -8988,7 +8988,7 @@
                <p>organizational personnel with information security responsibilities</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-6.1">
+         <control class="SP800-53-enhancement" id="au-6.1">
             <title>Process Integration</title>
             <prop name="label">AU-6(1)</prop>
             <part id="au-6.1_smt" name="statement">
@@ -9055,14 +9055,14 @@
                   <p>Automated mechanisms integrating audit review, analysis, and reporting processes</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-6.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-6.2">
             <title>Automated Security Alerts</title>
             <prop name="label">AU-6(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-4">SI-4</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-6.3">
+         </control>
+         <control class="SP800-53-enhancement" id="au-6.3">
             <title>Correlate Audit Repositories</title>
             <prop name="label">AU-6(3)</prop>
             <part id="au-6.3_smt" name="statement">
@@ -9100,8 +9100,8 @@
                   <p>Automated mechanisms supporting analysis and correlation of audit records</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-6.4">
+         </control>
+         <control class="SP800-53-enhancement" id="au-6.4">
             <title>Central Review and Analysis</title>
             <prop name="label">AU-6(4)</prop>
             <part id="au-6.4_smt" name="statement">
@@ -9141,8 +9141,8 @@
                   <p>Information system capability to centralize review and analysis of audit records</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-6.5">
+         </control>
+         <control class="SP800-53-enhancement" id="au-6.5">
             <title>Integration / Scanning and Monitoring Capabilities</title>
             <param id="au-6.5_prm_1">
                <select how-many="one or more">
@@ -9220,8 +9220,8 @@
                   <p>Automated mechanisms implementing capability to integrate analysis of audit records with analysis of data/information sources</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-6.6">
+         </control>
+         <control class="SP800-53-enhancement" id="au-6.6">
             <title>Correlation with Physical Monitoring</title>
             <prop name="label">AU-6(6)</prop>
             <part id="au-6.6_smt" name="statement">
@@ -9260,8 +9260,8 @@
                   <p>Automated mechanisms implementing capability to correlate information from audit records with information from monitoring physical access</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-6.7">
+         </control>
+         <control class="SP800-53-enhancement" id="au-6.7">
             <title>Permitted Actions</title>
             <param id="au-6.7_prm_1">
                <select how-many="one or more">
@@ -9314,8 +9314,8 @@
                   <p>Automated mechanisms supporting permitted actions for review, analysis, and reporting of audit information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-6.8">
+         </control>
+         <control class="SP800-53-enhancement" id="au-6.8">
             <title>Full Text Analysis of Privileged Commands</title>
             <prop name="label">AU-6(8)</prop>
             <part id="au-6.8_smt" name="statement">
@@ -9365,8 +9365,8 @@
                   <p>Automated mechanisms implementing capability to perform a full text analysis of audited privilege commands</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-6.9">
+         </control>
+         <control class="SP800-53-enhancement" id="au-6.9">
             <title>Correlation with Information from Nontechnical Sources</title>
             <prop name="label">AU-6(9)</prop>
             <part id="au-6.9_smt" name="statement">
@@ -9404,8 +9404,8 @@
                   <p>Automated mechanisms implementing capability to correlate information from non-technical sources</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-6.10">
+         </control>
+         <control class="SP800-53-enhancement" id="au-6.10">
             <title>Audit Level Adjustment</title>
             <prop name="label">AU-6(10)</prop>
             <part id="au-6.10_smt" name="statement">
@@ -9454,7 +9454,7 @@
                   <p>Automated mechanisms supporting review, analysis, and reporting of audit information</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-7">
          <title>Audit Reduction and Report Generation</title>
@@ -9525,7 +9525,7 @@
                <p>Audit reduction and report generation capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-7.1">
+         <control class="SP800-53-enhancement" id="au-7.1">
             <title>Automatic Processing</title>
             <param id="au-7.1_prm_1">
                <label>organization-defined audit fields within audit records</label>
@@ -9577,8 +9577,8 @@
                   <p>Audit reduction and report generation capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-7.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-7.2">
             <title>Automatic Sort and Search</title>
             <param id="au-7.2_prm_1">
                <label>organization-defined audit fields within audit records</label>
@@ -9628,7 +9628,7 @@
                   <p>Audit reduction and report generation capability</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-8">
          <title>Time Stamps</title>
@@ -9699,7 +9699,7 @@
                <p>Automated mechanisms implementing time stamp generation</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-8.1">
+         <control class="SP800-53-enhancement" id="au-8.1">
             <title>Synchronization with Authoritative Time Source</title>
             <param id="au-8.1_prm_1">
                <label>organization-defined frequency</label>
@@ -9781,8 +9781,8 @@
                   <p>Automated mechanisms implementing internal information system clock synchronization</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-8.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-8.2">
             <title>Secondary Authoritative Time Source</title>
             <prop name="label">AU-8(2)</prop>
             <part id="au-8.2_smt" name="statement">
@@ -9816,7 +9816,7 @@
                   <p>Automated mechanisms implementing internal information system clock authoritative time sources</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-9">
          <title>Protection of Audit Information</title>
@@ -9896,7 +9896,7 @@
                <p>Automated mechanisms implementing audit information protection</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-9.1">
+         <control class="SP800-53-enhancement" id="au-9.1">
             <title>Hardware Write-once Media</title>
             <prop name="label">AU-9(1)</prop>
             <part id="au-9.1_smt" name="statement">
@@ -9939,8 +9939,8 @@
                   <p>Information system media storing audit trails</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-9.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-9.2">
             <title>Audit Backup On Separate Physical Systems / Components</title>
             <param id="au-9.2_prm_1">
                <label>organization-defined frequency</label>
@@ -9992,8 +9992,8 @@
                   <p>Automated mechanisms implementing the backing up of audit records</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-9.3">
+         </control>
+         <control class="SP800-53-enhancement" id="au-9.3">
             <title>Cryptographic Protection</title>
             <prop name="label">AU-9(3)</prop>
             <part id="au-9.3_smt" name="statement">
@@ -10043,8 +10043,8 @@
                   <p>Cryptographic mechanisms protecting integrity of audit information and tools</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-9.4">
+         </control>
+         <control class="SP800-53-enhancement" id="au-9.4">
             <title>Access by Subset of Privileged Users</title>
             <param id="au-9.4_prm_1">
                <label>organization-defined subset of privileged users</label>
@@ -10096,8 +10096,8 @@
                   <p>Automated mechanisms managing access to audit functionality</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-9.5">
+         </control>
+         <control class="SP800-53-enhancement" id="au-9.5">
             <title>Dual Authorization</title>
             <param id="au-9.5_prm_1">
                <select how-many="one or more">
@@ -10166,8 +10166,8 @@
                   <p>Automated mechanisms implementing enforcement of dual authorization</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-9.6">
+         </control>
+         <control class="SP800-53-enhancement" id="au-9.6">
             <title>Read Only Access</title>
             <param id="au-9.6_prm_1">
                <label>organization-defined subset of privileged users</label>
@@ -10218,7 +10218,7 @@
                   <p>Automated mechanisms managing access to audit information</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-10">
          <title>Non-repudiation</title>
@@ -10274,7 +10274,7 @@
                <p>Automated mechanisms implementing non-repudiation capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-10.1">
+         <control class="SP800-53-enhancement" id="au-10.1">
             <title>Association of Identities</title>
             <param id="au-10.1_prm_1">
                <label>organization-defined strength of binding</label>
@@ -10341,8 +10341,8 @@
                   <p>Automated mechanisms implementing non-repudiation capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-10.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-10.2">
             <title>Validate Binding of Information Producer Identity</title>
             <param id="au-10.2_prm_1">
                <label>organization-defined frequency</label>
@@ -10421,8 +10421,8 @@
                   <p>Automated mechanisms implementing non-repudiation capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-10.3">
+         </control>
+         <control class="SP800-53-enhancement" id="au-10.3">
             <title>Chain of Custody</title>
             <prop name="label">AU-10(3)</prop>
             <part id="au-10.3_smt" name="statement">
@@ -10478,8 +10478,8 @@
                   <p>Automated mechanisms implementing non-repudiation capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-10.4">
+         </control>
+         <control class="SP800-53-enhancement" id="au-10.4">
             <title>Validate Binding of Information Reviewer Identity</title>
             <param id="au-10.4_prm_1">
                <label>organization-defined security domains</label>
@@ -10557,13 +10557,13 @@
                   <p>Automated mechanisms implementing non-repudiation capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-10.5">
+         </control>
+         <control class="SP800-53-enhancement" id="au-10.5">
             <title>Digital Signatures</title>
             <prop name="label">AU-10(5)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-7">SI-7</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-11">
          <title>Audit Record Retention</title>
@@ -10621,7 +10621,7 @@
                <p>system/network administrators</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-11.1">
+         <control class="SP800-53-enhancement" id="au-11.1">
             <title>Long-term Retrieval Capability</title>
             <param id="au-11.1_prm_1">
                <label>organization-defined measures</label>
@@ -10671,7 +10671,7 @@
                   <p>Automated mechanisms implementing audit record retention capability</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-12">
          <title>Audit Generation</title>
@@ -10762,7 +10762,7 @@
                <p>Automated mechanisms implementing audit record generation capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-12.1">
+         <control class="SP800-53-enhancement" id="au-12.1">
             <title>System-wide / Time-correlated Audit Trail</title>
             <param id="au-12.1_prm_1">
                <label>organization-defined information system components</label>
@@ -10821,8 +10821,8 @@
                   <p>Automated mechanisms implementing audit record generation capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-12.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-12.2">
             <title>Standardized Formats</title>
             <prop name="label">AU-12(2)</prop>
             <part id="au-12.2_smt" name="statement">
@@ -10861,8 +10861,8 @@
                   <p>Automated mechanisms implementing audit record generation capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-12.3">
+         </control>
+         <control class="SP800-53-enhancement" id="au-12.3">
             <title>Changes by Authorized Individuals</title>
             <param id="au-12.3_prm_1">
                <label>organization-defined individuals or roles</label>
@@ -10934,7 +10934,7 @@
                   <p>Automated mechanisms implementing audit record generation capability</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-13">
          <title>Monitoring for Information Disclosure</title>
@@ -10993,7 +10993,7 @@
                <p>Automated mechanisms implementing monitoring for information disclosure</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-13.1">
+         <control class="SP800-53-enhancement" id="au-13.1">
             <title>Use of Automated Tools</title>
             <prop name="label">AU-13(1)</prop>
             <part id="au-13.1_smt" name="statement">
@@ -11030,8 +11030,8 @@
                   <p>Automated mechanisms implementing monitoring for information disclosure</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-13.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-13.2">
             <title>Review of Monitored Sites</title>
             <param id="au-13.2_prm_1">
                <label>organization-defined frequency</label>
@@ -11076,7 +11076,7 @@
                   <p>Automated mechanisms implementing monitoring for information disclosure</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-14">
          <title>Session Audit</title>
@@ -11128,7 +11128,7 @@
                <p>Automated mechanisms implementing user session auditing capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-14.1">
+         <control class="SP800-53-enhancement" id="au-14.1">
             <title>System Start-up</title>
             <prop name="label">AU-14(1)</prop>
             <part id="au-14.1_smt" name="statement">
@@ -11162,8 +11162,8 @@
                   <p>Automated mechanisms implementing user session auditing capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-14.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-14.2">
             <title>Capture/record and Log Content</title>
             <prop name="label">AU-14(2)</prop>
             <part id="au-14.2_smt" name="statement">
@@ -11205,8 +11205,8 @@
                   <p>Automated mechanisms implementing user session auditing capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-14.3">
+         </control>
+         <control class="SP800-53-enhancement" id="au-14.3">
             <title>Remote Viewing / Listening</title>
             <prop name="label">AU-14(3)</prop>
             <part id="au-14.3_smt" name="statement">
@@ -11240,7 +11240,7 @@
                   <p>Automated mechanisms implementing user session auditing capability</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="au-15">
          <title>Alternate Audit Capability</title>
@@ -11348,7 +11348,7 @@
                <p>Automated mechanisms implementing cross-organizational auditing (if applicable)</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="au-16.1">
+         <control class="SP800-53-enhancement" id="au-16.1">
             <title>Identity Preservation</title>
             <prop name="label">AU-16(1)</prop>
             <part id="au-16.1_smt" name="statement">
@@ -11384,8 +11384,8 @@
                   <p>Automated mechanisms implementing cross-organizational auditing (if applicable)</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="au-16.2">
+         </control>
+         <control class="SP800-53-enhancement" id="au-16.2">
             <title>Sharing of Audit Information</title>
             <param id="au-16.2_prm_1">
                <label>organization-defined organizations</label>
@@ -11432,7 +11432,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
    </group>
    <group class="family" id="ca">
@@ -11725,7 +11725,7 @@
                <p>Automated mechanisms supporting security assessment, security assessment plan development, and/or security assessment reporting</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ca-2.1">
+         <control class="SP800-53-enhancement" id="ca-2.1">
             <title>Independent Assessors</title>
             <param id="ca-2.1_prm_1">
                <label>organization-defined level of independence</label>
@@ -11764,8 +11764,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ca-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ca-2.2">
             <title>Specialized Assessments</title>
             <param id="ca-2.2_prm_1">
                <label>organization-defined frequency</label>
@@ -11866,8 +11866,8 @@
                   <p>Automated mechanisms supporting security control assessment</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ca-2.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ca-2.3">
             <title>External Organizations</title>
             <param id="ca-2.3_prm_1">
                <label>organization-defined information system</label>
@@ -11926,7 +11926,7 @@
                   <p>personnel performing security assessments for the specified external organization</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ca-3">
          <title>System Interconnections</title>
@@ -12020,7 +12020,7 @@
                <p>personnel managing the system(s) to which the Interconnection Security Agreement applies</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ca-3.1">
+         <control class="SP800-53-enhancement" id="ca-3.1">
             <title>Unclassified National Security System Connections</title>
             <param id="ca-3.1_prm_1">
                <label>organization-defined unclassified, national security system</label>
@@ -12080,8 +12080,8 @@
                   <p>Automated mechanisms supporting the management of external network connections</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ca-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ca-3.2">
             <title>Classified National Security System Connections</title>
             <param id="ca-3.2_prm_1">
                <label>organization-defined boundary protection device</label>
@@ -12134,8 +12134,8 @@
                   <p>Automated mechanisms supporting the management of external network connections</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ca-3.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ca-3.3">
             <title>Unclassified Non-national Security System Connections</title>
             <param id="ca-3.3_prm_1">
                <label>organization-defined unclassified, non-national security system</label>
@@ -12195,8 +12195,8 @@
                   <p>Automated mechanisms supporting the management of external network connections</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ca-3.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ca-3.4">
             <title>Connections to Public Networks</title>
             <param id="ca-3.4_prm_1">
                <label>organization-defined information system</label>
@@ -12247,8 +12247,8 @@
                   <p>Automated mechanisms supporting the management of public network connections</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ca-3.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ca-3.5">
             <title>Restrictions On External System Connections</title>
             <param id="ca-3.5_prm_1">
                <select>
@@ -12323,7 +12323,7 @@
                   <p>Automated mechanisms implementing restrictions on external system connections</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ca-4">
          <title>Security Certification</title>
@@ -12421,7 +12421,7 @@
                <p>Automated mechanisms for developing, implementing, and maintaining plan of action and milestones</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ca-5.1">
+         <control class="SP800-53-enhancement" id="ca-5.1">
             <title>Automation Support for Accuracy / Currency</title>
             <prop name="label">CA-5(1)</prop>
             <part id="ca-5.1_smt" name="statement">
@@ -12466,7 +12466,7 @@
                   <p>Automated mechanisms for developing, implementing and maintaining plan of action and milestones</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ca-6">
          <title>Security Authorization</title>
@@ -12749,7 +12749,7 @@
                <p>Mechanisms implementing continuous monitoring</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ca-7.1">
+         <control class="SP800-53-enhancement" id="ca-7.1">
             <title>Independent Assessment</title>
             <param id="ca-7.1_prm_1">
                <label>organization-defined level of independence</label>
@@ -12793,14 +12793,14 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ca-7.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ca-7.2">
             <title>Types of Assessments</title>
             <prop name="label">CA-7(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ca-2">CA-2</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ca-7.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ca-7.3">
             <title>Trend Analyses</title>
             <prop name="label">CA-7(3)</prop>
             <part id="ca-7.3_smt" name="statement">
@@ -12846,7 +12846,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ca-8">
          <title>Penetration Testing</title>
@@ -12905,7 +12905,7 @@
                <p>Automated mechanisms supporting penetration testing</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ca-8.1">
+         <control class="SP800-53-enhancement" id="ca-8.1">
             <title>Independent Penetration Agent or Team</title>
             <prop name="label">CA-8(1)</prop>
             <part id="ca-8.1_smt" name="statement">
@@ -12938,8 +12938,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ca-8.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ca-8.2">
             <title>Red Team Exercises</title>
             <param id="ca-8.2_prm_1">
                <label>organization-defined red team exercises</label>
@@ -12999,7 +12999,7 @@
                   <p>Automated mechanisms supporting employment of red team exercises</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ca-9">
          <title>Internal System Connections</title>
@@ -13084,7 +13084,7 @@
                <p>organizational personnel with information security responsibilities</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ca-9.1">
+         <control class="SP800-53-enhancement" id="ca-9.1">
             <title>Security Compliance Checks</title>
             <prop name="label">CA-9(1)</prop>
             <part id="ca-9.1_smt" name="statement">
@@ -13125,7 +13125,7 @@
                   <p>Automated mechanisms supporting compliance checks</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
    </group>
    <group class="family" id="cm">
@@ -13337,7 +13337,7 @@
                <p>automated mechanisms supporting configuration control of the baseline configuration</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cm-2.1">
+         <control class="SP800-53-enhancement" id="cm-2.1">
             <title>Reviews and Updates</title>
             <param id="cm-2.1_prm_1">
                <label>organization-defined frequency</label>
@@ -13426,8 +13426,8 @@
                   <p>automated mechanisms supporting review and update of the baseline configuration</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-2.2">
             <title>Automation Support for Accuracy / Currency</title>
             <prop name="label">CM-2(2)</prop>
             <part id="cm-2.2_smt" name="statement">
@@ -13485,8 +13485,8 @@
                   <p>automated mechanisms implementing baseline configuration maintenance</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-2.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-2.3">
             <title>Retention of Previous Configurations</title>
             <param id="cm-2.3_prm_1">
                <label>organization-defined previous versions of baseline configurations of the information system</label>
@@ -13535,20 +13535,20 @@
                   <p>Organizational processes for managing baseline configurations</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-2.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-2.4">
             <title>Unauthorized Software</title>
             <prop name="label">CM-2(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#cm-7">CM-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-2.5">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-2.5">
             <title>Authorized Software</title>
             <prop name="label">CM-2(5)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#cm-7">CM-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-2.6">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-2.6">
             <title>Development and Test Environments</title>
             <prop name="label">CM-2(6)</prop>
             <part id="cm-2.6_smt" name="statement">
@@ -13590,8 +13590,8 @@
                   <p>automated mechanisms implementing separate baseline configurations for development, test, and operational environments</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-2.7">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-2.7">
             <title>Configure Systems, Components, or Devices for High-risk Areas</title>
             <param id="cm-2.7_prm_1">
                <label>organization-defined information systems, system components, or devices</label>
@@ -13677,7 +13677,7 @@
                   <p>Organizational processes for managing baseline configurations</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cm-3">
          <title>Configuration Change Control</title>
@@ -13828,7 +13828,7 @@
                <p>automated mechanisms that implement configuration change control</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cm-3.1">
+         <control class="SP800-53-enhancement" id="cm-3.1">
             <title>Automated Document / Notification / Prohibition of Changes</title>
             <param id="cm-3.1_prm_1">
                <label>organized-defined approval authorities</label>
@@ -13954,8 +13954,8 @@
                   <p>automated mechanisms implementing configuration change control activities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-3.2">
             <title>Test / Validate / Document Changes</title>
             <prop name="label">CM-3(2)</prop>
             <part id="cm-3.2_smt" name="statement">
@@ -14010,8 +14010,8 @@
                   <p>automated mechanisms supporting and/or implementing testing, validating, and documenting information system changes</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-3.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-3.3">
             <title>Automated Change Implementation</title>
             <prop name="label">CM-3(3)</prop>
             <part id="cm-3.3_smt" name="statement">
@@ -14058,8 +14058,8 @@
                   <p>automated mechanisms implementing changes to current information system baseline</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-3.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-3.4">
             <title>Security Representative</title>
             <param id="cm-3.4_prm_1">
                <label>organization-defined configuration change control element</label>
@@ -14105,8 +14105,8 @@
                   <p>Organizational processes for configuration change control</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-3.5">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-3.5">
             <title>Automated Security Response</title>
             <param id="cm-3.5_prm_1">
                <label>organization-defined security responses</label>
@@ -14160,8 +14160,8 @@
                   <p>automated mechanisms implementing security responses to changes to the baseline configurations</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-3.6">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-3.6">
             <title>Cryptography Management</title>
             <param id="cm-3.6_prm_1">
                <label>organization-defined security safeguards</label>
@@ -14213,7 +14213,7 @@
                   <p>cryptographic mechanisms implementing organizational security safeguards</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cm-4">
          <title>Security Impact Analysis</title>
@@ -14263,7 +14263,7 @@
                <p>Organizational processes for security impact analysis</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cm-4.1">
+         <control class="SP800-53-enhancement" id="cm-4.1">
             <title>Separate Test Environments</title>
             <prop name="label">CM-4(1)</prop>
             <part id="cm-4.1_smt" name="statement">
@@ -14332,8 +14332,8 @@
                   <p>automated mechanisms supporting and/or implementing security impact analysis of changes</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-4.2">
             <title>Verification of Security Functions</title>
             <prop name="label">CM-4(2)</prop>
             <part id="cm-4.2_smt" name="statement">
@@ -14386,7 +14386,7 @@
                   <p>automated mechanisms supporting and/or implementing verification of security functions</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cm-5">
          <title>Access Restrictions for Change</title>
@@ -14468,7 +14468,7 @@
                <p>automated mechanisms supporting/implementing/enforcing access restrictions associated with changes to the information system</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cm-5.1">
+         <control class="SP800-53-enhancement" id="cm-5.1">
             <title>Automated Access Enforcement / Auditing</title>
             <prop name="label">CM-5(1)</prop>
             <part id="cm-5.1_smt" name="statement">
@@ -14521,8 +14521,8 @@
                   <p>automated mechanisms supporting auditing of enforcement actions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-5.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-5.2">
             <title>Review System Changes</title>
             <param id="cm-5.2_prm_1">
                <label>organization-defined frequency</label>
@@ -14590,8 +14590,8 @@
                   <p>automated mechanisms supporting/implementing information system reviews to determine whether unauthorized changes have occurred</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-5.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-5.3">
             <title>Signed Components</title>
             <param id="cm-5.3_prm_1">
                <label>organization-defined software and firmware components</label>
@@ -14648,8 +14648,8 @@
                   <p>automated mechanisms preventing installation of software and firmware components not signed with an organization-recognized and approved certificate</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-5.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-5.4">
             <title>Dual Authorization</title>
             <param id="cm-5.4_prm_1">
                <label>organization-defined information system components and system-level information</label>
@@ -14704,8 +14704,8 @@
                   <p>automated mechanisms implementing dual authorization enforcement</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-5.5">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-5.5">
             <title>Limit Production / Operational Privileges</title>
             <param id="cm-5.5_prm_1">
                <label>organization-defined frequency</label>
@@ -14777,8 +14777,8 @@
                   <p>automated mechanisms supporting and/or implementing access restrictions for change</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-5.6">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-5.6">
             <title>Limit Library Privileges</title>
             <prop name="label">CM-5(6)</prop>
             <part id="cm-5.6_smt" name="statement">
@@ -14819,13 +14819,13 @@
                   <p>automated mechanisms supporting and/or implementing access restrictions for change</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-5.7">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-5.7">
             <title>Automatic Implementation of Security Safeguards</title>
             <prop name="label">CM-5(7)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-7">SI-7</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cm-6">
          <title>Configuration Settings</title>
@@ -14986,7 +14986,7 @@
                <p>automated mechanisms that identify and/or document deviations from established configuration settings</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cm-6.1">
+         <control class="SP800-53-enhancement" id="cm-6.1">
             <title>Automated Central Management / Application / Verification</title>
             <param id="cm-6.1_prm_1">
                <label>organization-defined information system components</label>
@@ -15064,8 +15064,8 @@
                   <p>automated mechanisms implemented to centrally manage, apply, and verify information system configuration settings</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-6.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-6.2">
             <title>Respond to Unauthorized Changes</title>
             <param id="cm-6.2_prm_1">
                <label>organization-defined security safeguards</label>
@@ -15128,19 +15128,19 @@
                   <p>automated mechanisms supporting and/or implementing security safeguards for response to unauthorized changes</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-6.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-6.3">
             <title>Unauthorized Change Detection</title>
             <prop name="label">CM-6(3)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-7">SI-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-6.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-6.4">
             <title>Conformance Demonstration</title>
             <prop name="label">CM-6(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#cm-4">CM-4</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cm-7">
          <title>Least Functionality</title>
@@ -15246,7 +15246,7 @@
                <p>automated mechanisms implementing restrictions or prohibition of functions, ports, protocols, and/or services</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cm-7.1">
+         <control class="SP800-53-enhancement" id="cm-7.1">
             <title>Periodic Review</title>
             <param id="cm-7.1_prm_1">
                <label>organization-defined frequency</label>
@@ -15394,8 +15394,8 @@
                   <p>automated mechanisms implementing review and disabling of nonsecure functions, ports, protocols, and/or services</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-7.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-7.2">
             <title>Prevent Program Execution</title>
             <param id="cm-7.2_prm_1">
                <select how-many="one or more">
@@ -15465,8 +15465,8 @@
                   <p>automated mechanisms supporting and/or implementing software program usage and restrictions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-7.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-7.3">
             <title>Registration Compliance</title>
             <param id="cm-7.3_prm_1">
                <label>organization-defined registration requirements for functions, ports, protocols, and services</label>
@@ -15548,8 +15548,8 @@
                   <p>automated mechanisms implementing compliance with registration requirements for functions, ports, protocols, and/or services</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-7.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-7.4">
             <title>Unauthorized Software / Blacklisting</title>
             <param id="cm-7.4_prm_1">
                <label>organization-defined software programs not authorized to execute on the information system</label>
@@ -15636,8 +15636,8 @@
                   <p>automated mechanisms supporting and/or implementing blacklisting</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-7.5">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-7.5">
             <title>Authorized Software / Whitelisting</title>
             <param id="cm-7.5_prm_1">
                <label>organization-defined software programs authorized to execute on the information system</label>
@@ -15728,7 +15728,7 @@
                   <p>automated mechanisms implementing whitelisting</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cm-8">
          <title>Information System Component Inventory</title>
@@ -15840,7 +15840,7 @@
                <p>automated mechanisms supporting and/or implementing the information system component inventory</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cm-8.1">
+         <control class="SP800-53-enhancement" id="cm-8.1">
             <title>Updates During Installations / Removals</title>
             <prop name="label">CM-8(1)</prop>
             <part id="cm-8.1_smt" name="statement">
@@ -15890,8 +15890,8 @@
                   <p>automated mechanisms implementing updating of the information system component inventory</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-8.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-8.2">
             <title>Automated Maintenance</title>
             <prop name="label">CM-8(2)</prop>
             <part id="cm-8.2_smt" name="statement">
@@ -15951,8 +15951,8 @@
                   <p>automated mechanisms implementing the information system component inventory</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-8.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-8.3">
             <title>Automated Unauthorized Component Detection</title>
             <param id="cm-8.3_prm_1">
                <label>organization-defined frequency</label>
@@ -16086,8 +16086,8 @@
                   <p>automated mechanisms implementing the detection of unauthorized information system components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-8.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-8.4">
             <title>Accountability Information</title>
             <param id="cm-8.4_prm_1">
                <select how-many="one or more">
@@ -16144,8 +16144,8 @@
                   <p>automated mechanisms implementing the information system component inventory</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-8.5">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-8.5">
             <title>No Duplicate Accounting of Components</title>
             <prop name="label">CM-8(5)</prop>
             <part id="cm-8.5_smt" name="statement">
@@ -16184,8 +16184,8 @@
                   <p>automated mechanisms implementing the information system component inventory</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-8.6">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-8.6">
             <title>Assessed Configurations / Approved Deviations</title>
             <prop name="label">CM-8(6)</prop>
             <part id="cm-8.6_smt" name="statement">
@@ -16235,8 +16235,8 @@
                   <p>automated mechanisms implementing the information system component inventory</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-8.7">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-8.7">
             <title>Centralized Repository</title>
             <prop name="label">CM-8(7)</prop>
             <part id="cm-8.7_smt" name="statement">
@@ -16273,8 +16273,8 @@
                   <p>Automated mechanisms implementing the information system component inventory in a centralized repository</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-8.8">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-8.8">
             <title>Automated Location Tracking</title>
             <prop name="label">CM-8(8)</prop>
             <part id="cm-8.8_smt" name="statement">
@@ -16315,8 +16315,8 @@
                   <p>automated mechanisms supporting tracking of information system components by geographic location</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-8.9">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-8.9">
             <title>Assignment of Components to Systems</title>
             <param id="cm-8.9_prm_1">
                <label>organization-defined acquired information system components</label>
@@ -16388,7 +16388,7 @@
                   <p>automated mechanisms implementing acknowledgment of assignment of acquired components to the information system</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cm-9">
          <title>Configuration Management Plan</title>
@@ -16506,7 +16506,7 @@
                <p>automated mechanisms for protecting the configuration management plan</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cm-9.1">
+         <control class="SP800-53-enhancement" id="cm-9.1">
             <title>Assignment of Responsibility</title>
             <prop name="label">CM-9(1)</prop>
             <part id="cm-9.1_smt" name="statement">
@@ -16535,7 +16535,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cm-10">
          <title>Software Usage Restrictions</title>
@@ -16608,7 +16608,7 @@
                <p>automated mechanisms implementing and controlling the use of peer-to-peer files sharing technology</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cm-10.1">
+         <control class="SP800-53-enhancement" id="cm-10.1">
             <title>Open Source Software</title>
             <param id="cm-10.1_prm_1">
                <label>organization-defined restrictions</label>
@@ -16656,7 +16656,7 @@
                   <p>automated mechanisms implementing restrictions on the use of open source software</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cm-11">
          <title>User-installed Software</title>
@@ -16765,7 +16765,7 @@
                <p>automated mechanisms monitoring policy compliance</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cm-11.1">
+         <control class="SP800-53-enhancement" id="cm-11.1">
             <title>Alerts for Unauthorized Installations</title>
             <param id="cm-11.1_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -16819,8 +16819,8 @@
                   <p>automated mechanisms for alerting personnel/roles when unauthorized installation of software is detected</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cm-11.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cm-11.2">
             <title>Prohibit Installation Without Privileged Status</title>
             <prop name="label">CM-11(2)</prop>
             <part id="cm-11.2_smt" name="statement">
@@ -16861,7 +16861,7 @@
                   <p>automated mechanisms for prohibiting installation of software without privileged status (e.g., access controls)</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
    </group>
    <group class="family" id="cp">
@@ -17244,7 +17244,7 @@
                <p>automated mechanisms for developing, reviewing, updating and/or protecting the contingency plan</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cp-2.1">
+         <control class="SP800-53-enhancement" id="cp-2.1">
             <title>Coordinate with Related Plans</title>
             <prop name="label">CP-2(1)</prop>
             <part id="cp-2.1_smt" name="statement">
@@ -17282,8 +17282,8 @@
                   <p>personnel with responsibility for related plans</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-2.2">
             <title>Capacity Planning</title>
             <prop name="label">CP-2(2)</prop>
             <part id="cp-2.2_smt" name="statement">
@@ -17324,8 +17324,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-2.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-2.3">
             <title>Resume Essential Missions / Business Functions</title>
             <param id="cp-2.3_prm_1">
                <label>organization-defined time period</label>
@@ -17374,8 +17374,8 @@
                   <p>Organizational processes for resumption of missions and business functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-2.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-2.4">
             <title>Resume All Missions / Business Functions</title>
             <param id="cp-2.4_prm_1">
                <label>organization-defined time period</label>
@@ -17424,8 +17424,8 @@
                   <p>Organizational processes for resumption of missions and business functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-2.5">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-2.5">
             <title>Continue Essential Missions / Business Functions</title>
             <prop name="label">CP-2(5)</prop>
             <part id="cp-2.5_smt" name="statement">
@@ -17475,8 +17475,8 @@
                   <p>Organizational processes for continuing missions and business functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-2.6">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-2.6">
             <title>Alternate Processing / Storage Site</title>
             <prop name="label">CP-2(6)</prop>
             <part id="cp-2.6_smt" name="statement">
@@ -17524,8 +17524,8 @@
                   <p>Organizational processes for transfer of essential missions and business functions to alternate processing/storage sites</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-2.7">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-2.7">
             <title>Coordinate with External Service Providers</title>
             <prop name="label">CP-2(7)</prop>
             <part id="cp-2.7_smt" name="statement">
@@ -17560,8 +17560,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-2.8">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-2.8">
             <title>Identify Critical Assets</title>
             <prop name="label">CP-2(8)</prop>
             <part id="cp-2.8_smt" name="statement">
@@ -17593,7 +17593,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cp-3">
          <title>Contingency Training</title>
@@ -17684,7 +17684,7 @@
                <p>Organizational processes for contingency training</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cp-3.1">
+         <control class="SP800-53-enhancement" id="cp-3.1">
             <title>Simulated Events</title>
             <prop name="label">CP-3(1)</prop>
             <part id="cp-3.1_smt" name="statement">
@@ -17718,8 +17718,8 @@
                   <p>automated mechanisms for simulating contingency events</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-3.2">
             <title>Automated Training Environments</title>
             <prop name="label">CP-3(2)</prop>
             <part id="cp-3.2_smt" name="statement">
@@ -17753,7 +17753,7 @@
                   <p>automated mechanisms for providing contingency training environments</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cp-4">
          <title>Contingency Plan Testing</title>
@@ -17841,7 +17841,7 @@
                <p>automated mechanisms supporting the contingency plan and/or contingency plan testing</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cp-4.1">
+         <control class="SP800-53-enhancement" id="cp-4.1">
             <title>Coordinate with Related Plans</title>
             <prop name="label">CP-4(1)</prop>
             <part id="cp-4.1_smt" name="statement">
@@ -17883,8 +17883,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-4.2">
             <title>Alternate Processing Site</title>
             <prop name="label">CP-4(2)</prop>
             <part id="cp-4.2_smt" name="statement">
@@ -17941,8 +17941,8 @@
                   <p>automated mechanisms supporting the contingency plan and/or contingency plan testing</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-4.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-4.3">
             <title>Automated Testing</title>
             <prop name="label">CP-4(3)</prop>
             <part id="cp-4.3_smt" name="statement">
@@ -17980,8 +17980,8 @@
                   <p>automated mechanisms supporting contingency plan testing</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-4.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-4.4">
             <title>Full Recovery / Reconstitution</title>
             <prop name="label">CP-4(4)</prop>
             <part id="cp-4.4_smt" name="statement">
@@ -18029,7 +18029,7 @@
                   <p>automated mechanisms supporting recovery and reconstitution of the information system</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cp-5">
          <title>Contingency Plan Update</title>
@@ -18097,7 +18097,7 @@
                <p>automated mechanisms supporting and/or implementing storage and retrieval of information system backup information at the alternate storage site</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cp-6.1">
+         <control class="SP800-53-enhancement" id="cp-6.1">
             <title>Separation from Primary Site</title>
             <prop name="label">CP-6(1)</prop>
             <part id="cp-6.1_smt" name="statement">
@@ -18130,8 +18130,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-6.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-6.2">
             <title>Recovery Time / Point Objectives</title>
             <prop name="label">CP-6(2)</prop>
             <part id="cp-6.2_smt" name="statement">
@@ -18167,8 +18167,8 @@
                   <p>automated mechanisms supporting recovery time/point objectives</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-6.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-6.3">
             <title>Accessibility</title>
             <prop name="label">CP-6(3)</prop>
             <part id="cp-6.3_smt" name="statement">
@@ -18210,7 +18210,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cp-7">
          <title>Alternate Processing Site</title>
@@ -18307,7 +18307,7 @@
                <p>automated mechanisms supporting and/or implementing recovery at the alternate processing site</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cp-7.1">
+         <control class="SP800-53-enhancement" id="cp-7.1">
             <title>Separation from Primary Site</title>
             <prop name="label">CP-7(1)</prop>
             <part id="cp-7.1_smt" name="statement">
@@ -18340,8 +18340,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-7.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-7.2">
             <title>Accessibility</title>
             <prop name="label">CP-7(2)</prop>
             <part id="cp-7.2_smt" name="statement">
@@ -18382,8 +18382,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-7.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-7.3">
             <title>Priority of Service</title>
             <prop name="label">CP-7(3)</prop>
             <part id="cp-7.3_smt" name="statement">
@@ -18415,8 +18415,8 @@
                   <p>organizational personnel with responsibility for acquisitions/contractual agreements</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-7.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-7.4">
             <title>Preparation for Use</title>
             <prop name="label">CP-7(4)</prop>
             <part id="cp-7.4_smt" name="statement">
@@ -18456,14 +18456,14 @@
                   <p>Automated mechanisms supporting and/or implementing recovery at the alternate processing site</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-7.5">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-7.5">
             <title>Equivalent Information Security Safeguards</title>
             <prop name="label">CP-7(5)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#cp-7">CP-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-7.6">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-7.6">
             <title>Inability to Return to Primary Site</title>
             <prop name="label">CP-7(6)</prop>
             <part id="cp-7.6_smt" name="statement">
@@ -18491,7 +18491,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cp-8">
          <title>Telecommunications Services</title>
@@ -18554,7 +18554,7 @@
                <p>Automated mechanisms supporting telecommunications</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cp-8.1">
+         <control class="SP800-53-enhancement" id="cp-8.1">
             <title>Priority of Service Provisions</title>
             <prop name="label">CP-8(1)</prop>
             <part id="cp-8.1_smt" name="statement">
@@ -18608,8 +18608,8 @@
                   <p>Automated mechanisms supporting telecommunications</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-8.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-8.2">
             <title>Single Points of Failure</title>
             <prop name="label">CP-8(2)</prop>
             <part id="cp-8.2_smt" name="statement">
@@ -18637,8 +18637,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-8.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-8.3">
             <title>Separation of Primary / Alternate Providers</title>
             <prop name="label">CP-8(3)</prop>
             <part id="cp-8.3_smt" name="statement">
@@ -18671,8 +18671,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-8.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-8.4">
             <title>Provider Contingency Plan</title>
             <param id="cp-8.4_prm_1">
                <label>organization-defined frequency</label>
@@ -18749,8 +18749,8 @@
                   <p>organizational personnel with responsibility for acquisitions/contractual agreements</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-8.5">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-8.5">
             <title>Alternate Telecommunication Service Testing</title>
             <param id="cp-8.5_prm_1">
                <label>organization-defined frequency</label>
@@ -18795,7 +18795,7 @@
                   <p>Automated mechanisms supporting testing alternate telecommunications services</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cp-9">
          <title>Information System Backup</title>
@@ -18902,7 +18902,7 @@
                <p>automated mechanisms supporting and/or implementing information system backups</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cp-9.1">
+         <control class="SP800-53-enhancement" id="cp-9.1">
             <title>Testing for Reliability / Integrity</title>
             <param id="cp-9.1_prm_1">
                <label>organization-defined frequency</label>
@@ -18951,8 +18951,8 @@
                   <p>automated mechanisms supporting and/or implementing information system backups</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-9.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-9.2">
             <title>Test Restoration Using Sampling</title>
             <prop name="label">CP-9(2)</prop>
             <part id="cp-9.2_smt" name="statement">
@@ -18991,8 +18991,8 @@
                   <p>automated mechanisms supporting and/or implementing information system backups</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-9.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-9.3">
             <title>Separate Storage for Critical Information</title>
             <param id="cp-9.3_prm_1">
                <label>organization-defined critical information system software and other security-related information</label>
@@ -19044,14 +19044,14 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-9.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-9.4">
             <title>Protection from Unauthorized Modification</title>
             <prop name="label">CP-9(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#cp-9">CP-9</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-9.5">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-9.5">
             <title>Transfer to Alternate Storage Site</title>
             <param id="cp-9.5_prm_1">
                <label>organization-defined time period and transfer rate consistent with the recovery time and recovery point objectives</label>
@@ -19105,8 +19105,8 @@
                   <p>automated mechanisms supporting and/or implementing information transfer to the alternate storage site</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-9.6">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-9.6">
             <title>Redundant Secondary System</title>
             <prop name="label">CP-9(6)</prop>
             <part id="cp-9.6_smt" name="statement">
@@ -19157,8 +19157,8 @@
                   <p>automated mechanisms supporting and/or implementing information transfer to a redundant secondary system</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-9.7">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-9.7">
             <title>Dual Authorization</title>
             <param id="cp-9.7_prm_1">
                <label>organization-defined backup information</label>
@@ -19210,7 +19210,7 @@
                   <p>automated mechanisms supporting and/or implementing deletion/destruction of backup information</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cp-10">
          <title>Information System Recovery and Reconstitution</title>
@@ -19294,13 +19294,13 @@
                <p>automated mechanisms supporting and/or implementing information system recovery and reconstitution operations</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="cp-10.1">
+         <control class="SP800-53-enhancement" id="cp-10.1">
             <title>Contingency Plan Testing</title>
             <prop name="label">CP-10(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#cp-4">CP-4</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-10.2">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-10.2">
             <title>Transaction Recovery</title>
             <prop name="label">CP-10(2)</prop>
             <part id="cp-10.2_smt" name="statement">
@@ -19340,14 +19340,14 @@
                   <p>Automated mechanisms supporting and/or implementing transaction recovery capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-10.3">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-10.3">
             <title>Compensating Security Controls</title>
             <prop name="label">CP-10(3)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="https://doi.org/10.6028/NIST.SP.800-53r4">Chapter 3</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-10.4">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-10.4">
             <title>Restore Within Time Period</title>
             <param id="cp-10.4_prm_1">
                <label>organization-defined restoration time-periods</label>
@@ -19398,14 +19398,14 @@
                   <p>Automated mechanisms supporting and/or implementing recovery/reconstitution of information system information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-10.5">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-10.5">
             <title>Failover Capability</title>
             <prop name="label">CP-10(5)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-13">SI-13</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="cp-10.6">
+         </control>
+         <control class="SP800-53-enhancement" id="cp-10.6">
             <title>Component Protection</title>
             <prop name="label">CP-10(6)</prop>
             <part id="cp-10.6_smt" name="statement">
@@ -19461,7 +19461,7 @@
                   <p>automated mechanisms supporting and/or implementing protection of backup and restoration hardware, firmware, and software</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="cp-11">
          <title>Alternate Communications Protocols</title>
@@ -19855,7 +19855,7 @@
                <p>automated mechanisms supporting and/or implementing identification and authentication capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.1">
+         <control class="SP800-53-enhancement" id="ia-2.1">
             <title>Network Access to Privileged Accounts</title>
             <prop name="label">IA-2(1)</prop>
             <part id="ia-2.1_smt" name="statement">
@@ -19895,8 +19895,8 @@
                   <p>Automated mechanisms supporting and/or implementing multifactor authentication capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.2">
             <title>Network Access to Non-privileged Accounts</title>
             <prop name="label">IA-2(2)</prop>
             <part id="ia-2.2_smt" name="statement">
@@ -19933,8 +19933,8 @@
                   <p>Automated mechanisms supporting and/or implementing multifactor authentication capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.3">
             <title>Local Access to Privileged Accounts</title>
             <prop name="label">IA-2(3)</prop>
             <part id="ia-2.3_smt" name="statement">
@@ -19974,8 +19974,8 @@
                   <p>Automated mechanisms supporting and/or implementing multifactor authentication capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.4">
             <title>Local Access to Non-privileged Accounts</title>
             <prop name="label">IA-2(4)</prop>
             <part id="ia-2.4_smt" name="statement">
@@ -20012,8 +20012,8 @@
                   <p>Automated mechanisms supporting and/or implementing multifactor authentication capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.5">
             <title>Group Authentication</title>
             <prop name="label">IA-2(5)</prop>
             <part id="ia-2.5_smt" name="statement">
@@ -20053,8 +20053,8 @@
                   <p>Automated mechanisms supporting and/or implementing authentication capability for group accounts</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.6">
             <title>Network Access to Privileged Accounts - Separate Device</title>
             <param id="ia-2.6_prm_1">
                <label>organization-defined strength of mechanism requirements</label>
@@ -20109,8 +20109,8 @@
                   <p>Automated mechanisms supporting and/or implementing multifactor authentication capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.7">
             <title>Network Access to Non-privileged Accounts - Separate Device</title>
             <param id="ia-2.7_prm_1">
                <label>organization-defined strength of mechanism requirements</label>
@@ -20162,8 +20162,8 @@
                   <p>Automated mechanisms supporting and/or implementing multifactor authentication capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.8">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.8">
             <title>Network Access to Privileged Accounts - Replay Resistant</title>
             <prop name="label">IA-2(8)</prop>
             <part id="ia-2.8_smt" name="statement">
@@ -20204,8 +20204,8 @@
                   <p>automated mechanisms supporting and/or implementing replay resistant authentication mechanisms</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.9">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.9">
             <title>Network Access to Non-privileged Accounts - Replay Resistant</title>
             <prop name="label">IA-2(9)</prop>
             <part id="ia-2.9_smt" name="statement">
@@ -20246,8 +20246,8 @@
                   <p>automated mechanisms supporting and/or implementing replay resistant authentication mechanisms</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.10">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.10">
             <title>Single Sign-on</title>
             <param id="ia-2.10_prm_1">
                <label>organization-defined information system accounts and services</label>
@@ -20300,8 +20300,8 @@
                   <p>automated mechanisms supporting and/or implementing single sign-on capability for information system accounts and services</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.11">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.11">
             <title>Remote Access - Separate Device</title>
             <param id="ia-2.11_prm_1">
                <label>organization-defined strength of mechanism requirements</label>
@@ -20369,8 +20369,8 @@
                   <p>Automated mechanisms supporting and/or implementing identification and authentication capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.12">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.12">
             <title>Acceptance of PIV Credentials</title>
             <prop name="label">IA-2(12)</prop>
             <part id="ia-2.12_smt" name="statement">
@@ -20423,8 +20423,8 @@
                   <p>Automated mechanisms supporting and/or implementing acceptance and verification of PIV credentials</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-2.13">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-2.13">
             <title>Out-of-band Authentication</title>
             <param id="ia-2.13_prm_1">
                <label>organization-defined out-of-band authentication</label>
@@ -20485,7 +20485,7 @@
                   <p>Automated mechanisms supporting and/or implementing out-of-band authentication capability</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ia-3">
          <title>Device Identification and Authentication</title>
@@ -20574,7 +20574,7 @@
                <p>Automated mechanisms supporting and/or implementing device identification and authentication capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ia-3.1">
+         <control class="SP800-53-enhancement" id="ia-3.1">
             <title>Cryptographic Bidirectional Authentication</title>
             <param id="ia-3.1_prm_1">
                <label>organization-defined specific devices and/or types of devices</label>
@@ -20659,14 +20659,14 @@
                   <p>cryptographically based bidirectional authentication mechanisms</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-3.2">
             <title>Cryptographic Bidirectional Network Authentication</title>
             <prop name="label">IA-3(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ia-3.1">IA-3 (1)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-3.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-3.3">
             <title>Dynamic Address Allocation</title>
             <param id="ia-3.3_prm_1">
                <label>organization-defined lease information and lease duration</label>
@@ -20748,8 +20748,8 @@
                   <p>automated mechanisms supporting and/or implanting auditing of lease information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-3.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-3.4">
             <title>Device Attestation</title>
             <param id="ia-3.4_prm_1">
                <label>organization-defined configuration management process</label>
@@ -20802,7 +20802,7 @@
                   <p>cryptographic mechanisms supporting device attestation</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ia-4">
          <title>Identifier Management</title>
@@ -20989,7 +20989,7 @@
                <p>Automated mechanisms supporting and/or implementing identifier management</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ia-4.1">
+         <control class="SP800-53-enhancement" id="ia-4.1">
             <title>Prohibit Account Identifiers as Public Identifiers</title>
             <prop name="label">IA-4(1)</prop>
             <part id="ia-4.1_smt" name="statement">
@@ -21028,8 +21028,8 @@
                   <p>Automated mechanisms supporting and/or implementing identifier management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-4.2">
             <title>Supervisor Authorization</title>
             <prop name="label">IA-4(2)</prop>
             <part id="ia-4.2_smt" name="statement">
@@ -21065,8 +21065,8 @@
                   <p>Automated mechanisms supporting and/or implementing identifier management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-4.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-4.3">
             <title>Multiple Forms of Certification</title>
             <prop name="label">IA-4(3)</prop>
             <part id="ia-4.3_smt" name="statement">
@@ -21103,8 +21103,8 @@
                   <p>Automated mechanisms supporting and/or implementing identifier management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-4.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-4.4">
             <title>Identify User Status</title>
             <param id="ia-4.4_prm_1">
                <label>organization-defined characteristic identifying individual status</label>
@@ -21152,8 +21152,8 @@
                   <p>Automated mechanisms supporting and/or implementing identifier management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-4.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-4.5">
             <title>Dynamic Management</title>
             <prop name="label">IA-4(5)</prop>
             <part id="ia-4.5_smt" name="statement">
@@ -21193,8 +21193,8 @@
                   <p>Automated mechanisms supporting and/or implementing dynamic identifier management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-4.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-4.6">
             <title>Cross-organization Management</title>
             <param id="ia-4.6_prm_1">
                <label>organization-defined external organizations</label>
@@ -21240,8 +21240,8 @@
                   <p>Automated mechanisms supporting and/or implementing identifier management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-4.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-4.7">
             <title>In-person Registration</title>
             <prop name="label">IA-4(7)</prop>
             <part id="ia-4.7_smt" name="statement">
@@ -21272,7 +21272,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ia-5">
          <title>Authenticator Management</title>
@@ -21479,7 +21479,7 @@
                <p>Automated mechanisms supporting and/or implementing authenticator management capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.1">
+         <control class="SP800-53-enhancement" id="ia-5.1">
             <title>Password-based Authentication</title>
             <param id="ia-5.1_prm_1">
                <label>organization-defined requirements for case sensitivity, number of characters, mix of upper-case letters, lower-case letters, numbers, and special characters, including minimum requirements for each type</label>
@@ -21634,8 +21634,8 @@
                   <p>Automated mechanisms supporting and/or implementing password-based authenticator management capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.2">
             <title>Pki-based Authentication</title>
             <prop name="label">IA-5(2)</prop>
             <part id="ia-5.2_smt" name="statement">
@@ -21723,8 +21723,8 @@
                   <p>Automated mechanisms supporting and/or implementing PKI-based, authenticator management capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.3">
             <title>In-person or Trusted Third-party Registration</title>
             <param id="ia-5.3_prm_1">
                <label>organization-defined types of and/or specific authenticators</label>
@@ -21796,8 +21796,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.4">
             <title>Automated Support for Password Strength Determination</title>
             <param id="ia-5.4_prm_1">
                <label>organization-defined requirements</label>
@@ -21850,8 +21850,8 @@
                   <p>automated tools for determining password strength</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.5">
             <title>Change Authenticators Prior to Delivery</title>
             <prop name="label">IA-5(5)</prop>
             <part id="ia-5.5_smt" name="statement">
@@ -21897,8 +21897,8 @@
                   <p>Automated mechanisms supporting and/or implementing authenticator management capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.6">
             <title>Protection of Authenticators</title>
             <prop name="label">IA-5(6)</prop>
             <part id="ia-5.6_smt" name="statement">
@@ -21938,8 +21938,8 @@
                   <p>automated mechanisms protecting authenticators</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.7">
             <title>No Embedded Unencrypted Static Authenticators</title>
             <prop name="label">IA-5(7)</prop>
             <part id="ia-5.7_smt" name="statement">
@@ -21991,8 +21991,8 @@
                   <p>automated mechanisms implementing authentication in applications</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.8">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.8">
             <title>Multiple Information System Accounts</title>
             <param id="ia-5.8_prm_1">
                <label>organization-defined security safeguards</label>
@@ -22040,8 +22040,8 @@
                   <p>Automated mechanisms supporting and/or implementing safeguards for authenticator management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.9">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.9">
             <title>Cross-organization Credential Management</title>
             <param id="ia-5.9_prm_1">
                <label>organization-defined external organizations</label>
@@ -22089,8 +22089,8 @@
                   <p>Automated mechanisms supporting and/or implementing safeguards for authenticator management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.10">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.10">
             <title>Dynamic Credential Association</title>
             <prop name="label">IA-5(10)</prop>
             <part id="ia-5.10_smt" name="statement">
@@ -22130,8 +22130,8 @@
                   <p>automated mechanisms implementing dynamic provisioning of identifiers</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.11">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.11">
             <title>Hardware Token-based Authentication</title>
             <param id="ia-5.11_prm_1">
                <label>organization-defined token quality requirements</label>
@@ -22183,8 +22183,8 @@
                   <p>Automated mechanisms supporting and/or implementing hardware token-based authenticator management capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.12">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.12">
             <title>Biometric-based Authentication</title>
             <param id="ia-5.12_prm_1">
                <label>organization-defined biometric quality requirements</label>
@@ -22236,8 +22236,8 @@
                   <p>Automated mechanisms supporting and/or implementing biometric-based authenticator management capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.13">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.13">
             <title>Expiration of Cached Authenticators</title>
             <param id="ia-5.13_prm_1">
                <label>organization-defined time period</label>
@@ -22284,8 +22284,8 @@
                   <p>Automated mechanisms supporting and/or implementing authenticator management capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.14">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.14">
             <title>Managing Content of PKI Trust Stores</title>
             <prop name="label">IA-5(14)</prop>
             <part id="ia-5.14_smt" name="statement">
@@ -22340,8 +22340,8 @@
                   <p>automated mechanisms supporting and/or implementing the PKI trust store capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-5.15">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-5.15">
             <title>Ficam-approved Products and Services</title>
             <prop name="label">IA-5(15)</prop>
             <part id="ia-5.15_smt" name="statement">
@@ -22381,7 +22381,7 @@
                   <p>automated mechanisms supporting and/or implementing identification and authentication management capability for the information system</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ia-6">
          <title>Authenticator Feedback</title>
@@ -22524,7 +22524,7 @@
                <p>Automated mechanisms supporting and/or implementing identification and authentication capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ia-8.1">
+         <control class="SP800-53-enhancement" id="ia-8.1">
             <title>Acceptance of PIV Credentials from Other Agencies</title>
             <prop name="label">IA-8(1)</prop>
             <part id="ia-8.1_smt" name="statement">
@@ -22578,8 +22578,8 @@
                   <p>automated mechanisms that accept and verify PIV credentials</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-8.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-8.2">
             <title>Acceptance of Third-party Credentials</title>
             <prop name="label">IA-8(2)</prop>
             <part id="ia-8.2_smt" name="statement">
@@ -22624,8 +22624,8 @@
                   <p>automated mechanisms that accept FICAM-approved credentials</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-8.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-8.3">
             <title>Use of Ficam-approved Products</title>
             <param id="ia-8.3_prm_1">
                <label>organization-defined information systems</label>
@@ -22683,8 +22683,8 @@
                   <p>Automated mechanisms supporting and/or implementing identification and authentication capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-8.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-8.4">
             <title>Use of Ficam-issued Profiles</title>
             <prop name="label">IA-8(4)</prop>
             <part id="ia-8.4_smt" name="statement">
@@ -22730,8 +22730,8 @@
                   <p>automated mechanisms supporting and/or implementing conformance with FICAM-issued profiles</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-8.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-8.5">
             <title>Acceptance of PIV-I Credentials</title>
             <prop name="label">IA-8(5)</prop>
             <part id="ia-8.5_smt" name="statement">
@@ -22783,7 +22783,7 @@
                   <p>automated mechanisms that accept and verify PIV-I credentials</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ia-9">
          <title>Service Identification and Authentication</title>
@@ -22844,7 +22844,7 @@
                <p>Security safeguards implementing service identification and authentication capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ia-9.1">
+         <control class="SP800-53-enhancement" id="ia-9.1">
             <title>Information Exchange</title>
             <prop name="label">IA-9(1)</prop>
             <part id="ia-9.1_smt" name="statement">
@@ -22892,8 +22892,8 @@
                   <p>Automated mechanisms implementing service identification and authentication capabilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ia-9.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ia-9.2">
             <title>Transmission of Decisions</title>
             <param id="ia-9.2_prm_1">
                <label>organization-defined services</label>
@@ -22946,7 +22946,7 @@
                   <p>Automated mechanisms implementing service identification and authentication capabilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ia-10">
          <title>Adaptive Identification and Authentication</title>
@@ -23304,7 +23304,7 @@
                <p>organizational personnel with information security responsibilities</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ir-2.1">
+         <control class="SP800-53-enhancement" id="ir-2.1">
             <title>Simulated Events</title>
             <prop name="label">IR-2(1)</prop>
             <part id="ir-2.1_smt" name="statement">
@@ -23338,8 +23338,8 @@
                   <p>Automated mechanisms that support and/or implement simulated events for incident response training</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-2.2">
             <title>Automated Training Environments</title>
             <prop name="label">IR-2(2)</prop>
             <part id="ir-2.2_smt" name="statement">
@@ -23374,7 +23374,7 @@
                   <p>Automated mechanisms that provide a thorough and realistic incident response training environment</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ir-3">
          <title>Incident Response Testing</title>
@@ -23433,7 +23433,7 @@
                <p>organizational personnel with information security responsibilities</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ir-3.1">
+         <control class="SP800-53-enhancement" id="ir-3.1">
             <title>Automated Testing</title>
             <prop name="label">IR-3(1)</prop>
             <part id="ir-3.1_smt" name="statement">
@@ -23476,8 +23476,8 @@
                   <p>Automated mechanisms that more thoroughly and effectively test the incident response capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-3.2">
             <title>Coordination with Related Plans</title>
             <prop name="label">IR-3(2)</prop>
             <part id="ir-3.2_smt" name="statement">
@@ -23516,7 +23516,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ir-4">
          <title>Incident Handling</title>
@@ -23646,7 +23646,7 @@
                <p>Incident handling capability for the organization</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ir-4.1">
+         <control class="SP800-53-enhancement" id="ir-4.1">
             <title>Automated Incident Handling Processes</title>
             <prop name="label">IR-4(1)</prop>
             <part id="ir-4.1_smt" name="statement">
@@ -23685,8 +23685,8 @@
                   <p>Automated mechanisms that support and/or implement the incident handling process</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-4.2">
             <title>Dynamic Reconfiguration</title>
             <param id="ir-4.2_prm_1">
                <label>organization-defined information system components</label>
@@ -23743,8 +23743,8 @@
                   <p>Automated mechanisms that support and/or implement dynamic reconfiguration of components as part of incident response</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-4.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-4.3">
             <title>Continuity of Operations</title>
             <param id="ir-4.3_prm_1">
                <label>organization-defined classes of incidents</label>
@@ -23799,8 +23799,8 @@
                   <p>Automated mechanisms that support and/or implement continuity of operations</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-4.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-4.4">
             <title>Information Correlation</title>
             <prop name="label">IR-4(4)</prop>
             <part id="ir-4.4_smt" name="statement">
@@ -23847,8 +23847,8 @@
                   <p>automated mechanisms that support and or implement correlation of incident response information with individual incident responses</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-4.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-4.5">
             <title>Automatic Disabling of Information System</title>
             <param id="ir-4.5_prm_1">
                <label>organization-defined security violations</label>
@@ -23896,8 +23896,8 @@
                   <p>automated mechanisms supporting and/or implementing automatic disabling of the information system</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-4.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-4.6">
             <title>Insider Threats - Specific Capabilities</title>
             <prop name="label">IR-4(6)</prop>
             <part id="ir-4.6_smt" name="statement">
@@ -23936,8 +23936,8 @@
                   <p>Incident handling capability for the organization</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-4.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-4.7">
             <title>Insider Threats - Intra-organization Coordination</title>
             <param id="ir-4.7_prm_1">
                <label>organization-defined components or elements of the organization</label>
@@ -23984,8 +23984,8 @@
                   <p>Organizational processes for coordinating incident handling</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-4.8">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-4.8">
             <title>Correlation with External Organizations</title>
             <param id="ir-4.8_prm_1">
                <label>organization-defined external organizations</label>
@@ -24041,8 +24041,8 @@
                   <p>Organizational processes for coordinating incident handling information with external organizations</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-4.9">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-4.9">
             <title>Dynamic Response Capability</title>
             <param id="ir-4.9_prm_1">
                <label>organization-defined dynamic response capabilities</label>
@@ -24094,8 +24094,8 @@
                   <p>automated mechanisms supporting and/or implementing the dynamic response capability for the organization</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-4.10">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-4.10">
             <title>Supply Chain Coordination</title>
             <prop name="label">IR-4(10)</prop>
             <part id="ir-4.10_smt" name="statement">
@@ -24128,7 +24128,7 @@
                   <p>organizational personnel with supply chain responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ir-5">
          <title>Incident Monitoring</title>
@@ -24184,7 +24184,7 @@
                <p>automated mechanisms supporting and/or implementing tracking and documenting of system security incidents</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ir-5.1">
+         <control class="SP800-53-enhancement" id="ir-5.1">
             <title>Automated Tracking / Data Collection / Analysis</title>
             <prop name="label">IR-5(1)</prop>
             <part id="ir-5.1_smt" name="statement">
@@ -24237,7 +24237,7 @@
                   <p>Automated mechanisms assisting in tracking of security incidents and in the collection and analysis of incident information</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ir-6">
          <title>Incident Reporting</title>
@@ -24319,7 +24319,7 @@
                <p>automated mechanisms supporting and/or implementing incident reporting</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ir-6.1">
+         <control class="SP800-53-enhancement" id="ir-6.1">
             <title>Automated Reporting</title>
             <prop name="label">IR-6(1)</prop>
             <part id="ir-6.1_smt" name="statement">
@@ -24358,8 +24358,8 @@
                   <p>automated mechanisms supporting and/or implementing reporting of security incidents</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-6.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-6.2">
             <title>Vulnerabilities Related to Incidents</title>
             <param id="ir-6.2_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -24406,8 +24406,8 @@
                   <p>automated mechanisms supporting and/or implementing reporting of vulnerabilities associated with security incidents</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-6.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-6.3">
             <title>Coordination with Supply Chain</title>
             <prop name="label">IR-6(3)</prop>
             <part id="ir-6.3_smt" name="statement">
@@ -24447,7 +24447,7 @@
                   <p>automated mechanisms supporting and/or implementing reporting of incident information involved in the supply chain</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ir-7">
          <title>Incident Response Assistance</title>
@@ -24499,7 +24499,7 @@
                <p>automated mechanisms supporting and/or implementing incident response assistance</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ir-7.1">
+         <control class="SP800-53-enhancement" id="ir-7.1">
             <title>Automation Support for Availability of Information / Support</title>
             <prop name="label">IR-7(1)</prop>
             <part id="ir-7.1_smt" name="statement">
@@ -24539,8 +24539,8 @@
                   <p>automated mechanisms supporting and/or implementing an increase in the availability of incident response information and support</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-7.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-7.2">
             <title>Coordination with External Providers</title>
             <prop name="label">IR-7(2)</prop>
             <part id="ir-7.2_smt" name="statement">
@@ -24588,7 +24588,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ir-8">
          <title>Incident Response Plan</title>
@@ -24933,7 +24933,7 @@
                <p>automated mechanisms supporting and/or implementing information spillage response actions and related communications</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ir-9.1">
+         <control class="SP800-53-enhancement" id="ir-9.1">
             <title>Responsible Personnel</title>
             <param id="ir-9.1_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -24970,8 +24970,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-9.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-9.2">
             <title>Training</title>
             <param id="ir-9.2_prm_1">
                <label>organization-defined frequency</label>
@@ -25010,8 +25010,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-9.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-9.3">
             <title>Post-spill Operations</title>
             <param id="ir-9.3_prm_1">
                <label>organization-defined procedures</label>
@@ -25057,8 +25057,8 @@
                   <p>Organizational processes for post-spill operations</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ir-9.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ir-9.4">
             <title>Exposure to Unauthorized Personnel</title>
             <param id="ir-9.4_prm_1">
                <label>organization-defined security safeguards</label>
@@ -25106,7 +25106,7 @@
                   <p>automated mechanisms supporting and/or implementing safeguards for personnel exposed to information not within assigned access authorizations</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ir-10">
          <title>Integrated Information Security Analysis Team</title>
@@ -25461,13 +25461,13 @@
                <p>automated mechanisms implementing sanitization of information system components</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ma-2.1">
+         <control class="SP800-53-enhancement" id="ma-2.1">
             <title>Record Content</title>
             <prop name="label">MA-2(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ma-2">MA-2</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-2.2">
             <title>Automated Maintenance Activities</title>
             <prop name="label">MA-2(2)</prop>
             <part id="ma-2.2_smt" name="statement">
@@ -25552,7 +25552,7 @@
                   <p>automated mechanisms supporting and/or implementing production of records of maintenance and repair actions</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ma-3">
          <title>Maintenance Tools</title>
@@ -25606,7 +25606,7 @@
                <p>automated mechanisms supporting and/or implementing approval, control, and/or monitoring of maintenance tools</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ma-3.1">
+         <control class="SP800-53-enhancement" id="ma-3.1">
             <title>Inspect Tools</title>
             <prop name="label">MA-3(1)</prop>
             <part id="ma-3.1_smt" name="statement">
@@ -25644,8 +25644,8 @@
                   <p>automated mechanisms supporting and/or implementing inspection of maintenance tools</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-3.2">
             <title>Inspect Media</title>
             <prop name="label">MA-3(2)</prop>
             <part id="ma-3.2_smt" name="statement">
@@ -25682,8 +25682,8 @@
                   <p>automated mechanisms supporting and/or implementing inspection of media used for maintenance</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-3.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-3.3">
             <title>Prevent Unauthorized Removal</title>
             <param id="ma-3.3_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -25770,8 +25770,8 @@
                   <p>automated mechanisms supporting verification of media sanitization</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-3.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-3.4">
             <title>Restricted Tool Use</title>
             <prop name="label">MA-3(4)</prop>
             <part id="ma-3.4_smt" name="statement">
@@ -25813,7 +25813,7 @@
                   <p>automated mechanisms supporting and/or implementing restricted use of maintenance tools</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ma-4">
          <title>Nonlocal Maintenance</title>
@@ -25942,7 +25942,7 @@
                <p>automated mechanisms for terminating nonlocal maintenance sessions and network connections</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ma-4.1">
+         <control class="SP800-53-enhancement" id="ma-4.1">
             <title>Auditing and Review</title>
             <param id="ma-4.1_prm_1">
                <label>organization-defined audit events</label>
@@ -26014,8 +26014,8 @@
                   <p>automated mechanisms supporting and/or implementing audit and review of nonlocal maintenance</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-4.2">
             <title>Document Nonlocal Maintenance</title>
             <prop name="label">MA-4(2)</prop>
             <part id="ma-4.2_smt" name="statement">
@@ -26051,8 +26051,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-4.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-4.3">
             <title>Comparable Security / Sanitization</title>
             <prop name="label">MA-4(3)</prop>
             <part id="ma-4.3_smt" name="statement">
@@ -26129,8 +26129,8 @@
                   <p>automated mechanisms supporting and/or implementing component sanitization and inspection</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-4.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-4.4">
             <title>Authentication / Separation of Maintenance Sessions</title>
             <param id="ma-4.4_prm_1">
                <label>organization-defined authenticators that are replay resistant</label>
@@ -26217,8 +26217,8 @@
                   <p>automated mechanisms implementing logically separated/encrypted communications paths</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-4.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-4.5">
             <title>Approvals and Notifications</title>
             <param id="ma-4.5_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -26296,8 +26296,8 @@
                   <p>automated mechanisms supporting notification and approval of nonlocal maintenance</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-4.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-4.6">
             <title>Cryptographic Protection</title>
             <prop name="label">MA-4(6)</prop>
             <part id="ma-4.6_smt" name="statement">
@@ -26339,8 +26339,8 @@
                   <p>Cryptographic mechanisms protecting nonlocal maintenance and diagnostic communications</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-4.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-4.7">
             <title>Remote Disconnect Verification</title>
             <prop name="label">MA-4(7)</prop>
             <part id="ma-4.7_smt" name="statement">
@@ -26382,7 +26382,7 @@
                   <p>Automated mechanisms implementing remote disconnect verifications of terminated nonlocal maintenance and diagnostic sessions</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ma-5">
          <title>Maintenance Personnel</title>
@@ -26461,7 +26461,7 @@
                <p>automated mechanisms supporting and/or implementing authorization of maintenance personnel</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ma-5.1">
+         <control class="SP800-53-enhancement" id="ma-5.1">
             <title>Individuals Without Appropriate Access</title>
             <prop name="label">MA-5(1)</prop>
             <part id="ma-5.1_smt" name="statement">
@@ -26568,8 +26568,8 @@
                   <p>automated mechanisms supporting and/or implementing information storage component sanitization</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-5.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-5.2">
             <title>Security Clearances for Classified Systems</title>
             <prop name="label">MA-5(2)</prop>
             <part id="ma-5.2_smt" name="statement">
@@ -26625,8 +26625,8 @@
                   <p>Organizational processes for managing security clearances for maintenance personnel</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-5.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-5.3">
             <title>Citizenship Requirements for Classified Systems</title>
             <prop name="label">MA-5(3)</prop>
             <part id="ma-5.3_smt" name="statement">
@@ -26659,8 +26659,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-5.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-5.4">
             <title>Foreign Nationals</title>
             <prop name="label">MA-5(4)</prop>
             <part id="ma-5.4_smt" name="statement">
@@ -26728,8 +26728,8 @@
                   <p>Organizational processes for managing foreign national maintenance personnel</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-5.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-5.5">
             <title>Nonsystem-related Maintenance</title>
             <prop name="label">MA-5(5)</prop>
             <part id="ma-5.5_smt" name="statement">
@@ -26764,7 +26764,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ma-6">
          <title>Timely Maintenance</title>
@@ -26835,7 +26835,7 @@
                <p>Organizational processes for ensuring timely maintenance</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ma-6.1">
+         <control class="SP800-53-enhancement" id="ma-6.1">
             <title>Preventive Maintenance</title>
             <param id="ma-6.1_prm_1">
                <label>organization-defined information system components</label>
@@ -26893,8 +26893,8 @@
                   <p>automated mechanisms supporting and/or implementing preventive maintenance</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-6.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-6.2">
             <title>Predictive Maintenance</title>
             <param id="ma-6.2_prm_1">
                <label>organization-defined information system components</label>
@@ -26952,8 +26952,8 @@
                   <p>automated mechanisms supporting and/or implementing predictive maintenance</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ma-6.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ma-6.3">
             <title>Automated Support for Predictive Maintenance</title>
             <prop name="label">MA-6(3)</prop>
             <part id="ma-6.3_smt" name="statement">
@@ -26993,7 +26993,7 @@
                   <p>operations of the computer maintenance management system</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
    </group>
    <group class="family" id="mp">
@@ -27212,18 +27212,18 @@
                <p>automated mechanisms supporting and/or implementing media access restrictions</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="mp-2.1">
+         <control class="SP800-53-enhancement" id="mp-2.1">
             <title>Automated Restricted Access</title>
             <prop name="label">MP-2(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-4.2">MP-4 (2)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-2.2">
             <title>Cryptographic Protection</title>
             <prop name="label">MP-2(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-28.1">SC-28 (1)</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="mp-3">
          <title>Media Marking</title>
@@ -27398,13 +27398,13 @@
                <p>automated mechanisms supporting and/or implementing secure media storage/media protection</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="mp-4.1">
+         <control class="SP800-53-enhancement" id="mp-4.1">
             <title>Cryptographic Protection</title>
             <prop name="label">MP-4(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-28.1">SC-28 (1)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-4.2">
             <title>Automated Restricted Access</title>
             <prop name="label">MP-4(2)</prop>
             <part id="mp-4.2_smt" name="statement">
@@ -27463,7 +27463,7 @@
                   <p>automated mechanisms auditing access attempts and access granted to media storage areas</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="mp-5">
          <title>Media Transport</title>
@@ -27564,19 +27564,19 @@
                <p>automated mechanisms supporting and/or implementing media storage/media protection</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="mp-5.1">
+         <control class="SP800-53-enhancement" id="mp-5.1">
             <title>Protection Outside of Controlled Areas</title>
             <prop name="label">MP-5(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-5">MP-5</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-5.2">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-5.2">
             <title>Documentation of Activities</title>
             <prop name="label">MP-5(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-5">MP-5</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-5.3">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-5.3">
             <title>Custodians</title>
             <prop name="label">MP-5(3)</prop>
             <part id="mp-5.3_smt" name="statement">
@@ -27606,8 +27606,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-5.4">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-5.4">
             <title>Cryptographic Protection</title>
             <prop name="label">MP-5(4)</prop>
             <part id="mp-5.4_smt" name="statement">
@@ -27645,7 +27645,7 @@
                   <p>Cryptographic mechanisms protecting information on digital media during transportation outside controlled areas</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="mp-6">
          <title>Media Sanitization</title>
@@ -27752,7 +27752,7 @@
                <p>automated mechanisms supporting and/or implementing media sanitization</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="mp-6.1">
+         <control class="SP800-53-enhancement" id="mp-6.1">
             <title>Review / Approve / Track / Document / Verify</title>
             <prop name="label">MP-6(1)</prop>
             <part id="mp-6.1_smt" name="statement">
@@ -27814,8 +27814,8 @@
                   <p>automated mechanisms supporting and/or implementing media sanitization</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-6.2">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-6.2">
             <title>Equipment Testing</title>
             <param id="mp-6.2_prm_1">
                <label>organization-defined frequency</label>
@@ -27863,8 +27863,8 @@
                   <p>automated mechanisms supporting and/or implementing media sanitization</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-6.3">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-6.3">
             <title>Nondestructive Techniques</title>
             <param id="mp-6.3_prm_1">
                <label>organization-defined circumstances requiring sanitization of portable storage devices</label>
@@ -27913,26 +27913,26 @@
                   <p>automated mechanisms supporting and/or implementing media sanitization</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-6.4">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-6.4">
             <title>Controlled Unclassified Information</title>
             <prop name="label">MP-6(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-6">MP-6</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-6.5">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-6.5">
             <title>Classified Information</title>
             <prop name="label">MP-6(5)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-6">MP-6</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-6.6">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-6.6">
             <title>Media Destruction</title>
             <prop name="label">MP-6(6)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-6">MP-6</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-6.7">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-6.7">
             <title>Dual Authorization</title>
             <param id="mp-6.7_prm_1">
                <label>organization-defined information system media</label>
@@ -27985,8 +27985,8 @@
                   <p>automated mechanisms supporting and/or implementing dual authorization</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-6.8">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-6.8">
             <title>Remote Purging / Wiping of Information</title>
             <param id="mp-6.8_prm_1">
                <label>organization-defined information systems, system components, or devices</label>
@@ -28051,7 +28051,7 @@
                   <p>automated mechanisms supporting and/or implementing purge/wipe capabilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="mp-7">
          <title>Media Use</title>
@@ -28145,7 +28145,7 @@
                <p>automated mechanisms restricting or prohibiting use of information system media on information systems or system components</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="mp-7.1">
+         <control class="SP800-53-enhancement" id="mp-7.1">
             <title>Prohibit Use Without Owner</title>
             <prop name="label">MP-7(1)</prop>
             <part id="mp-7.1_smt" name="statement">
@@ -28187,8 +28187,8 @@
                   <p>automated mechanisms prohibiting use of media on information systems or system components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-7.2">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-7.2">
             <title>Prohibit Use of Sanitization-resistant Media</title>
             <prop name="label">MP-7(2)</prop>
             <part id="mp-7.2_smt" name="statement">
@@ -28226,7 +28226,7 @@
                   <p>automated mechanisms prohibiting use of media on information systems or system components</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="mp-8">
          <title>Media Downgrading</title>
@@ -28327,7 +28327,7 @@
                <p>automated mechanisms supporting and/or implementing media downgrading</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="mp-8.1">
+         <control class="SP800-53-enhancement" id="mp-8.1">
             <title>Documentation of Process</title>
             <prop name="label">MP-8(1)</prop>
             <part id="mp-8.1_smt" name="statement">
@@ -28364,8 +28364,8 @@
                   <p>automated mechanisms supporting and/or implementing media downgrading</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-8.2">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-8.2">
             <title>Equipment Testing</title>
             <param id="mp-8.2_prm_1">
                <label>organization-defined tests</label>
@@ -28424,8 +28424,8 @@
                   <p>automated mechanisms supporting and/or implementing tests for downgrading equipment</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-8.3">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-8.3">
             <title>Controlled Unclassified Information</title>
             <param id="mp-8.3_prm_1">
                <label>organization-defined Controlled Unclassified Information (CUI)</label>
@@ -28470,8 +28470,8 @@
                   <p>automated mechanisms supporting and/or implementing media downgrading</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="mp-8.4">
+         </control>
+         <control class="SP800-53-enhancement" id="mp-8.4">
             <title>Classified Information</title>
             <prop name="label">MP-8(4)</prop>
             <part id="mp-8.4_smt" name="statement">
@@ -28509,7 +28509,7 @@
                   <p>automated mechanisms supporting and/or implementing media downgrading</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
    </group>
    <group class="family" id="pe">
@@ -28759,7 +28759,7 @@
                <p>automated mechanisms supporting and/or implementing physical access authorizations</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-2.1">
+         <control class="SP800-53-enhancement" id="pe-2.1">
             <title>Access by Position / Role</title>
             <prop name="label">PE-2(1)</prop>
             <part id="pe-2.1_smt" name="statement">
@@ -28799,8 +28799,8 @@
                   <p>automated mechanisms supporting and/or implementing physical access authorizations</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-2.2">
             <title>Two Forms of Identification</title>
             <param id="pe-2.2_prm_1">
                <label>organization-defined list of acceptable forms of identification</label>
@@ -28853,8 +28853,8 @@
                   <p>automated mechanisms supporting and/or implementing physical access authorizations</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-2.3">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-2.3">
             <title>Restrict Unescorted Access</title>
             <param id="pe-2.3_prm_1">
                <select how-many="one or more">
@@ -28931,7 +28931,7 @@
                   <p>automated mechanisms supporting and/or implementing physical access authorizations</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-3">
          <title>Physical Access Control</title>
@@ -29198,7 +29198,7 @@
                <p>physical access control devices</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-3.1">
+         <control class="SP800-53-enhancement" id="pe-3.1">
             <title>Information System Access</title>
             <param id="pe-3.1_prm_1">
                <label>organization-defined physical spaces containing one or more components of the information system</label>
@@ -29250,8 +29250,8 @@
                   <p>automated mechanisms supporting and/or implementing physical access control for facility areas containing information system components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-3.2">
             <title>Facility / Information System Boundaries</title>
             <param id="pe-3.2_prm_1">
                <label>organization-defined frequency</label>
@@ -29321,8 +29321,8 @@
                   <p>automated mechanisms supporting and/or implementing security checks for unauthorized exfiltration of information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-3.3">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-3.3">
             <title>Continuous Guards / Alarms / Monitoring</title>
             <prop name="label">PE-3(3)</prop>
             <part id="pe-3.3_smt" name="statement">
@@ -29370,8 +29370,8 @@
                   <p>automated mechanisms supporting and/or implementing physical access control for the facility where the information system resides</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-3.4">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-3.4">
             <title>Lockable Casings</title>
             <param id="pe-3.4_prm_1">
                <label>organization-defined information system components</label>
@@ -29415,8 +29415,8 @@
                   <p>Lockable physical casings</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-3.5">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-3.5">
             <title>Tamper Protection</title>
             <param id="pe-3.5_prm_1">
                <label>organization-defined security safeguards</label>
@@ -29484,8 +29484,8 @@
                   <p>automated mechanisms/security safeguards supporting and/or implementing detection/prevention of physical tampering/alternation of information system hardware components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-3.6">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-3.6">
             <title>Facility Penetration Testing</title>
             <param id="pe-3.6_prm_1">
                <label>organization-defined frequency</label>
@@ -29535,7 +29535,7 @@
                   <p>automated mechanisms supporting and/or implementing facility penetration testing</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-4">
          <title>Access Control for Transmission Medium</title>
@@ -29641,7 +29641,7 @@
                <p>automated mechanisms supporting and/or implementing access control to output devices</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-5.1">
+         <control class="SP800-53-enhancement" id="pe-5.1">
             <title>Access to Output by Authorized Individuals</title>
             <param id="pe-5.1_prm_1">
                <label>organization-defined output devices</label>
@@ -29705,8 +29705,8 @@
                   <p>automated mechanisms supporting and/or implementing access control to output devices</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-5.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-5.2">
             <title>Access to Output by Individual Identity</title>
             <param id="pe-5.2_prm_1">
                <label>organization-defined output devices</label>
@@ -29775,8 +29775,8 @@
                   <p>automated mechanisms supporting and/or implementing access control to output devices</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-5.3">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-5.3">
             <title>Marking Output Devices</title>
             <param id="pe-5.3_prm_1">
                <label>organization-defined information system output devices</label>
@@ -29821,7 +29821,7 @@
                   <p>Organizational processes for marking output devices</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-6">
          <title>Monitoring Physical Access</title>
@@ -29907,7 +29907,7 @@
                <p>automated mechanisms supporting and/or implementing reviewing of physical access logs</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-6.1">
+         <control class="SP800-53-enhancement" id="pe-6.1">
             <title>Intrusion Alarms / Surveillance Equipment</title>
             <prop name="label">PE-6(1)</prop>
             <part id="pe-6.1_smt" name="statement">
@@ -29944,8 +29944,8 @@
                   <p>automated mechanisms supporting and/or implementing physical intrusion alarms and surveillance equipment</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-6.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-6.2">
             <title>Automated Intrusion Recognition / Responses</title>
             <param id="pe-6.2_prm_1">
                <label>organization-defined classes/types of intrusions</label>
@@ -30002,8 +30002,8 @@
                   <p>automated mechanisms supporting and/or implementing recognition of classes/types of intrusions and initiation of a response</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-6.3">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-6.3">
             <title>Video Surveillance</title>
             <param id="pe-6.3_prm_1">
                <label>organization-defined operational areas</label>
@@ -30066,8 +30066,8 @@
                   <p>automated mechanisms supporting and/or implementing video surveillance</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-6.4">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-6.4">
             <title>Monitoring Physical Access to Information Systems</title>
             <param id="pe-6.4_prm_1">
                <label>organization-defined physical spaces containing one or more components of the information system</label>
@@ -30119,7 +30119,7 @@
                   <p>automated mechanisms supporting and/or implementing physical access monitoring for facility areas containing information system components</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-7">
          <title>Visitor Control</title>
@@ -30201,7 +30201,7 @@
                <p>automated mechanisms supporting and/or implementing maintenance and review of visitor access records</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-8.1">
+         <control class="SP800-53-enhancement" id="pe-8.1">
             <title>Automated Records Maintenance / Review</title>
             <prop name="label">PE-8(1)</prop>
             <part id="pe-8.1_smt" name="statement">
@@ -30234,13 +30234,13 @@
                   <p>automated mechanisms supporting and/or implementing maintenance and review of visitor access records</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-8.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-8.2">
             <title>Physical Access Records</title>
             <prop name="label">PE-8(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#pe-2">PE-2</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-9">
          <title>Power Equipment and Cabling</title>
@@ -30277,7 +30277,7 @@
                <p>Automated mechanisms supporting and/or implementing protection of power equipment/cabling</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-9.1">
+         <control class="SP800-53-enhancement" id="pe-9.1">
             <title>Redundant Cabling</title>
             <param id="pe-9.1_prm_1">
                <label>organization-defined distance</label>
@@ -30322,8 +30322,8 @@
                   <p>Automated mechanisms supporting and/or implementing protection of power equipment/cabling</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-9.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-9.2">
             <title>Automatic Voltage Controls</title>
             <param id="pe-9.2_prm_1">
                <label>organization-defined critical information system components</label>
@@ -30367,7 +30367,7 @@
                   <p>Automated mechanisms supporting and/or implementing automatic voltage controls</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-10">
          <title>Emergency Shutoff</title>
@@ -30441,12 +30441,12 @@
                <p>Automated mechanisms supporting and/or implementing emergency power shutoff</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-10.1">
+         <control class="SP800-53-enhancement" id="pe-10.1">
             <title>Accidental / Unauthorized Activation</title>
             <prop name="label">PE-10(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#pe-10">PE-10</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-11">
          <title>Emergency Power</title>
@@ -30501,7 +30501,7 @@
                <p>the uninterruptable power supply</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-11.1">
+         <control class="SP800-53-enhancement" id="pe-11.1">
             <title>Long-term Alternate Power Supply - Minimal Operational Capability</title>
             <prop name="label">PE-11(1)</prop>
             <part id="pe-11.1_smt" name="statement">
@@ -30538,8 +30538,8 @@
                   <p>the alternate power supply</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-11.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-11.2">
             <title>Long-term Alternate Power Supply - Self-contained</title>
             <param id="pe-11.2_prm_1">
                <select>
@@ -30617,7 +30617,7 @@
                   <p>the alternate power supply</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-12">
          <title>Emergency Lighting</title>
@@ -30665,7 +30665,7 @@
                <p>Automated mechanisms supporting and/or implementing emergency lighting capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-12.1">
+         <control class="SP800-53-enhancement" id="pe-12.1">
             <title>Essential Missions / Business Functions</title>
             <prop name="label">PE-12(1)</prop>
             <part id="pe-12.1_smt" name="statement">
@@ -30699,7 +30699,7 @@
                   <p>Automated mechanisms supporting and/or implementing emergency lighting capability</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-13">
          <title>Fire Protection</title>
@@ -30745,7 +30745,7 @@
                <p>Automated mechanisms supporting and/or implementing fire suppression/detection devices/systems</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-13.1">
+         <control class="SP800-53-enhancement" id="pe-13.1">
             <title>Detection Devices / Systems</title>
             <param id="pe-13.1_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -30816,8 +30816,8 @@
                   <p>automated notifications</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-13.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-13.2">
             <title>Suppression Devices / Systems</title>
             <param id="pe-13.2_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -30883,8 +30883,8 @@
                   <p>automated notifications</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-13.3">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-13.3">
             <title>Automatic Fire Suppression</title>
             <prop name="label">PE-13(3)</prop>
             <part id="pe-13.3_smt" name="statement">
@@ -30920,8 +30920,8 @@
                   <p>activation of fire suppression devices/systems (simulated)</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-13.4">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-13.4">
             <title>Inspections</title>
             <param id="pe-13.4_prm_1">
                <label>organization-defined frequency</label>
@@ -30973,7 +30973,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-14">
          <title>Temperature and Humidity Controls</title>
@@ -31066,7 +31066,7 @@
                <p>Automated mechanisms supporting and/or implementing maintenance and monitoring of temperature and humidity levels</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-14.1">
+         <control class="SP800-53-enhancement" id="pe-14.1">
             <title>Automatic Controls</title>
             <prop name="label">PE-14(1)</prop>
             <part id="pe-14.1_smt" name="statement">
@@ -31108,8 +31108,8 @@
                   <p>Automated mechanisms supporting and/or implementing temperature and humidity levels</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pe-14.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pe-14.2">
             <title>Monitoring with Alarms / Notifications</title>
             <prop name="label">PE-14(2)</prop>
             <part id="pe-14.2_smt" name="statement">
@@ -31158,7 +31158,7 @@
                   <p>Automated mechanisms supporting and/or implementing temperature and humidity monitoring</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-15">
          <title>Water Damage Protection</title>
@@ -31211,7 +31211,7 @@
                <p>organizational process for activating master water-shutoff</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-15.1">
+         <control class="SP800-53-enhancement" id="pe-15.1">
             <title>Automation Support</title>
             <param id="pe-15.1_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -31263,7 +31263,7 @@
                   <p>Automated mechanisms supporting and/or implementing water detection capability and alerts for the information system</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-16">
          <title>Delivery and Removal</title>
@@ -31484,7 +31484,7 @@
                <p>Organizational processes for positioning information system components</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-18.1">
+         <control class="SP800-53-enhancement" id="pe-18.1">
             <title>Facility Site</title>
             <prop name="label">PE-18(1)</prop>
             <part id="pe-18.1_smt" name="statement">
@@ -31536,7 +31536,7 @@
                   <p>Organizational processes for site planning</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-19">
          <title>Information Leakage</title>
@@ -31575,7 +31575,7 @@
                <p>Automated mechanisms supporting and/or implementing protection from information leakage due to electromagnetic signals emanations</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pe-19.1">
+         <control class="SP800-53-enhancement" id="pe-19.1">
             <title>National Emissions / Tempest Policies and Procedures</title>
             <prop name="label">PE-19(1)</prop>
             <part id="pe-19.1_smt" name="statement">
@@ -31618,7 +31618,7 @@
                   <p>Information system components for compliance with national emissions and TEMPEST policies and procedures</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pe-20">
          <title>Asset Monitoring and Tracking</title>
@@ -32067,19 +32067,19 @@
                <p>automated mechanisms supporting the information system security plan</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pl-2.1">
+         <control class="SP800-53-enhancement" id="pl-2.1">
             <title>Concept of Operations</title>
             <prop name="label">PL-2(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#pl-7">PL-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pl-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pl-2.2">
             <title>Functional Architecture</title>
             <prop name="label">PL-2(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#pl-8">PL-8</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pl-2.3">
+         </control>
+         <control class="SP800-53-enhancement" id="pl-2.3">
             <title>Plan / Coordinate with Other Organizational Entities</title>
             <param id="pl-2.3_prm_1">
                <label>organization-defined individuals or groups</label>
@@ -32125,7 +32125,7 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pl-3">
          <title>System Security Plan Update</title>
@@ -32239,7 +32239,7 @@
                <p>automated mechanisms supporting and/or implementing the establishment, review, dissemination, and update of rules of behavior</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pl-4.1">
+         <control class="SP800-53-enhancement" id="pl-4.1">
             <title>Social Media and Networking Restrictions</title>
             <prop name="label">PL-4(1)</prop>
             <part id="pl-4.1_smt" name="statement">
@@ -32283,7 +32283,7 @@
                   <p>automated mechanisms supporting and/or implementing the establishment of rules of behavior</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pl-5">
          <title>Privacy Impact Assessment</title>
@@ -32482,7 +32482,7 @@
                <p>automated mechanisms supporting and/or implementing the development, review, and update of the information security architecture</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="pl-8.1">
+         <control class="SP800-53-enhancement" id="pl-8.1">
             <title>Defense-in-depth</title>
             <param id="pl-8.1_prm_1">
                <label>organization-defined security safeguards</label>
@@ -32558,8 +32558,8 @@
                   <p>automated mechanisms supporting and/or implementing the design of the information security architecture</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="pl-8.2">
+         </control>
+         <control class="SP800-53-enhancement" id="pl-8.2">
             <title>Supplier Diversity</title>
             <param id="pl-8.2_prm_1">
                <label>organization-defined security safeguards</label>
@@ -32617,7 +32617,7 @@
                   <p>Organizational processes for obtaining information security safeguards from different suppliers</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="pl-9">
          <title>Central Management</title>
@@ -32974,7 +32974,7 @@
                <p>Organizational processes for personnel screening</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ps-3.1">
+         <control class="SP800-53-enhancement" id="ps-3.1">
             <title>Classified Information</title>
             <prop name="label">PS-3(1)</prop>
             <part id="ps-3.1_smt" name="statement">
@@ -33017,8 +33017,8 @@
                   <p>Organizational processes for clearing and indoctrinating personnel for access to classified information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ps-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ps-3.2">
             <title>Formal Indoctrination</title>
             <prop name="label">PS-3(2)</prop>
             <part id="ps-3.2_smt" name="statement">
@@ -33054,8 +33054,8 @@
                   <p>Organizational processes for formal indoctrination for all relevant types of information to which personnel have access</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ps-3.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ps-3.3">
             <title>Information with Special Protection Measures</title>
             <param id="ps-3.3_prm_1">
                <label>organization-defined additional personnel screening criteria</label>
@@ -33120,7 +33120,7 @@
                   <p>organizational process for additional personnel screening for information requiring special protection</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ps-4">
          <title>Personnel Termination</title>
@@ -33253,7 +33253,7 @@
                <p>automated mechanisms for disabling information system access/revoking authenticators</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ps-4.1">
+         <control class="SP800-53-enhancement" id="ps-4.1">
             <title>Post-employment Requirements</title>
             <prop name="label">PS-4(1)</prop>
             <part id="ps-4.1_smt" name="statement">
@@ -33306,8 +33306,8 @@
                   <p>Organizational processes for post-employment requirements</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ps-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ps-4.2">
             <title>Automated Notification</title>
             <param id="ps-4.2_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -33356,7 +33356,7 @@
                   <p>automated mechanisms supporting and/or implementing personnel termination notifications</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ps-5">
          <title>Personnel Transfer</title>
@@ -33578,13 +33578,13 @@
                <p>automated mechanisms supporting access agreements</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ps-6.1">
+         <control class="SP800-53-enhancement" id="ps-6.1">
             <title>Information Requiring Special Protection</title>
             <prop name="label">PS-6(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ps-3">PS-3</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ps-6.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ps-6.2">
             <title>Classified Information Requiring Special Protection</title>
             <prop name="label">PS-6(2)</prop>
             <part id="ps-6.2_smt" name="statement">
@@ -33649,8 +33649,8 @@
                   <p>Organizational processes for access to classified information requiring special protection</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ps-6.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ps-6.3">
             <title>Post-employment Requirements</title>
             <prop name="label">PS-6(3)</prop>
             <part id="ps-6.3_smt" name="statement">
@@ -33706,7 +33706,7 @@
                   <p>automated mechanisms supporting notifications and individual acknowledgements of post-employment requirements</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ps-7">
          <title>Third-party Personnel Security</title>
@@ -34487,7 +34487,7 @@
                <p>automated mechanisms supporting and/or implementing vulnerability scanning, analysis, remediation, and information sharing</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="ra-5.1">
+         <control class="SP800-53-enhancement" id="ra-5.1">
             <title>Update Tool Capability</title>
             <prop name="label">RA-5(1)</prop>
             <part id="ra-5.1_smt" name="statement">
@@ -34527,8 +34527,8 @@
                   <p>automated mechanisms/tools supporting and/or implementing vulnerability scanning</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ra-5.2">
+         </control>
+         <control class="SP800-53-enhancement" id="ra-5.2">
             <title>Update by Frequency / Prior to New Scan / When Identified</title>
             <param id="ra-5.2_prm_1">
                <select how-many="one or more">
@@ -34599,8 +34599,8 @@
                   <p>automated mechanisms/tools supporting and/or implementing vulnerability scanning</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ra-5.3">
+         </control>
+         <control class="SP800-53-enhancement" id="ra-5.3">
             <title>Breadth / Depth of Coverage</title>
             <prop name="label">RA-5(3)</prop>
             <part id="ra-5.3_smt" name="statement">
@@ -34644,8 +34644,8 @@
                   <p>automated mechanisms/tools supporting and/or implementing vulnerability scanning</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ra-5.4">
+         </control>
+         <control class="SP800-53-enhancement" id="ra-5.4">
             <title>Discoverable Information</title>
             <param id="ra-5.4_prm_1">
                <label>organization-defined corrective actions</label>
@@ -34708,8 +34708,8 @@
                   <p>automated mechanisms supporting and/or implementing incident management and response</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ra-5.5">
+         </control>
+         <control class="SP800-53-enhancement" id="ra-5.5">
             <title>Privileged Access</title>
             <param id="ra-5.5_prm_1">
                <label>organization-identified information system components</label>
@@ -34774,8 +34774,8 @@
                   <p>automated mechanisms/tools supporting and/or implementing vulnerability scanning</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ra-5.6">
+         </control>
+         <control class="SP800-53-enhancement" id="ra-5.6">
             <title>Automated Trend Analyses</title>
             <prop name="label">RA-5(6)</prop>
             <part id="ra-5.6_smt" name="statement">
@@ -34816,14 +34816,14 @@
                   <p>automated mechanisms supporting and/or implementing trend analysis of vulnerability scan results</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ra-5.7">
+         </control>
+         <control class="SP800-53-enhancement" id="ra-5.7">
             <title>Automated Detection and Notification of Unauthorized Components</title>
             <prop name="label">RA-5(7)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#cm-8">CM-8</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ra-5.8">
+         </control>
+         <control class="SP800-53-enhancement" id="ra-5.8">
             <title>Review Historic Audit Logs</title>
             <prop name="label">RA-5(8)</prop>
             <part id="ra-5.8_smt" name="statement">
@@ -34866,14 +34866,14 @@
                   <p>automated mechanisms supporting and/or implementing audit record review</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ra-5.9">
+         </control>
+         <control class="SP800-53-enhancement" id="ra-5.9">
             <title>Penetration Testing and Analyses</title>
             <prop name="label">RA-5(9)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ca-8">CA-8</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="ra-5.10">
+         </control>
+         <control class="SP800-53-enhancement" id="ra-5.10">
             <title>Correlate Scanning Information</title>
             <prop name="label">RA-5(10)</prop>
             <part id="ra-5.10_smt" name="statement">
@@ -34913,7 +34913,7 @@
                   <p>automated mechanisms implementing correlation of vulnerability scan results</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="ra-6">
          <title>Technical Surveillance Countermeasures Survey</title>
@@ -35435,7 +35435,7 @@
                <p>automated mechanisms supporting and/or implementing acquisitions and inclusion of security requirements in contracts</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-4.1">
+         <control class="SP800-53-enhancement" id="sa-4.1">
             <title>Functional Properties of Security Controls</title>
             <prop name="label">SA-4(1)</prop>
             <part id="sa-4.1_smt" name="statement">
@@ -35476,8 +35476,8 @@
                   <p>automated mechanisms supporting and/or implementing acquisitions and inclusion of security requirements in contracts</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-4.2">
             <title>Design / Implementation Information for Security Controls</title>
             <param id="sa-4.2_prm_1">
                <select how-many="one or more">
@@ -35570,8 +35570,8 @@
                   <p>automated mechanisms supporting and/or implementing development of system design details</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-4.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-4.3">
             <title>Development Methods / Techniques / Practices</title>
             <param id="sa-4.3_prm_1">
                <label>organization-defined state-of-the-practice system/security engineering methods, software development methods, testing/evaluation/validation techniques, and quality control processes</label>
@@ -35653,14 +35653,14 @@
                   <p>Organizational processes for development methods, techniques, and processes</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-4.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-4.4">
             <title>Assignment of Components to Systems</title>
             <prop name="label">SA-4(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#cm-8.9">CM-8 (9)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-4.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-4.5">
             <title>System / Component / Service Configurations</title>
             <param id="sa-4.5_prm_1">
                <label>organization-defined security configurations</label>
@@ -35729,8 +35729,8 @@
                   <p>Automated mechanisms used to verify that the configuration of the information system, component, or service, as delivered, is as specified</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-4.6">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-4.6">
             <title>Use of Information Assurance Products</title>
             <prop name="label">SA-4(6)</prop>
             <part id="sa-4.6_smt" name="statement">
@@ -35791,8 +35791,8 @@
                   <p>Organizational processes for selecting and employing evaluated and/or validated information assurance products and services that compose an NSA-approved solution to protect classified information</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-4.7">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-4.7">
             <title>Niap-approved Protection Profiles</title>
             <prop name="label">SA-4(7)</prop>
             <part id="sa-4.7_smt" name="statement">
@@ -35851,8 +35851,8 @@
                   <p>Organizational processes for selecting and employing products/services evaluated against a NIAP-approved protection profile or FIPS-validated products</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-4.8">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-4.8">
             <title>Continuous Monitoring Plan</title>
             <param id="sa-4.8_prm_1">
                <label>organization-defined level of detail</label>
@@ -35907,8 +35907,8 @@
                   <p>automated mechanisms supporting and/or implementing developer continuous monitoring</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-4.9">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-4.9">
             <title>Functions / Ports / Protocols / Services in Use</title>
             <prop name="label">SA-4(9)</prop>
             <part id="sa-4.9_smt" name="statement">
@@ -35964,8 +35964,8 @@
                   <p>organizational personnel with information security responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-4.10">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-4.10">
             <title>Use of Approved PIV Products</title>
             <prop name="label">SA-4(10)</prop>
             <part id="sa-4.10_smt" name="statement">
@@ -36005,7 +36005,7 @@
                   <p>Organizational processes for selecting and employing FIPS 201-approved products</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-5">
          <title>Information System Documentation</title>
@@ -36192,36 +36192,36 @@
                <p>Organizational processes for obtaining, protecting, and distributing information system administrator and user documentation</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-5.1">
+         <control class="SP800-53-enhancement" id="sa-5.1">
             <title>Functional Properties of Security Controls</title>
             <prop name="label">SA-5(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sa-4.1">SA-4 (1)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-5.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-5.2">
             <title>Security-relevant External System Interfaces</title>
             <prop name="label">SA-5(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sa-4.2">SA-4 (2)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-5.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-5.3">
             <title>High-level Design</title>
             <prop name="label">SA-5(3)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sa-4.2">SA-4 (2)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-5.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-5.4">
             <title>Low-level Design</title>
             <prop name="label">SA-5(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sa-4.2">SA-4 (2)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-5.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-5.5">
             <title>Source Code</title>
             <prop name="label">SA-5(5)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sa-4.2">SA-4 (2)</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-6">
          <title>Software Usage Restrictions</title>
@@ -36402,7 +36402,7 @@
                <p>automated mechanisms for monitoring security control compliance by external service providers on an ongoing basis</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-9.1">
+         <control class="SP800-53-enhancement" id="sa-9.1">
             <title>Risk Assessments / Organizational Approvals</title>
             <param id="sa-9.1_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -36474,8 +36474,8 @@
                   <p>automated mechanisms supporting and/or implementing approval processes</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-9.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-9.2">
             <title>Identification of Functions / Ports / Protocols / Services</title>
             <param id="sa-9.2_prm_1">
                <label>organization-defined external information system services</label>
@@ -36537,8 +36537,8 @@
                   <p>external providers of information system services</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-9.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-9.3">
             <title>Establish / Maintain Trust Relationship with Providers</title>
             <param id="sa-9.3_prm_1">
                <label>organization-defined security requirements, properties, factors, or conditions defining acceptable trust relationships</label>
@@ -36595,8 +36595,8 @@
                   <p>external providers of information system services</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-9.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-9.4">
             <title>Consistent Interests of Consumers and Providers</title>
             <param id="sa-9.4_prm_1">
                <label>organization-defined security safeguards</label>
@@ -36656,8 +36656,8 @@
                   <p>automated mechanisms supporting and/or implementing safeguards to ensure consistent interests with external service providers</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-9.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-9.5">
             <title>Processing, Storage, and Service Location</title>
             <param id="sa-9.5_prm_1">
                <select how-many="one or more">
@@ -36737,7 +36737,7 @@
                   <p>organizational processes for ensuring the location is restricted in accordance with requirements or conditions</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-10">
          <title>Developer Configuration Management</title>
@@ -36906,7 +36906,7 @@
                <p>automated mechanisms supporting and/or implementing the monitoring of developer configuration management</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-10.1">
+         <control class="SP800-53-enhancement" id="sa-10.1">
             <title>Software / Firmware Integrity Verification</title>
             <prop name="label">SA-10(1)</prop>
             <part id="sa-10.1_smt" name="statement">
@@ -36953,8 +36953,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer configuration management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-10.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-10.2">
             <title>Alternative Configuration Management Processes</title>
             <prop name="label">SA-10(2)</prop>
             <part id="sa-10.2_smt" name="statement">
@@ -36997,8 +36997,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer configuration management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-10.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-10.3">
             <title>Hardware Integrity Verification</title>
             <prop name="label">SA-10(3)</prop>
             <part id="sa-10.3_smt" name="statement">
@@ -37041,8 +37041,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer configuration management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-10.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-10.4">
             <title>Trusted Generation</title>
             <prop name="label">SA-10(4)</prop>
             <part id="sa-10.4_smt" name="statement">
@@ -37094,8 +37094,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer configuration management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-10.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-10.5">
             <title>Mapping Integrity for Version Control</title>
             <prop name="label">SA-10(5)</prop>
             <part id="sa-10.5_smt" name="statement">
@@ -37140,8 +37140,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer configuration management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-10.6">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-10.6">
             <title>Trusted Distribution</title>
             <prop name="label">SA-10(6)</prop>
             <part id="sa-10.6_smt" name="statement">
@@ -37185,7 +37185,7 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer configuration management</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-11">
          <title>Developer Security Testing and Evaluation</title>
@@ -37329,7 +37329,7 @@
                <p>automated mechanisms supporting and/or implementing the monitoring of developer security testing and evaluation</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-11.1">
+         <control class="SP800-53-enhancement" id="sa-11.1">
             <title>Static Code Analysis</title>
             <prop name="label">SA-11(1)</prop>
             <part id="sa-11.1_smt" name="statement">
@@ -37375,8 +37375,8 @@
                   <p>static code analysis tools</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-11.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-11.2">
             <title>Threat and Vulnerability Analyses</title>
             <prop name="label">SA-11(2)</prop>
             <part id="sa-11.2_smt" name="statement">
@@ -37435,8 +37435,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer security testing and evaluation</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-11.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-11.3">
             <title>Independent Verification of Assessment Plans / Evidence</title>
             <param id="sa-11.3_prm_1">
                <label>organization-defined independence criteria</label>
@@ -37528,8 +37528,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer security testing and evaluation</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-11.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-11.4">
             <title>Manual Code Reviews</title>
             <param id="sa-11.4_prm_1">
                <label>organization-defined specific code</label>
@@ -37593,8 +37593,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer security testing and evaluation</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-11.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-11.5">
             <title>Penetration Testing</title>
             <param id="sa-11.5_prm_1">
                <label>organization-defined breadth/depth</label>
@@ -37663,8 +37663,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer security testing and evaluation</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-11.6">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-11.6">
             <title>Attack Surface Reviews</title>
             <prop name="label">SA-11(6)</prop>
             <part id="sa-11.6_smt" name="statement">
@@ -37708,8 +37708,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer security testing and evaluation</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-11.7">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-11.7">
             <title>Verify Scope of Testing / Evaluation</title>
             <param id="sa-11.7_prm_1">
                <label>organization-defined depth of testing/evaluation</label>
@@ -37763,8 +37763,8 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer security testing and evaluation</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-11.8">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-11.8">
             <title>Dynamic Code Analysis</title>
             <prop name="label">SA-11(8)</prop>
             <part id="sa-11.8_smt" name="statement">
@@ -37809,7 +37809,7 @@
                   <p>automated mechanisms supporting and/or implementing the monitoring of developer security testing and evaluation</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-12">
          <title>Supply Chain Protection</title>
@@ -37884,7 +37884,7 @@
                <p>automated mechanisms supporting and/or implementing safeguards for supply chain threats</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.1">
+         <control class="SP800-53-enhancement" id="sa-12.1">
             <title>Acquisition Strategies / Tools / Methods</title>
             <param id="sa-12.1_prm_1">
                <label>organization-defined tailored acquisition strategies, contract tools, and procurement methods</label>
@@ -37952,8 +37952,8 @@
                   <p>automated mechanisms supporting and/or implementing the definition and employment of tailored acquisition strategies, contract tools, and procurement methods</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.2">
             <title>Supplier Reviews</title>
             <prop name="label">SA-12(2)</prop>
             <part id="sa-12.2_smt" name="statement">
@@ -37990,20 +37990,20 @@
                   <p>automated mechanisms supporting and/or implementing supplier reviews</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.3">
             <title>Trusted Shipping and Warehousing</title>
             <prop name="label">SA-12(3)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sa-12.1">SA-12 (1)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.4">
             <title>Diversity of Suppliers</title>
             <prop name="label">SA-12(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sa-12.13">SA-12 (13)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.5">
             <title>Limitation of Harm</title>
             <param id="sa-12.5_prm_1">
                <label>organization-defined security safeguards</label>
@@ -38059,14 +38059,14 @@
                   <p>automated mechanisms supporting and/or implementing the definition and employment of safeguards to protect the organizational supply chain</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.6">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.6">
             <title>Minimizing Procurement Time</title>
             <prop name="label">SA-12(6)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sa-12.1">SA-12 (1)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.7">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.7">
             <title>Assessments Prior to Selection / Acceptance / Update</title>
             <prop name="label">SA-12(7)</prop>
             <part id="sa-12.7_smt" name="statement">
@@ -38120,8 +38120,8 @@
                   <p>automated mechanisms supporting and/or implementing the conducting of assessments prior to selection, acceptance, or update</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.8">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.8">
             <title>Use of All-source Intelligence</title>
             <prop name="label">SA-12(8)</prop>
             <part id="sa-12.8_smt" name="statement">
@@ -38169,8 +38169,8 @@
                   <p>automated mechanisms supporting and/or implementing the use of all-source analysis of suppliers and potential suppliers</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.9">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.9">
             <title>Operations Security</title>
             <param id="sa-12.9_prm_1">
                <label>organization-defined Operations Security (OPSEC) safeguards</label>
@@ -38220,8 +38220,8 @@
                   <p>automated mechanisms supporting and/or implementing the definition and employment of OPSEC safeguards</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.10">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.10">
             <title>Validate as Genuine and Not Altered</title>
             <param id="sa-12.10_prm_1">
                <label>organization-defined security safeguards</label>
@@ -38273,8 +38273,8 @@
                   <p>automated mechanisms supporting and/or implementing the definition and employment of validation safeguards</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.11">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.11">
             <title>Penetration Testing / Analysis of Elements, Processes, and Actors</title>
             <param id="sa-12.11_prm_1">
                <select how-many="one or more">
@@ -38357,8 +38357,8 @@
                   <p>automated mechanisms supporting and/or implementing the analysis/testing of supply chain elements, processes, and actors</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.12">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.12">
             <title>Inter-organizational Agreements</title>
             <prop name="label">SA-12(12)</prop>
             <part id="sa-12.12_smt" name="statement">
@@ -38404,8 +38404,8 @@
                   <p>Organizational processes for establishing inter-organizational agreements and procedures with supply chain entities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.13">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.13">
             <title>Critical Information System Components</title>
             <param id="sa-12.13_prm_1">
                <label>organization-defined security safeguards</label>
@@ -38461,8 +38461,8 @@
                   <p>automated mechanisms supporting and/or implementing the security safeguards that ensure an adequate supply of critical information system components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.14">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.14">
             <title>Identity and Traceability</title>
             <param id="sa-12.14_prm_1">
                <label>organization-defined supply chain elements, processes, and actors</label>
@@ -38523,8 +38523,8 @@
                   <p>automated mechanisms supporting and/or implementing the definition, establishment, and retention of unique identification for supply chain elements, processes, and actors</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-12.15">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-12.15">
             <title>Processes to Address Weaknesses or Deficiencies</title>
             <prop name="label">SA-12(15)</prop>
             <part id="sa-12.15_smt" name="statement">
@@ -38562,7 +38562,7 @@
                   <p>automated mechanisms supporting and/or implementing the addressing of weaknesses or deficiencies in supply chain elements</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-13">
          <title>Trustworthiness</title>
@@ -38706,12 +38706,12 @@
                <p>organizational personnel with responsibilities for performing criticality analysis for the information system</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-14.1">
+         <control class="SP800-53-enhancement" id="sa-14.1">
             <title>Critical Components with No Viable Alternative Sourcing</title>
             <prop name="label">SA-14(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sa-20">SA-20</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-15">
          <title>Development Process, Standards, and Tools</title>
@@ -38850,7 +38850,7 @@
                <p>system developer</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.1">
+         <control class="SP800-53-enhancement" id="sa-15.1">
             <title>Quality Metrics</title>
             <param id="sa-15.1_prm_1">
                <select how-many="one or more">
@@ -38939,8 +38939,8 @@
                   <p>system developer</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-15.2">
             <title>Security Tracking Tools</title>
             <prop name="label">SA-15(2)</prop>
             <part id="sa-15.2_smt" name="statement">
@@ -38975,8 +38975,8 @@
                   <p>system developer</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-15.3">
             <title>Criticality Analysis</title>
             <param id="sa-15.3_prm_1">
                <label>organization-defined breadth/depth</label>
@@ -39044,8 +39044,8 @@
                   <p>automated mechanisms supporting and/or implementing criticality analysis</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-15.4">
             <title>Threat Modeling / Vulnerability Analysis</title>
             <param id="sa-15.4_prm_1">
                <label>organization-defined breadth/depth</label>
@@ -39151,8 +39151,8 @@
                   <p>automated mechanisms supporting and/or implementing development threat modeling and vulnerability analysis</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-15.5">
             <title>Attack Surface Reduction</title>
             <param id="sa-15.5_prm_1">
                <label>organization-defined thresholds</label>
@@ -39208,8 +39208,8 @@
                   <p>Organizational processes for defining attack surface reduction thresholds</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.6">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-15.6">
             <title>Continuous Improvement</title>
             <prop name="label">SA-15(6)</prop>
             <part id="sa-15.6_smt" name="statement">
@@ -39244,8 +39244,8 @@
                   <p>system developer</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.7">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-15.7">
             <title>Automated Vulnerability Analysis</title>
             <param id="sa-15.7_prm_1">
                <label>organization-defined tools</label>
@@ -39346,8 +39346,8 @@
                   <p>automated mechanisms supporting and/or implementing vulnerability analysis of information systems, system components, or information system services under development</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.8">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-15.8">
             <title>Reuse of Threat / Vulnerability Information</title>
             <prop name="label">SA-15(8)</prop>
             <part id="sa-15.8_smt" name="statement">
@@ -39380,8 +39380,8 @@
                   <p>system developer</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.9">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-15.9">
             <title>Use of Live Data</title>
             <prop name="label">SA-15(9)</prop>
             <part id="sa-15.9_smt" name="statement">
@@ -39435,8 +39435,8 @@
                   <p>automated mechanisms supporting and/or implementing the approval, documentation, and control of the use of live data in development and test environments</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.10">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-15.10">
             <title>Incident Response Plan</title>
             <prop name="label">SA-15(10)</prop>
             <part id="sa-15.10_smt" name="statement">
@@ -39473,8 +39473,8 @@
                   <p>system developer</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-15.11">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-15.11">
             <title>Archive Information System / Component</title>
             <prop name="label">SA-15(11)</prop>
             <part id="sa-15.11_smt" name="statement">
@@ -39510,7 +39510,7 @@
                   <p>system developer</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-16">
          <title>Developer-provided Training</title>
@@ -39635,7 +39635,7 @@
                <p>organizational personnel with security architecture and design responsibilities</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-17.1">
+         <control class="SP800-53-enhancement" id="sa-17.1">
             <title>Formal Policy Model</title>
             <param id="sa-17.1_prm_1">
                <label>organization-defined elements of organizational security policy</label>
@@ -39700,8 +39700,8 @@
                   <p>organizational personnel with security architecture and design responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-17.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-17.2">
             <title>Security-relevant Components</title>
             <prop name="label">SA-17(2)</prop>
             <part id="sa-17.2_smt" name="statement">
@@ -39767,8 +39767,8 @@
                   <p>organizational personnel with security architecture and design responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-17.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-17.3">
             <title>Formal Correspondence</title>
             <prop name="label">SA-17(3)</prop>
             <part id="sa-17.3_smt" name="statement">
@@ -39866,8 +39866,8 @@
                   <p>organizational personnel with security architecture and design responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-17.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-17.4">
             <title>Informal Correspondence</title>
             <param id="sa-17.4_prm_1">
                <select>
@@ -39970,8 +39970,8 @@
                   <p>organizational personnel with security architecture and design responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-17.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-17.5">
             <title>Conceptually Simple Design</title>
             <prop name="label">SA-17(5)</prop>
             <part id="sa-17.5_smt" name="statement">
@@ -40027,8 +40027,8 @@
                   <p>organizational personnel with security architecture and design responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-17.6">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-17.6">
             <title>Structure for Testing</title>
             <prop name="label">SA-17(6)</prop>
             <part id="sa-17.6_smt" name="statement">
@@ -40066,8 +40066,8 @@
                   <p>organizational personnel with security architecture and design responsibilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-17.7">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-17.7">
             <title>Structure for Least Privilege</title>
             <prop name="label">SA-17(7)</prop>
             <part id="sa-17.7_smt" name="statement">
@@ -40106,7 +40106,7 @@
                   <p>organizational personnel with security architecture and design responsibilities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-18">
          <title>Tamper Resistance and Detection</title>
@@ -40149,7 +40149,7 @@
                <p>automated mechanisms supporting and/or implementing the tamper protection program</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-18.1">
+         <control class="SP800-53-enhancement" id="sa-18.1">
             <title>Multiple Phases of SDLC</title>
             <prop name="label">SA-18(1)</prop>
             <part id="sa-18.1_smt" name="statement">
@@ -40210,8 +40210,8 @@
                   <p>automated mechanisms supporting and/or implementing anti-tamper technologies</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-18.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-18.2">
             <title>Inspection of Information Systems, Components, or Devices</title>
             <param id="sa-18.2_prm_1">
                <label>organization-defined information systems, system components, or devices</label>
@@ -40293,7 +40293,7 @@
                   <p>automated mechanisms supporting and/or implementing tampering detection</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-19">
          <title>Component Authenticity</title>
@@ -40391,7 +40391,7 @@
                <p>automated mechanisms supporting and/or implementing anti-counterfeit detection, prevention, and reporting</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-19.1">
+         <control class="SP800-53-enhancement" id="sa-19.1">
             <title>Anti-counterfeit Training</title>
             <param id="sa-19.1_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -40438,8 +40438,8 @@
                   <p>Organizational processes for anti-counterfeit training</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-19.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-19.2">
             <title>Configuration Control for Component Service / Repair</title>
             <param id="sa-19.2_prm_1">
                <label>organization-defined information system components</label>
@@ -40496,8 +40496,8 @@
                   <p>automated mechanisms supporting and/or implementing configuration management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-19.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-19.3">
             <title>Component Disposal</title>
             <param id="sa-19.3_prm_1">
                <label>organization-defined techniques and methods</label>
@@ -40548,8 +40548,8 @@
                   <p>automated mechanisms supporting and/or implementing system component disposal</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sa-19.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sa-19.4">
             <title>Anti-counterfeit Scanning</title>
             <param id="sa-19.4_prm_1">
                <label>organization-defined frequency</label>
@@ -40597,7 +40597,7 @@
                   <p>automated mechanisms supporting and/or implementing anti-counterfeit scanning</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-20">
          <title>Customized Development of Critical Components</title>
@@ -40736,7 +40736,7 @@
                <p>automated mechanisms supporting developer screening</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-21.1">
+         <control class="SP800-53-enhancement" id="sa-21.1">
             <title>Validation of Screening</title>
             <param id="sa-21.1_prm_1">
                <label>organization-defined actions</label>
@@ -40789,7 +40789,7 @@
                   <p>automated mechanisms supporting developer screening</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sa-22">
          <title>Unsupported System Components</title>
@@ -40854,7 +40854,7 @@
                <p>automated mechanisms supporting and/or implementing replacement of unsupported system components</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sa-22.1">
+         <control class="SP800-53-enhancement" id="sa-22.1">
             <title>Alternative Sources for Continued Support</title>
             <param id="sa-22.1_prm_1">
                <select how-many="one or more">
@@ -40919,7 +40919,7 @@
                   <p>automated mechanisms providing support for system components no longer supported by original developers, vendors, or manufacturers</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
    </group>
    <group class="family" id="sc">
@@ -41113,7 +41113,7 @@
                <p>Separation of user functionality from information system management functionality</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-2.1">
+         <control class="SP800-53-enhancement" id="sc-2.1">
             <title>Interfaces for Non-privileged Users</title>
             <prop name="label">SC-2(1)</prop>
             <part id="sc-2.1_smt" name="statement">
@@ -41152,7 +41152,7 @@
                   <p>Separation of user functionality from information system management functionality</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-3">
          <title>Security Function Isolation</title>
@@ -41201,7 +41201,7 @@
                <p>Separation of security functions from nonsecurity functions within the information system</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-3.1">
+         <control class="SP800-53-enhancement" id="sc-3.1">
             <title>Hardware Separation</title>
             <prop name="label">SC-3(1)</prop>
             <part id="sc-3.1_smt" name="statement">
@@ -41239,8 +41239,8 @@
                   <p>Separation of security functions from nonsecurity functions within the information system</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-3.2">
             <title>Access / Flow Control Functions</title>
             <prop name="label">SC-3(2)</prop>
             <part id="sc-3.2_smt" name="statement">
@@ -41294,8 +41294,8 @@
                   <p>Isolation of security functions enforcing access and information flow control</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-3.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-3.3">
             <title>Minimize Nonsecurity Functionality</title>
             <prop name="label">SC-3(3)</prop>
             <part id="sc-3.3_smt" name="statement">
@@ -41331,8 +41331,8 @@
                   <p>Automated mechanisms supporting and/or implementing an isolation boundary</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-3.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-3.4">
             <title>Module Coupling and Cohesiveness</title>
             <prop name="label">SC-3(4)</prop>
             <part id="sc-3.4_smt" name="statement">
@@ -41377,8 +41377,8 @@
                   <p>automated mechanisms supporting and/or implementing security functions as independent modules</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-3.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-3.5">
             <title>Layered Structures</title>
             <prop name="label">SC-3(5)</prop>
             <part id="sc-3.5_smt" name="statement">
@@ -41423,7 +41423,7 @@
                   <p>automated mechanisms supporting and/or implementing security functions as a layered structure</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-4">
          <title>Information in Shared Resources</title>
@@ -41465,13 +41465,13 @@
                <p>Automated mechanisms preventing unauthorized and unintended transfer of information via shared system resources</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-4.1">
+         <control class="SP800-53-enhancement" id="sc-4.1">
             <title>Security Levels</title>
             <prop name="label">SC-4(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-4">SC-4</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-4.2">
             <title>Periods Processing</title>
             <param id="sc-4.2_prm_1">
                <label>organization-defined procedures</label>
@@ -41519,7 +41519,7 @@
                   <p>Automated mechanisms preventing unauthorized transfer of information via shared system resources</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-5">
          <title>Denial of Service Protection</title>
@@ -41582,7 +41582,7 @@
                <p>Automated mechanisms protecting against or limiting the effects of denial of service attacks</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-5.1">
+         <control class="SP800-53-enhancement" id="sc-5.1">
             <title>Restrict Internal Users</title>
             <param id="sc-5.1_prm_1">
                <label>organization-defined denial of service attacks</label>
@@ -41633,8 +41633,8 @@
                   <p>Automated mechanisms restricting the ability to launch denial of service attacks against other information systems</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-5.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-5.2">
             <title>Excess Capacity / Bandwidth / Redundancy</title>
             <prop name="label">SC-5(2)</prop>
             <part id="sc-5.2_smt" name="statement">
@@ -41684,8 +41684,8 @@
                   <p>Automated mechanisms implementing management of information system bandwidth, capacity, and redundancy to limit the effects of information flooding denial of service attacks</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-5.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-5.3">
             <title>Detection / Monitoring</title>
             <param id="sc-5.3_prm_1">
                <label>organization-defined monitoring tools</label>
@@ -41763,7 +41763,7 @@
                   <p>Automated mechanisms/tools implementing information system monitoring for denial of service attacks</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-6">
          <title>Resource Availability</title>
@@ -41947,19 +41947,19 @@
                <p>Automated mechanisms implementing boundary protection capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.1">
+         <control class="SP800-53-enhancement" id="sc-7.1">
             <title>Physically Separated Subnetworks</title>
             <prop name="label">SC-7(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-7">SC-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.2">
             <title>Public Access</title>
             <prop name="label">SC-7(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-7">SC-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.3">
             <title>Access Points</title>
             <prop name="label">SC-7(3)</prop>
             <part id="sc-7.3_smt" name="statement">
@@ -42000,8 +42000,8 @@
                   <p>automated mechanisms limiting the number of external network connections to the information system</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.4">
             <title>External Telecommunications Services</title>
             <param id="sc-7.4_prm_1">
                <label>organization-defined frequency</label>
@@ -42114,8 +42114,8 @@
                   <p>managed interfaces implementing traffic flow policy</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.5">
             <title>Deny by Default / Allow by Exception</title>
             <prop name="label">SC-7(5)</prop>
             <part id="sc-7.5_smt" name="statement">
@@ -42161,14 +42161,14 @@
                   <p>Automated mechanisms implementing traffic management at managed interfaces</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.6">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.6">
             <title>Response to Recognized Failures</title>
             <prop name="label">SC-7(6)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-7.18">SC-7 (18)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.7">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.7">
             <title>Prevent Split Tunneling for Remote Devices</title>
             <prop name="label">SC-7(7)</prop>
             <part id="sc-7.7_smt" name="statement">
@@ -42209,8 +42209,8 @@
                   <p>automated mechanisms supporting/restricting non-remote connections</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.8">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.8">
             <title>Route Traffic to Authenticated Proxy Servers</title>
             <param id="sc-7.8_prm_1">
                <label>organization-defined internal communications traffic</label>
@@ -42270,8 +42270,8 @@
                   <p>Automated mechanisms implementing traffic management through authenticated proxy servers at managed interfaces</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.9">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.9">
             <title>Restrict Threatening Outgoing Communications Traffic</title>
             <prop name="label">SC-7(9)</prop>
             <part id="sc-7.9_smt" name="statement">
@@ -42344,8 +42344,8 @@
                   <p>automated mechanisms implementing auditing of outgoing communications traffic</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.10">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.10">
             <title>Prevent Unauthorized Exfiltration</title>
             <prop name="label">SC-7(10)</prop>
             <part id="sc-7.10_smt" name="statement">
@@ -42384,8 +42384,8 @@
                   <p>preventing unauthorized exfiltration of information across managed interfaces</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.11">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.11">
             <title>Restrict Incoming Communications Traffic</title>
             <param id="sc-7.11_prm_1">
                <label>organization-defined authorized sources</label>
@@ -42442,8 +42442,8 @@
                   <p>Automated mechanisms implementing boundary protection capabilities with respect to source/destination address pairs</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.12">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.12">
             <title>Host-based Protection</title>
             <param id="sc-7.12_prm_1">
                <label>organization-defined host-based boundary protection mechanisms</label>
@@ -42500,8 +42500,8 @@
                   <p>Automated mechanisms implementing host-based boundary protection capabilities</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.13">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.13">
             <title>Isolation of Security Tools / Mechanisms / Support Components</title>
             <param id="sc-7.13_prm_1">
                <label>organization-defined information security tools, mechanisms, and support components</label>
@@ -42555,8 +42555,8 @@
                   <p>Automated mechanisms supporting and/or implementing isolation of information security tools, mechanisms, and support components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.14">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.14">
             <title>Protects Against Unauthorized Physical Connections</title>
             <param id="sc-7.14_prm_1">
                <label>organization-defined managed interfaces</label>
@@ -42608,8 +42608,8 @@
                   <p>Automated mechanisms supporting and/or implementing protection against unauthorized physical connections</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.15">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.15">
             <title>Route Privileged Network Accesses</title>
             <prop name="label">SC-7(15)</prop>
             <part id="sc-7.15_smt" name="statement">
@@ -42660,8 +42660,8 @@
                   <p>Automated mechanisms supporting and/or implementing the routing of networked, privileged access through dedicated managed interfaces</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.16">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.16">
             <title>Prevent Discovery of Components / Devices</title>
             <prop name="label">SC-7(16)</prop>
             <part id="sc-7.16_smt" name="statement">
@@ -42701,8 +42701,8 @@
                   <p>Automated mechanisms supporting and/or implementing the prevention of discovery of system components at managed interfaces</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.17">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.17">
             <title>Automated Enforcement of Protocol Formats</title>
             <prop name="label">SC-7(17)</prop>
             <part id="sc-7.17_smt" name="statement">
@@ -42742,8 +42742,8 @@
                   <p>Automated mechanisms supporting and/or implementing enforcement of adherence to protocol formats</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.18">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.18">
             <title>Fail Secure</title>
             <prop name="label">SC-7(18)</prop>
             <part id="sc-7.18_smt" name="statement">
@@ -42784,8 +42784,8 @@
                   <p>Automated mechanisms supporting and/or implementing secure failure</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.19">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.19">
             <title>Blocks Communication from Non-organizationally Configured Hosts</title>
             <param id="sc-7.19_prm_1">
                <label>organization-defined communication clients</label>
@@ -42844,8 +42844,8 @@
                   <p>Automated mechanisms supporting and/or implementing the blocking of inbound and outbound communications traffic between communication clients independently configured by end users and external service providers</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.20">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.20">
             <title>Dynamic Isolation / Segregation</title>
             <param id="sc-7.20_prm_1">
                <label>organization-defined information system components</label>
@@ -42897,8 +42897,8 @@
                   <p>Automated mechanisms supporting and/or implementing the capability to dynamically isolate/segregate information system components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.21">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.21">
             <title>Isolation of Information System Components</title>
             <param id="sc-7.21_prm_1">
                <label>organization-defined information system components</label>
@@ -42958,8 +42958,8 @@
                   <p>Automated mechanisms supporting and/or implementing the capability to separate information system components supporting organizational missions and/or business functions</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.22">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.22">
             <title>Separate Subnets for Connecting to Different Security Domains</title>
             <prop name="label">SC-7(22)</prop>
             <part id="sc-7.22_smt" name="statement">
@@ -42999,8 +42999,8 @@
                   <p>Automated mechanisms supporting and/or implementing separate network addresses/different subnets</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-7.23">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-7.23">
             <title>Disable Sender Feedback On Protocol Validation Failure</title>
             <prop name="label">SC-7(23)</prop>
             <part id="sc-7.23_smt" name="statement">
@@ -43040,7 +43040,7 @@
                   <p>Automated mechanisms supporting and/or implementing the disabling of feedback to senders on protocol format validation failure</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-8">
          <title>Transmission Confidentiality and Integrity</title>
@@ -43103,7 +43103,7 @@
                <p>Automated mechanisms supporting and/or implementing transmission confidentiality and/or integrity</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-8.1">
+         <control class="SP800-53-enhancement" id="sc-8.1">
             <title>Cryptographic or Alternate Physical Protection</title>
             <param id="sc-8.1_prm_1">
                <select how-many="one or more">
@@ -43168,8 +43168,8 @@
                   <p>organizational processes for defining and implementing alternative physical safeguards</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-8.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-8.2">
             <title>Pre / Post Transmission Handling</title>
             <param id="sc-8.2_prm_1">
                <select how-many="one or more">
@@ -43229,8 +43229,8 @@
                   <p>Automated mechanisms supporting and/or implementing transmission confidentiality and/or integrity</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-8.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-8.3">
             <title>Cryptographic Protection for Message Externals</title>
             <param id="sc-8.3_prm_1">
                <label>organization-defined alternative physical safeguards</label>
@@ -43282,8 +43282,8 @@
                   <p>organizational processes for defining and implementing alternative physical safeguards</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-8.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-8.4">
             <title>Conceal / Randomize Communications</title>
             <param id="sc-8.4_prm_1">
                <label>organization-defined alternative physical safeguards</label>
@@ -43343,7 +43343,7 @@
                   <p>organizational processes for defining and implementing alternative physical safeguards</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-9">
          <title>Transmission Confidentiality</title>
@@ -43457,7 +43457,7 @@
                <p>Automated mechanisms supporting and/or implementing trusted communications paths</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-11.1">
+         <control class="SP800-53-enhancement" id="sc-11.1">
             <title>Logical Isolation</title>
             <prop name="label">SC-11(1)</prop>
             <part id="sc-11.1_smt" name="statement">
@@ -43501,7 +43501,7 @@
                   <p>Automated mechanisms supporting and/or implementing trusted communications paths</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-12">
          <title>Cryptographic Key Establishment and Management</title>
@@ -43576,7 +43576,7 @@
                <p>Automated mechanisms supporting and/or implementing cryptographic key establishment and management</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-12.1">
+         <control class="SP800-53-enhancement" id="sc-12.1">
             <title>Availability</title>
             <prop name="label">SC-12(1)</prop>
             <part id="sc-12.1_smt" name="statement">
@@ -43613,8 +43613,8 @@
                   <p>Automated mechanisms supporting and/or implementing cryptographic key establishment and management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-12.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-12.2">
             <title>Symmetric Keys</title>
             <param id="sc-12.2_prm_1">
                <select>
@@ -43665,8 +43665,8 @@
                   <p>Automated mechanisms supporting and/or implementing symmetric cryptographic key establishment and management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-12.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-12.3">
             <title>Asymmetric Keys</title>
             <param id="sc-12.3_prm_1">
                <select>
@@ -43723,19 +43723,19 @@
                   <p>Automated mechanisms supporting and/or implementing asymmetric cryptographic key establishment and management</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-12.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-12.4">
             <title>PKI Certificates</title>
             <prop name="label">SC-12(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-12">SC-12</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-12.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-12.5">
             <title>PKI Certificates / Hardware Tokens</title>
             <prop name="label">SC-12(5)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-12">SC-12</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-13">
          <title>Cryptographic Protection</title>
@@ -43815,30 +43815,30 @@
                <p>Automated mechanisms supporting and/or implementing cryptographic protection</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-13.1">
+         <control class="SP800-53-enhancement" id="sc-13.1">
             <title>Fips-validated Cryptography</title>
             <prop name="label">SC-13(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-13">SC-13</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-13.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-13.2">
             <title>Nsa-approved Cryptography</title>
             <prop name="label">SC-13(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-13">SC-13</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-13.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-13.3">
             <title>Individuals Without Formal Access Approvals</title>
             <prop name="label">SC-13(3)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-13">SC-13</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-13.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-13.4">
             <title>Digital Signatures</title>
             <prop name="label">SC-13(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-13">SC-13</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-14">
          <title>Public Access Protections</title>
@@ -43921,7 +43921,7 @@
                <p>automated mechanisms providing an indication of use of collaborative computing devices</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-15.1">
+         <control class="SP800-53-enhancement" id="sc-15.1">
             <title>Physical Disconnect</title>
             <prop name="label">SC-15(1)</prop>
             <part id="sc-15.1_smt" name="statement">
@@ -43960,14 +43960,14 @@
                   <p>Automated mechanisms supporting and/or implementing physical disconnect of collaborative computing devices</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-15.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-15.2">
             <title>Blocking Inbound / Outbound Communications Traffic</title>
             <prop name="label">SC-15(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-7">SC-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-15.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-15.3">
             <title>Disabling / Removal in Secure Work Areas</title>
             <param id="sc-15.3_prm_1">
                <label>organization-defined information systems or information system components</label>
@@ -44025,8 +44025,8 @@
                   <p>Automated mechanisms supporting and/or implementing the capability to disable collaborative computing devices</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-15.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-15.4">
             <title>Explicitly Indicate Current Participants</title>
             <param id="sc-15.4_prm_1">
                <label>organization-defined online meetings and teleconferences</label>
@@ -44076,7 +44076,7 @@
                   <p>Automated mechanisms supporting and/or implementing the capability to indicate participants on collaborative computing devices</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-16">
          <title>Transmission of Security Attributes</title>
@@ -44145,7 +44145,7 @@
                <p>Automated mechanisms supporting and/or implementing transmission of security attributes between information systems</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-16.1">
+         <control class="SP800-53-enhancement" id="sc-16.1">
             <title>Integrity Validation</title>
             <prop name="label">SC-16(1)</prop>
             <part id="sc-16.1_smt" name="statement">
@@ -44184,7 +44184,7 @@
                   <p>Automated mechanisms supporting and/or implementing validation of the integrity of transmitted security attributes</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-17">
          <title>Public Key Infrastructure Certificates</title>
@@ -44338,7 +44338,7 @@
                <p>automated mechanisms supporting and/or implementing the monitoring of mobile code</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-18.1">
+         <control class="SP800-53-enhancement" id="sc-18.1">
             <title>Identify Unacceptable Code / Take Corrective Actions</title>
             <param id="sc-18.1_prm_1">
                <label>organization-defined unacceptable mobile code</label>
@@ -44406,8 +44406,8 @@
                   <p>Automated mechanisms supporting and/or implementing mobile code detection, inspection, and corrective capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-18.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-18.2">
             <title>Acquisition / Development / Use</title>
             <param id="sc-18.2_prm_1">
                <label>organization-defined mobile code requirements</label>
@@ -44467,8 +44467,8 @@
                   <p>Organizational processes for the acquisition, development, and use of mobile code</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-18.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-18.3">
             <title>Prevent Downloading / Execution</title>
             <param id="sc-18.3_prm_1">
                <label>organization-defined unacceptable mobile code</label>
@@ -44523,8 +44523,8 @@
                   <p>Automated mechanisms preventing download and execution of unacceptable mobile code</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-18.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-18.4">
             <title>Prevent Automatic Execution</title>
             <param id="sc-18.4_prm_1">
                <label>organization-defined software applications</label>
@@ -44588,8 +44588,8 @@
                   <p>automated mechanisms enforcing actions to be taken prior to the execution of the mobile code</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-18.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-18.5">
             <title>Allow Execution Only in Confined Environments</title>
             <prop name="label">SC-18(5)</prop>
             <part id="sc-18.5_smt" name="statement">
@@ -44627,7 +44627,7 @@
                   <p>Automated mechanisms allowing execution of permitted mobile code in confined virtual machine environments</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-19">
          <title>Voice Over Internet Protocol</title>
@@ -44776,13 +44776,13 @@
                <p>Automated mechanisms supporting and/or implementing secure name/address resolution service</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-20.1">
+         <control class="SP800-53-enhancement" id="sc-20.1">
             <title>Child Subspaces</title>
             <prop name="label">SC-20(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-20">SC-20</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-20.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-20.2">
             <title>Data Origin / Integrity</title>
             <prop name="label">SC-20(2)</prop>
             <part id="sc-20.2_smt" name="statement">
@@ -44816,7 +44816,7 @@
                   <p>Automated mechanisms supporting and/or implementing data origin and integrity protection for internal name/address resolution service queries</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-21">
          <title>Secure Name / Address Resolution Service (recursive or Caching Resolver)</title>
@@ -44874,12 +44874,12 @@
                <p>Automated mechanisms supporting and/or implementing data origin authentication and data integrity verification for name/address resolution services</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-21.1">
+         <control class="SP800-53-enhancement" id="sc-21.1">
             <title>Data Origin / Integrity</title>
             <prop name="label">SC-21(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-21">SC-21</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-22">
          <title>Architecture and Provisioning for Name / Address Resolution Service</title>
@@ -44976,7 +44976,7 @@
                <p>Automated mechanisms supporting and/or implementing session authenticity</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-23.1">
+         <control class="SP800-53-enhancement" id="sc-23.1">
             <title>Invalidate Session Identifiers at Logout</title>
             <prop name="label">SC-23(1)</prop>
             <part id="sc-23.1_smt" name="statement">
@@ -45012,14 +45012,14 @@
                   <p>Automated mechanisms supporting and/or implementing session identifier invalidation upon session termination</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-23.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-23.2">
             <title>User-initiated Logouts / Message Displays</title>
             <prop name="label">SC-23(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ac-12.1">AC-12 (1)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-23.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-23.3">
             <title>Unique Session Identifiers with Randomization</title>
             <param id="sc-23.3_prm_1">
                <label>organization-defined randomness requirements</label>
@@ -45072,14 +45072,14 @@
                   <p>automated mechanisms supporting and/or implementing randomness requirements</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-23.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-23.4">
             <title>Unique Session Identifiers with Randomization</title>
             <prop name="label">SC-23(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-23.3">SC-23 (3)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-23.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-23.5">
             <title>Allowed Certificate Authorities</title>
             <param id="sc-23.5_prm_1">
                <label>organization-defined certificate authorities</label>
@@ -45128,7 +45128,7 @@
                   <p>Automated mechanisms supporting and/or implementing management of certificate authorities</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-24">
          <title>Fail in Known State</title>
@@ -45295,12 +45295,12 @@
                <p>Automated mechanisms supporting and/or implementing honey pots</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-26.1">
+         <control class="SP800-53-enhancement" id="sc-26.1">
             <title>Detection of Malicious Code</title>
             <prop name="label">SC-26(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-35">SC-35</link>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-27">
          <title>Platform-independent Applications</title>
@@ -45438,7 +45438,7 @@
                <p>Automated mechanisms supporting and/or implementing confidentiality and integrity protections for information at rest</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-28.1">
+         <control class="SP800-53-enhancement" id="sc-28.1">
             <title>Cryptographic Protection</title>
             <param id="sc-28.1_prm_1">
                <label>organization-defined information</label>
@@ -45496,8 +45496,8 @@
                   <p>Cryptographic mechanisms implementing confidentiality and integrity protections for information at rest</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-28.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-28.2">
             <title>Off-line Storage</title>
             <param id="sc-28.2_prm_1">
                <label>organization-defined information</label>
@@ -45551,7 +45551,7 @@
                   <p>automated mechanisms supporting and/or implementing storage of information off-line</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-29">
          <title>Heterogeneity</title>
@@ -45605,7 +45605,7 @@
                <p>Automated mechanisms supporting and/or implementing employment of a diverse set of information technologies</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-29.1">
+         <control class="SP800-53-enhancement" id="sc-29.1">
             <title>Virtualization Techniques</title>
             <param id="sc-29.1_prm_1">
                <label>organization-defined frequency</label>
@@ -45658,7 +45658,7 @@
                   <p>automated mechanisms supporting and/or implementing virtualization techniques</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-30">
          <title>Concealment and Misdirection</title>
@@ -45727,13 +45727,13 @@
                <p>Automated mechanisms supporting and/or implementing concealment and misdirection techniques</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-30.1">
+         <control class="SP800-53-enhancement" id="sc-30.1">
             <title>Virtualization Techniques</title>
             <prop name="label">SC-30(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sc-29.1">SC-29 (1)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-30.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-30.2">
             <title>Randomness</title>
             <param id="sc-30.2_prm_1">
                <label>organization-defined techniques</label>
@@ -45783,8 +45783,8 @@
                   <p>Automated mechanisms supporting and/or implementing randomness as a concealment and misdirection technique</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-30.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-30.3">
             <title>Change Processing / Storage Locations</title>
             <param id="sc-30.3_prm_1">
                <label>organization-defined processing and/or storage</label>
@@ -45855,8 +45855,8 @@
                   <p>Automated mechanisms supporting and/or implementing changing processing and/or storage locations</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-30.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-30.4">
             <title>Misleading Information</title>
             <param id="sc-30.4_prm_1">
                <label>organization-defined information system components</label>
@@ -45905,8 +45905,8 @@
                   <p>Automated mechanisms supporting and/or implementing employment of realistic, but misleading information about the security posture of information system components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-30.5">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-30.5">
             <title>Concealment of System Components</title>
             <param id="sc-30.5_prm_1">
                <label>organization-defined techniques</label>
@@ -45963,7 +45963,7 @@
                   <p>Automated mechanisms supporting and/or implementing techniques for concealment of system components</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-31">
          <title>Covert Channel Analysis</title>
@@ -46039,7 +46039,7 @@
                <p>automated mechanisms supporting and/or implementing the capability to estimate the bandwidth of covert channels</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-31.1">
+         <control class="SP800-53-enhancement" id="sc-31.1">
             <title>Test Covert Channels for Exploitability</title>
             <prop name="label">SC-31(1)</prop>
             <part id="sc-31.1_smt" name="statement">
@@ -46076,8 +46076,8 @@
                   <p>automated mechanisms supporting and/or implementing testing of covert channels analysis</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-31.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-31.2">
             <title>Maximum Bandwidth</title>
             <param id="sc-31.2_prm_1">
                <select how-many="one or more">
@@ -46145,8 +46145,8 @@
                   <p>automated mechanisms supporting and/or implementing the capability to reduce the bandwidth of covert channels</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-31.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-31.3">
             <title>Measure Bandwidth in Operational Environments</title>
             <param id="sc-31.3_prm_1">
                <label>organization-defined subset of identified covert channels</label>
@@ -46198,7 +46198,7 @@
                   <p>automated mechanisms supporting and/or implementing the capability to measure the bandwidth of covert channels</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-32">
          <title>Information System Partitioning</title>
@@ -46353,7 +46353,7 @@
                <p>automated mechanisms supporting and/or implementing loading and executing applications from hardware-enforced, read-only media</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-34.1">
+         <control class="SP800-53-enhancement" id="sc-34.1">
             <title>No Writable Storage</title>
             <param id="sc-34.1_prm_1">
                <label>organization-defined information system components</label>
@@ -46407,8 +46407,8 @@
                   <p>automated mechanisms supporting and/or implementing persistent non-writeable storage across component restart and power on/off</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-34.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-34.2">
             <title>Integrity Protection / Read-only Media</title>
             <prop name="label">SC-34(2)</prop>
             <part id="sc-34.2_smt" name="statement">
@@ -46465,8 +46465,8 @@
                   <p>Automated mechanisms supporting and/or implementing capability for protecting information integrity on read-only media prior to storage and after information has been recorded onto the media</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-34.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-34.3">
             <title>Hardware-based Protection</title>
             <param id="sc-34.3_prm_1">
                <label>organization-defined information system firmware components</label>
@@ -46541,7 +46541,7 @@
                   <p>automated mechanisms supporting and/or implementing hardware-based, write-protection for firmware</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-35">
          <title>Honeyclients</title>
@@ -46646,7 +46646,7 @@
                <p>automated mechanisms supporting and/or implementing capability for distributing processing and storage across multiple physical locations</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-36.1">
+         <control class="SP800-53-enhancement" id="sc-36.1">
             <title>Polling Techniques</title>
             <param id="sc-36.1_prm_1">
                <label>organization-defined distributed processing and storage components</label>
@@ -46698,7 +46698,7 @@
                   <p>Automated mechanisms supporting and/or implementing polling techniques</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-37">
          <title>Out-of-band Channels</title>
@@ -46783,7 +46783,7 @@
                <p>automated mechanisms supporting and/or implementing use of out-of-band channels</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-37.1">
+         <control class="SP800-53-enhancement" id="sc-37.1">
             <title>Ensure Delivery / Transmission</title>
             <param id="sc-37.1_prm_1">
                <label>organization-defined security safeguards</label>
@@ -46855,7 +46855,7 @@
                   <p>automated mechanisms supporting/implementing safeguards to ensure delivery of designated information, system components, or devices</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-38">
          <title>Operations Security</title>
@@ -46957,7 +46957,7 @@
                <p>Automated mechanisms supporting and/or implementing separate execution domains for each executing process</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-39.1">
+         <control class="SP800-53-enhancement" id="sc-39.1">
             <title>Hardware Separation</title>
             <prop name="label">SC-39(1)</prop>
             <part id="sc-39.1_smt" name="statement">
@@ -46998,8 +46998,8 @@
                   <p>Information system capability implementing underlying hardware separation mechanisms for process separation</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-39.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-39.2">
             <title>Thread Isolation</title>
             <param id="sc-39.2_prm_1">
                <label>organization-defined multi-threaded processing</label>
@@ -47049,7 +47049,7 @@
                   <p>Information system capability implementing a separate execution domain for each thread in multi-threaded processing</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-40">
          <title>Wireless Link Protection</title>
@@ -47123,7 +47123,7 @@
                <p>Automated mechanisms supporting and/or implementing protection of wireless links</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-40.1">
+         <control class="SP800-53-enhancement" id="sc-40.1">
             <title>Electromagnetic Interference</title>
             <param id="sc-40.1_prm_1">
                <label>organization-defined level of protection</label>
@@ -47180,8 +47180,8 @@
                   <p>Cryptographic mechanisms enforcing protections against effects of intentional electromagnetic interference</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-40.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-40.2">
             <title>Reduce Detection Potential</title>
             <param id="sc-40.2_prm_1">
                <label>organization-defined level of reduction</label>
@@ -47238,8 +47238,8 @@
                   <p>Cryptographic mechanisms enforcing protections to reduce detection of wireless links</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-40.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-40.3">
             <title>Imitative or Manipulative Communications Deception</title>
             <prop name="label">SC-40(3)</prop>
             <part id="sc-40.3_smt" name="statement">
@@ -47291,8 +47291,8 @@
                   <p>Cryptographic mechanisms enforcing wireless link protections against imitative or manipulative communications deception</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-40.4">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-40.4">
             <title>Signal Parameter Identification</title>
             <param id="sc-40.4_prm_1">
                <label>organization-defined wireless transmitters</label>
@@ -47347,7 +47347,7 @@
                   <p>Cryptographic mechanisms preventing the identification of wireless transmitters</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-41">
          <title>Port and I/O Device Access</title>
@@ -47484,7 +47484,7 @@
                <p>automated mechanisms implementing capability to indicate sensor use</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="sc-42.1">
+         <control class="SP800-53-enhancement" id="sc-42.1">
             <title>Reporting to Authorized Individuals or Roles</title>
             <param id="sc-42.1_prm_1">
                <label>organization-defined sensors</label>
@@ -47537,8 +47537,8 @@
                   <p>sensor data collection and reporting capability for the information system</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-42.2">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-42.2">
             <title>Authorized Use</title>
             <param id="sc-42.2_prm_1">
                <label>organization-defined measures</label>
@@ -47598,8 +47598,8 @@
                   <p>sensor information collection capability for the information system</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="sc-42.3">
+         </control>
+         <control class="SP800-53-enhancement" id="sc-42.3">
             <title>Prohibit Use of Devices</title>
             <param id="sc-42.3_prm_1">
                <label>organization-defined environmental sensing capabilities</label>
@@ -47653,7 +47653,7 @@
                   <p>organizational personnel with responsibility for sensor capability</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="sc-43">
          <title>Usage Restrictions</title>
@@ -48073,7 +48073,7 @@
                <p>automated mechanisms supporting and/or implementing testing software and firmware updates</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="si-2.1">
+         <control class="SP800-53-enhancement" id="si-2.1">
             <title>Central Management</title>
             <prop name="label">SI-2(1)</prop>
             <part id="si-2.1_smt" name="statement">
@@ -48113,8 +48113,8 @@
                   <p>automated mechanisms supporting and/or implementing central management of the flaw remediation process</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-2.2">
+         </control>
+         <control class="SP800-53-enhancement" id="si-2.2">
             <title>Automated Flaw Remediation Status</title>
             <param id="si-2.2_prm_1">
                <label>organization-defined frequency</label>
@@ -48165,8 +48165,8 @@
                   <p>Automated mechanisms used to determine the state of information system components with regard to flaw remediation</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-2.3">
+         </control>
+         <control class="SP800-53-enhancement" id="si-2.3">
             <title>Time to Remediate Flaws / Benchmarks for Corrective Actions</title>
             <param id="si-2.3_prm_1">
                <label>organization-defined benchmarks</label>
@@ -48234,14 +48234,14 @@
                   <p>automated mechanisms used to measure the time between flaw identification and flaw remediation</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-2.4">
+         </control>
+         <control class="SP800-53-enhancement" id="si-2.4">
             <title>Automated Patch Management Tools</title>
             <prop name="label">SI-2(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-2">SI-2</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-2.5">
+         </control>
+         <control class="SP800-53-enhancement" id="si-2.5">
             <title>Automatic Software / Firmware Updates</title>
             <param id="si-2.5_prm_1">
                <label>organization-defined security-relevant software and firmware updates</label>
@@ -48320,8 +48320,8 @@
                   <p>Automated mechanisms implementing automatic software/firmware updates</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-2.6">
+         </control>
+         <control class="SP800-53-enhancement" id="si-2.6">
             <title>Removal of Previous Versions of Software / Firmware</title>
             <param id="si-2.6_prm_1">
                <label>organization-defined software and firmware components</label>
@@ -48386,7 +48386,7 @@
                   <p>Automated mechanisms supporting and/or implementing removal of previous versions of software/firmware</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="si-3">
          <title>Malicious Code Protection</title>
@@ -48565,7 +48565,7 @@
                <p>automated mechanisms supporting and/or implementing malicious code scanning and subsequent actions</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="si-3.1">
+         <control class="SP800-53-enhancement" id="si-3.1">
             <title>Central Management</title>
             <prop name="label">SI-3(1)</prop>
             <part id="si-3.1_smt" name="statement">
@@ -48607,8 +48607,8 @@
                   <p>automated mechanisms supporting and/or implementing central management of malicious code protection mechanisms</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-3.2">
+         </control>
+         <control class="SP800-53-enhancement" id="si-3.2">
             <title>Automatic Updates</title>
             <prop name="label">SI-3(2)</prop>
             <part id="si-3.2_smt" name="statement">
@@ -48649,14 +48649,14 @@
                   <p>Automated mechanisms supporting and/or implementing automatic updates to malicious code protection capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-3.3">
+         </control>
+         <control class="SP800-53-enhancement" id="si-3.3">
             <title>Non-privileged Users</title>
             <prop name="label">SI-3(3)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ac-6.10">AC-6 (10)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-3.4">
+         </control>
+         <control class="SP800-53-enhancement" id="si-3.4">
             <title>Updates Only by Privileged Users</title>
             <prop name="label">SI-3(4)</prop>
             <part id="si-3.4_smt" name="statement">
@@ -48699,14 +48699,14 @@
                   <p>Automated mechanisms supporting and/or implementing malicious code protection capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-3.5">
+         </control>
+         <control class="SP800-53-enhancement" id="si-3.5">
             <title>Portable Storage Devices</title>
             <prop name="label">SI-3(5)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#mp-7">MP-7</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-3.6">
+         </control>
+         <control class="SP800-53-enhancement" id="si-3.6">
             <title>Testing / Verification</title>
             <param id="si-3.6_prm_1">
                <label>organization-defined frequency</label>
@@ -48783,8 +48783,8 @@
                   <p>Automated mechanisms supporting and/or implementing testing and verification of malicious code protection capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-3.7">
+         </control>
+         <control class="SP800-53-enhancement" id="si-3.7">
             <title>Nonsignature-based Detection</title>
             <prop name="label">SI-3(7)</prop>
             <part id="si-3.7_smt" name="statement">
@@ -48825,8 +48825,8 @@
                   <p>Automated mechanisms supporting and/or implementing nonsignature-based malicious code protection capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-3.8">
+         </control>
+         <control class="SP800-53-enhancement" id="si-3.8">
             <title>Detect Unauthorized Commands</title>
             <param id="si-3.8_prm_1">
                <label>organization-defined unauthorized operating system commands</label>
@@ -48906,8 +48906,8 @@
                   <p>automated mechanisms supporting and/or implementing detection of unauthorized operating system commands through the kernel application programming interface</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-3.9">
+         </control>
+         <control class="SP800-53-enhancement" id="si-3.9">
             <title>Authenticate Remote Commands</title>
             <param id="si-3.9_prm_1">
                <label>organization-defined security safeguards</label>
@@ -48971,8 +48971,8 @@
                   <p>automated mechanisms supporting and/or implementing security safeguards to authenticate remote commands</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-3.10">
+         </control>
+         <control class="SP800-53-enhancement" id="si-3.10">
             <title>Malicious Code Analysis</title>
             <param id="si-3.10_prm_1">
                <label>organization-defined tools and techniques</label>
@@ -49048,7 +49048,7 @@
                   <p>tools and techniques for analysis of malicious code characteristics and behavior</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="si-4">
          <title>Information System Monitoring</title>
@@ -49292,7 +49292,7 @@
                <p>automated mechanisms supporting and/or implementing information system monitoring capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="si-4.1">
+         <control class="SP800-53-enhancement" id="si-4.1">
             <title>System-wide Intrusion Detection System</title>
             <prop name="label">SI-4(1)</prop>
             <part id="si-4.1_smt" name="statement">
@@ -49338,8 +49338,8 @@
                   <p>automated mechanisms supporting and/or implementing intrusion detection capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.2">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.2">
             <title>Automated Tools for Real-time Analysis</title>
             <prop name="label">SI-4(2)</prop>
             <part id="si-4.2_smt" name="statement">
@@ -49382,8 +49382,8 @@
                   <p>automated mechanisms/tools supporting and/or implementing analysis of events</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.3">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.3">
             <title>Automated Tool Integration</title>
             <prop name="label">SI-4(3)</prop>
             <part id="si-4.3_smt" name="statement">
@@ -49432,8 +49432,8 @@
                   <p>automated mechanisms/tools supporting and/or implementing integration of intrusion detection tools into access/flow control mechanisms</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.4">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.4">
             <title>Inbound and Outbound Communications Traffic</title>
             <param id="si-4.4_prm_1">
                <label>organization-defined frequency</label>
@@ -49503,8 +49503,8 @@
                   <p>automated mechanisms supporting and/or implementing monitoring of inbound/outbound communications traffic</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.5">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.5">
             <title>System-generated Alerts</title>
             <param id="si-4.5_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -49567,14 +49567,14 @@
                   <p>automated mechanisms supporting and/or implementing alerts for compromise indicators</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.6">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.6">
             <title>Restrict Non-privileged Users</title>
             <prop name="label">SI-4(6)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#ac-6.10">AC-6 (10)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.7">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.7">
             <title>Automated Response to Suspicious Events</title>
             <param id="si-4.7_prm_1">
                <label>organization-defined incident response personnel (identified by name and/or by role)</label>
@@ -49642,14 +49642,14 @@
                   <p>automated mechanisms supporting and/or implementing actions to terminate suspicious events</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.8">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.8">
             <title>Protection of Monitoring Information</title>
             <prop name="label">SI-4(8)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-4">SI-4</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.9">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.9">
             <title>Testing of Monitoring Tools</title>
             <param id="si-4.9_prm_1">
                <label>organization-defined frequency</label>
@@ -49700,8 +49700,8 @@
                   <p>automated mechanisms supporting and/or implementing testing of intrusion-monitoring tools</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.10">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.10">
             <title>Visibility of Encrypted Communications</title>
             <param id="si-4.10_prm_1">
                <label>organization-defined encrypted communications traffic</label>
@@ -49761,8 +49761,8 @@
                   <p>automated mechanisms supporting and/or implementing visibility of encrypted communications traffic to monitoring tools</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.11">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.11">
             <title>Analyze Communications Traffic Anomalies</title>
             <param id="si-4.11_prm_1">
                <label>organization-defined interior points within the system (e.g., subnetworks, subsystems)</label>
@@ -49825,8 +49825,8 @@
                   <p>automated mechanisms supporting and/or implementing analysis of communications traffic</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.12">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.12">
             <title>Automated Alerts</title>
             <param id="si-4.12_prm_1">
                <label>organization-defined activities that trigger alerts</label>
@@ -49885,8 +49885,8 @@
                   <p>automated mechanisms supporting and/or implementing automated alerts to security personnel</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.13">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.13">
             <title>Analyze Traffic / Event Patterns</title>
             <prop name="label">SI-4(13)</prop>
             <part id="si-4.13_smt" name="statement">
@@ -49954,8 +49954,8 @@
                   <p>automated mechanisms supporting and/or implementing analysis of communications traffic/event patterns</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.14">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.14">
             <title>Wireless Intrusion Detection</title>
             <prop name="label">SI-4(14)</prop>
             <part id="si-4.14_smt" name="statement">
@@ -50011,8 +50011,8 @@
                   <p>automated mechanisms supporting and/or implementing wireless intrusion detection capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.15">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.15">
             <title>Wireless to Wireline Communications</title>
             <prop name="label">SI-4(15)</prop>
             <part id="si-4.15_smt" name="statement">
@@ -50055,8 +50055,8 @@
                   <p>automated mechanisms supporting and/or implementing wireless intrusion detection capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.16">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.16">
             <title>Correlate Monitoring Information</title>
             <prop name="label">SI-4(16)</prop>
             <part id="si-4.16_smt" name="statement">
@@ -50100,8 +50100,8 @@
                   <p>automated mechanisms supporting and/or implementing correlation of information from monitoring tools</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.17">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.17">
             <title>Integrated Situational Awareness</title>
             <prop name="label">SI-4(17)</prop>
             <part id="si-4.17_smt" name="statement">
@@ -50157,8 +50157,8 @@
                   <p>automated mechanisms supporting and/or implementing correlation of information from monitoring tools</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.18">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.18">
             <title>Analyze Traffic / Covert Exfiltration</title>
             <param id="si-4.18_prm_1">
                <label>organization-defined interior points within the system (e.g., subsystems, subnetworks)</label>
@@ -50221,8 +50221,8 @@
                   <p>automated mechanisms supporting and/or implementing analysis of outbound communications traffic</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.19">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.19">
             <title>Individuals Posing Greater Risk</title>
             <param id="si-4.19_prm_1">
                <label>organization-defined additional monitoring</label>
@@ -50281,8 +50281,8 @@
                   <p>automated mechanisms supporting and/or implementing system monitoring capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.20">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.20">
             <title>Privileged Users</title>
             <param id="si-4.20_prm_1">
                <label>organization-defined additional monitoring</label>
@@ -50332,8 +50332,8 @@
                   <p>automated mechanisms supporting and/or implementing system monitoring capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.21">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.21">
             <title>Probationary Periods</title>
             <param id="si-4.21_prm_1">
                <label>organization-defined additional monitoring</label>
@@ -50389,8 +50389,8 @@
                   <p>automated mechanisms supporting and/or implementing system monitoring capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.22">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.22">
             <title>Unauthorized Network Services</title>
             <param id="si-4.22_prm_1">
                <label>organization-defined authorization or approval processes</label>
@@ -50472,8 +50472,8 @@
                   <p>automated mechanisms for providing alerts</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.23">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.23">
             <title>Host-based Devices</title>
             <param id="si-4.23_prm_1">
                <label>organization-defined host-based monitoring mechanisms</label>
@@ -50534,8 +50534,8 @@
                   <p>automated mechanisms supporting and/or implementing host-based monitoring capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-4.24">
+         </control>
+         <control class="SP800-53-enhancement" id="si-4.24">
             <title>Indicators of Compromise</title>
             <prop name="label">SI-4(24)</prop>
             <part id="si-4.24_smt" name="statement">
@@ -50595,7 +50595,7 @@
                   <p>automated mechanisms supporting and/or implementing the discovery, collection, distribution, and use of indicators of compromise</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="si-5">
          <title>Security Alerts, Advisories, and Directives</title>
@@ -50730,7 +50730,7 @@
                <p>automated mechanisms supporting and/or implementing security directives</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="si-5.1">
+         <control class="SP800-53-enhancement" id="si-5.1">
             <title>Automated Alerts and Advisories</title>
             <prop name="label">SI-5(1)</prop>
             <part id="si-5.1_smt" name="statement">
@@ -50772,7 +50772,7 @@
                   <p>automated mechanisms supporting and/or implementing dissemination of security alerts and advisories</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="si-6">
          <title>Security Function Verification</title>
@@ -50935,13 +50935,13 @@
                <p>automated mechanisms supporting and/or implementing security function verification capability</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="si-6.1">
+         <control class="SP800-53-enhancement" id="si-6.1">
             <title>Notification of Failed Security Tests</title>
             <prop name="label">SI-6(1)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-6">SI-6</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-6.2">
+         </control>
+         <control class="SP800-53-enhancement" id="si-6.2">
             <title>Automation Support for Distributed Testing</title>
             <prop name="label">SI-6(2)</prop>
             <part id="si-6.2_smt" name="statement">
@@ -50980,8 +50980,8 @@
                   <p>automated mechanisms supporting and/or implementing the management of distributed security testing</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-6.3">
+         </control>
+         <control class="SP800-53-enhancement" id="si-6.3">
             <title>Report Verification Results</title>
             <param id="si-6.3_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -51033,7 +51033,7 @@
                   <p>automated mechanisms supporting and/or implementing the reporting of security function verification results</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="si-7">
          <title>Software, Firmware, and Information Integrity</title>
@@ -51114,7 +51114,7 @@
                <p>Software, firmware, and information integrity verification tools</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="si-7.1">
+         <control class="SP800-53-enhancement" id="si-7.1">
             <title>Integrity Checks</title>
             <param id="si-7.1_prm_1">
                <label>organization-defined software, firmware, and information</label>
@@ -51233,8 +51233,8 @@
                   <p>Software, firmware, and information integrity verification tools</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.2">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.2">
             <title>Automated Notifications of Integrity Violations</title>
             <param id="si-7.2_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -51286,8 +51286,8 @@
                   <p>automated mechanisms providing integrity discrepancy notifications</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.3">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.3">
             <title>Centrally-managed Integrity Tools</title>
             <prop name="label">SI-7(3)</prop>
             <part id="si-7.3_smt" name="statement">
@@ -51326,14 +51326,14 @@
                   <p>Automated mechanisms supporting and/or implementing central management of integrity verification tools</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.4">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.4">
             <title>Tamper-evident Packaging</title>
             <prop name="label">SI-7(4)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#sa-12">SA-12</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.5">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.5">
             <title>Automated Response to Integrity Violations</title>
             <param id="si-7.5_prm_1">
                <select how-many="one or more">
@@ -51406,8 +51406,8 @@
                   <p>automated mechanisms supporting and/or implementing security safeguards to be implemented when integrity violations are discovered</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.6">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.6">
             <title>Cryptographic Protection</title>
             <prop name="label">SI-7(6)</prop>
             <part id="si-7.6_smt" name="statement">
@@ -51461,8 +51461,8 @@
                   <p>cryptographic mechanisms implementing software, firmware, and information integrity</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.7">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.7">
             <title>Integration of Detection and Response</title>
             <param id="si-7.7_prm_1">
                <label>organization-defined security-relevant changes to the information system</label>
@@ -51517,8 +51517,8 @@
                   <p>automated mechanisms supporting and/or implementing incorporation of detection of unauthorized security-relevant changes into the incident response capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.8">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.8">
             <title>Auditing Capability for Significant Events</title>
             <param id="si-7.8_prm_1">
                <select how-many="one or more">
@@ -51614,8 +51614,8 @@
                   <p>automated mechanisms supporting and/or implementing alerts about potential integrity violations</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.9">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.9">
             <title>Verify Boot Process</title>
             <param id="si-7.9_prm_1">
                <label>organization-defined devices</label>
@@ -51667,8 +51667,8 @@
                   <p>automated mechanisms supporting and/or implementing integrity verification of the boot process</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.10">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.10">
             <title>Protection of Boot Firmware</title>
             <param id="si-7.10_prm_1">
                <label>organization-defined security safeguards</label>
@@ -51728,8 +51728,8 @@
                   <p>safeguards implementing protection of the integrity of boot firmware</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.11">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.11">
             <title>Confined Environments with Limited Privileges</title>
             <param id="si-7.11_prm_1">
                <label>organization-defined user-installed software</label>
@@ -51778,8 +51778,8 @@
                   <p>automated mechanisms supporting and/or implementing limited privileges in the confined environment</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.12">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.12">
             <title>Integrity Verification</title>
             <param id="si-7.12_prm_1">
                <label>organization-defined user-installed software</label>
@@ -51828,8 +51828,8 @@
                   <p>automated mechanisms supporting and/or implementing verification of the integrity of user-installed software prior to execution</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.13">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.13">
             <title>Code Execution in Protected Environments</title>
             <param id="si-7.13_prm_1">
                <label>organization-defined personnel or roles</label>
@@ -51888,8 +51888,8 @@
                   <p>automated mechanisms supporting and/or implementing approvals for execution of binary or machine-executable code</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.14">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.14">
             <title>Binary or Machine Executable Code</title>
             <prop name="label">SI-7(14)</prop>
             <part id="si-7.14_smt" name="statement">
@@ -51962,8 +51962,8 @@
                   <p>Automated mechanisms supporting and/or implementing prohibition of the execution of binary or machine-executable code</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.15">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.15">
             <title>Code Authentication</title>
             <param id="si-7.15_prm_1">
                <label>organization-defined software or firmware components</label>
@@ -52027,8 +52027,8 @@
                   <p>Cryptographic mechanisms authenticating software/firmware prior to installation</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-7.16">
+         </control>
+         <control class="SP800-53-enhancement" id="si-7.16">
             <title>Time Limit On Process Execution w/o Supervision</title>
             <param id="si-7.16_prm_1">
                <label>organization-defined time period</label>
@@ -52078,7 +52078,7 @@
                   <p>automated mechanisms supporting and/or implementing time limits on process execution without supervision</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="si-8">
          <title>Spam Protection</title>
@@ -52160,7 +52160,7 @@
                <p>automated mechanisms supporting and/or implementing spam protection</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="si-8.1">
+         <control class="SP800-53-enhancement" id="si-8.1">
             <title>Central Management</title>
             <prop name="label">SI-8(1)</prop>
             <part id="si-8.1_smt" name="statement">
@@ -52202,8 +52202,8 @@
                   <p>automated mechanisms supporting and/or implementing central management of spam protection</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-8.2">
+         </control>
+         <control class="SP800-53-enhancement" id="si-8.2">
             <title>Automatic Updates</title>
             <prop name="label">SI-8(2)</prop>
             <part id="si-8.2_smt" name="statement">
@@ -52241,8 +52241,8 @@
                   <p>automated mechanisms supporting and/or implementing automatic updates to spam protection mechanisms</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-8.3">
+         </control>
+         <control class="SP800-53-enhancement" id="si-8.3">
             <title>Continuous Learning Capability</title>
             <prop name="label">SI-8(3)</prop>
             <part id="si-8.3_smt" name="statement">
@@ -52282,7 +52282,7 @@
                   <p>automated mechanisms supporting and/or implementing spam protection mechanisms with a learning capability</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="si-9">
          <title>Information Input Restrictions</title>
@@ -52346,7 +52346,7 @@
                <p>Automated mechanisms supporting and/or implementing validity checks on information inputs</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="si-10.1">
+         <control class="SP800-53-enhancement" id="si-10.1">
             <title>Manual Override Capability</title>
             <param id="si-10.1_prm_1">
                <label>organization-defined inputs</label>
@@ -52436,8 +52436,8 @@
                   <p>automated mechanisms supporting and/or implementing auditing of the use of manual override capability</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-10.2">
+         </control>
+         <control class="SP800-53-enhancement" id="si-10.2">
             <title>Review / Resolution of Errors</title>
             <param id="si-10.2_prm_1">
                <label>organization-defined time period</label>
@@ -52490,8 +52490,8 @@
                   <p>automated mechanisms supporting and/or implementing review and resolution of input validation errors</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-10.3">
+         </control>
+         <control class="SP800-53-enhancement" id="si-10.3">
             <title>Predictable Behavior</title>
             <prop name="label">SI-10(3)</prop>
             <part id="si-10.3_smt" name="statement">
@@ -52529,8 +52529,8 @@
                   <p>Automated mechanisms supporting and/or implementing predictable behavior when invalid inputs are received</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-10.4">
+         </control>
+         <control class="SP800-53-enhancement" id="si-10.4">
             <title>Review / Timing Interactions</title>
             <prop name="label">SI-10(4)</prop>
             <part id="si-10.4_smt" name="statement">
@@ -52569,8 +52569,8 @@
                   <p>automated mechanisms supporting and/or implementing responses to invalid inputs</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-10.5">
+         </control>
+         <control class="SP800-53-enhancement" id="si-10.5">
             <title>Restrict Inputs to Trusted Sources and Approved Formats</title>
             <param id="si-10.5_prm_1">
                <label>organization-defined trusted sources</label>
@@ -52637,7 +52637,7 @@
                   <p>automated mechanisms supporting and/or implementing restriction of information inputs</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="si-11">
          <title>Error Handling</title>
@@ -52850,7 +52850,7 @@
                <p>Organizational processes for managing MTTF</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="si-13.1">
+         <control class="SP800-53-enhancement" id="si-13.1">
             <title>Transferring Component Responsibilities</title>
             <param id="si-13.1_prm_1">
                <label>organization-defined fraction or percentage</label>
@@ -52897,14 +52897,14 @@
                   <p>automated mechanisms supporting and/or implementing transfer of component responsibilities to substitute components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-13.2">
+         </control>
+         <control class="SP800-53-enhancement" id="si-13.2">
             <title>Time Limit On Process Execution Without Supervision</title>
             <prop name="label">SI-13(2)</prop>
             <prop name="status">Withdrawn</prop>
             <link rel="incorporated-into" href="#si-7.16">SI-7 (16)</link>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-13.3">
+         </control>
+         <control class="SP800-53-enhancement" id="si-13.3">
             <title>Manual Transfer Between Components</title>
             <param id="si-13.3_prm_1">
                <label>organization-defined frequency</label>
@@ -52957,8 +52957,8 @@
                   <p>Organizational processes for managing MTTF and conducting the manual transfer between active and standby components</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-13.4">
+         </control>
+         <control class="SP800-53-enhancement" id="si-13.4">
             <title>Standby Component Installation / Notification</title>
             <param id="si-13.4_prm_1">
                <label>organization-defined time period</label>
@@ -53051,8 +53051,8 @@
                   <p>automated mechanisms supporting and/or implementing alarms or system shutdown if component failures are detected</p>
                </part>
             </part>
-         </subcontrol>
-         <subcontrol class="SP800-53-enhancement" id="si-13.5">
+         </control>
+         <control class="SP800-53-enhancement" id="si-13.5">
             <title>Failover Capability</title>
             <param id="si-13.5_prm_1">
                <select>
@@ -53117,7 +53117,7 @@
                   <p>automated mechanisms supporting and/or implementing failover capability</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="si-14">
          <title>Non-persistence</title>
@@ -53194,7 +53194,7 @@
                <p>Automated mechanisms supporting and/or implementing initiation and termination of non-persistent components</p>
             </part>
          </part>
-         <subcontrol class="SP800-53-enhancement" id="si-14.1">
+         <control class="SP800-53-enhancement" id="si-14.1">
             <title>Refresh from Trusted Sources</title>
             <param id="si-14.1_prm_1">
                <label>organization-defined trusted sources</label>
@@ -53242,7 +53242,7 @@
                   <p>automated mechanisms supporting and/or implementing component and service refreshes</p>
                </part>
             </part>
-         </subcontrol>
+         </control>
       </control>
       <control class="SP800-53" id="si-15">
          <title>Information Output Filtering</title>

--- a/src/metaschema/oscal_catalog_metaschema.xml
+++ b/src/metaschema/oscal_catalog_metaschema.xml
@@ -119,8 +119,8 @@
          <assembly ref="part" max-occurs="unbounded">
             <group-as name="parts"/>
          </assembly>
-         <assembly ref="subcontrol" max-occurs="unbounded">
-            <group-as name="subcontrols"/>
+         <assembly ref="control" max-occurs="unbounded">
+            <group-as name="controls"/>
          </assembly>
          <!--<assembly named="ref-list"/>-->
          <any/>
@@ -134,28 +134,6 @@
             <title>Control 1</title>
          </control>
       </example>
-   </define-assembly>
-   <define-assembly name="subcontrol">
-      <formal-name>Sub-Control</formal-name>
-      <description>A control extension or enhancement</description>
-      <flag ref="id" required="yes"/>
-      <flag ref="class"/>
-      <model>
-         <field ref="title" min-occurs="1"/>
-         <assembly ref="param" max-occurs="unbounded">
-            <group-as name="parameters"/>
-         </assembly>
-         <field ref="prop" max-occurs="unbounded">
-            <group-as name="properties"/></field>
-         <field ref="link" max-occurs="unbounded">
-            <group-as name="links"/>
-         </field>
-         <assembly ref="part" max-occurs="unbounded">
-            <group-as name="parts"/>
-         </assembly>
-         <!--<assembly named="ref-list"/>-->
-         <any/>
-      </model>
    </define-assembly>
    <!-- See metadata model for 'prop' element -->
    <define-assembly name="param">


### PR DESCRIPTION

Addressing #473: `subcontrol` has been replaced by `control` everywhere in SP800-53.

Remaining to do (at time of writing): adjusting profile and higher models to address controls only, never subcontrols.

Also in this PR, an adjustment to the Metaschema Schematron, see #465, #475 - overriding declarations are now detected and reported as errors.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass? tbd

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? *See Issue #473*
- [x] Have you written new tests for your core changes, as applicable? *n/a*
- [x] Have you included examples of how to use your new feature(s)? *n/a*
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch. *Metaschema changes should propagate through docs*
