### PR TITLE
Incorrect link to JSON schema integer type in datatypes docs

### DIFF
--- a/docs/content/documentation/schemas/datatypes.md
+++ b/docs/content/documentation/schemas/datatypes.md
@@ -71,7 +71,7 @@ OSCAL represents integers
 [as defined in XSD](https://www.w3.org/TR/xmlschema11-2/#integer).
 
 In JSON Schema, the
-[`integer` type](https://www.w3.org/TR/xmlschema11-2/#integer) is used.
+[`integer` type](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.1.1) is used.
 
 ### nonNegativeInteger
 


### PR DESCRIPTION
# Committer Notes

The JSON schema integer type in the datatype docs had the wrong external reference link. This PR addresses this with the correct link.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?
