### PR TITLE
Repaired bugs - lapses in 'allowed-values' listings

### DIFF
--- a/build/metaschema/lib/metaschema-common-html.xsl
+++ b/build/metaschema/lib/metaschema-common-html.xsl
@@ -83,6 +83,10 @@
         <a href="#{@name}"><xsl:value-of select="@name"/></a>
     </xsl:template>
     
+    <xsl:template match="*[exists(@ref)]" mode="link-here">
+        <a href="#{@ref}"><xsl:value-of select="@ref"/></a>
+    </xsl:template>
+    
     <xsl:template name="definition-header">
         <header class="definition-header">
             <xsl:call-template name="cross-links"/>

--- a/build/metaschema/lib/metaschema-jsondocs-hugo-uswds.xsl
+++ b/build/metaschema/lib/metaschema-jsondocs-hugo-uswds.xsl
@@ -41,6 +41,7 @@
          <xsl:call-template name="definition-header"/>
          <xsl:apply-templates select="description"/>
          <xsl:apply-templates select="." mode="representation-in-json"/>
+         <xsl:apply-templates select="allowed-values"/>
          <xsl:for-each-group select="key('references',@name)/parent::*" group-by="true()">
             <p><xsl:text>Appears as a property on: </xsl:text>
                <xsl:for-each select="current-group()">
@@ -59,6 +60,7 @@
          <xsl:call-template name="definition-header"/>
          <xsl:apply-templates select="formal-name | description"/>
          <xsl:apply-templates select="." mode="representation-in-json"/>
+         <xsl:apply-templates select="allowed-values"/>
          <xsl:call-template name="appears-in"/>
          <xsl:if test="exists(flag)">
             <xsl:variable name="modal">

--- a/build/metaschema/lib/metaschema-jsondocs-hugo-uswds.xsl
+++ b/build/metaschema/lib/metaschema-jsondocs-hugo-uswds.xsl
@@ -44,11 +44,11 @@
          <xsl:apply-templates select="allowed-values"/>
          <xsl:for-each-group select="key('references',@name)/parent::*" group-by="true()">
             <p><xsl:text>Appears as a property on: </xsl:text>
-               <xsl:for-each select="current-group()">
+               <xsl:for-each-group select="current-group()" group-by="@ref">
                   <xsl:if test="position() gt 1 and last() ne 2">, </xsl:if>
                   <xsl:if test="position() gt 1 and position() eq last()"> and </xsl:if>
                   <xsl:apply-templates select="." mode="link-here"/>
-               </xsl:for-each>.</p>
+               </xsl:for-each-group>.</p>
          </xsl:for-each-group>
          <xsl:call-template name="remarks-group"/>
          <xsl:call-template name="report-module"/>

--- a/build/metaschema/lib/metaschema-xmldocs-hugo-uswds.xsl
+++ b/build/metaschema/lib/metaschema-xmldocs-hugo-uswds.xsl
@@ -40,6 +40,7 @@
          <xsl:call-template name="definition-header"/>
          <xsl:apply-templates select="description"/>
          <xsl:apply-templates select="." mode="representation-in-xml"/>
+         <xsl:apply-templates select="allowed-values"/>
          <xsl:for-each-group select="key('references',@name)/parent::*" group-by="true()">
             <p><xsl:text>This attribute appears on: </xsl:text>
                <xsl:for-each select="current-group()">
@@ -58,6 +59,7 @@
          <xsl:call-template name="definition-header"/>
          <xsl:apply-templates select="formal-name | description"/>
          <xsl:apply-templates mode="representation-in-xml" select="."/>
+         <xsl:apply-templates select="allowed-values"/>
          <xsl:call-template name="appears-in"/>
          <xsl:if test="exists(flag)">
             <xsl:variable name="modal">

--- a/build/metaschema/lib/metaschema-xmldocs-hugo-uswds.xsl
+++ b/build/metaschema/lib/metaschema-xmldocs-hugo-uswds.xsl
@@ -43,11 +43,11 @@
          <xsl:apply-templates select="allowed-values"/>
          <xsl:for-each-group select="key('references',@name)/parent::*" group-by="true()">
             <p><xsl:text>This attribute appears on: </xsl:text>
-               <xsl:for-each select="current-group()">
+               <xsl:for-each-group select="current-group()" group-by="@ref">
                   <xsl:if test="position() gt 1 and last() ne 2">, </xsl:if>
                   <xsl:if test="position() gt 1 and position() eq last()"> and </xsl:if>
                   <xsl:apply-templates select="." mode="link-here"/>
-               </xsl:for-each>.</p>
+               </xsl:for-each-group>.</p>
          </xsl:for-each-group>
          <xsl:call-template name="remarks-group"/>
          <xsl:call-template name="report-module"/>


### PR DESCRIPTION
# Committer Notes

These adjustments to docs production stylesheets restore 'allowed values' listings to field and flag definitions (that have them) - inadvertantly lost in a previous upgrade.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

Bug repair - n/a
