### PR TITLE
Repaired bug in display of groupable objects in JSON map

### DIFF
--- a/build/metaschema/lib/metaschema-jsondocs-hugo-uswds.xsl
+++ b/build/metaschema/lib/metaschema-jsondocs-hugo-uswds.xsl
@@ -421,11 +421,11 @@
       <xsl:variable name="definition" select="key('definitions',@ref)"/>
       <li>
          <p>
-            <xsl:text>Labeled </xsl:text>
+            <xsl:text>An array labeled </xsl:text>
             <b>
                <xsl:value-of select="group-as/@name"/>
             </b>
-            <xsl:text>, an array containing </xsl:text>
+            <xsl:text>, containing </xsl:text>
             <a href="#{@ref}">
                <xsl:apply-templates select="@ref"/>
             </a>

--- a/build/metaschema/lib/metaschema-jsondocs-hugo-uswds.xsl
+++ b/build/metaschema/lib/metaschema-jsondocs-hugo-uswds.xsl
@@ -323,7 +323,7 @@
    </xsl:template>
 
    <xsl:template match="flag[(@name|@ref)=../json-key/@flag-name]" mode="model">
-      <xsl:message expand-text="true">{ ../@name }</xsl:message>
+      <!--<xsl:message expand-text="true">{ ../@name }</xsl:message>-->
       <li>
          <p>
             <i>Implicitly</i>

--- a/build/metaschema/lib/metaschema-jsonobject-map.xsl
+++ b/build/metaschema/lib/metaschema-jsonobject-map.xsl
@@ -39,6 +39,13 @@
       </div>
    </xsl:template>
 
+   <xsl:template match="/" mode="debug">
+      <xsl:copy-of select="$surrogate-tree"/>
+      <div class="OM-map">
+            <xsl:apply-templates select="$surrogate-tree/*" mode="html-render"/>
+      </div>
+   </xsl:template>
+   
    <xsl:template match="/">
       <!--<xsl:copy-of select="$surrogate-tree"/>-->
       <div class="OM-map">
@@ -48,7 +55,7 @@
          <xsl:apply-templates select="$html-basic" mode="elaborate"/>
       </div>
    </xsl:template>
-
+   
    <xsl:template mode="html-render" match="@m:*"/>
 
    <xsl:template mode="html-render" match="m:flag[(@name)= ../@json-key-flag]"/>
@@ -122,7 +129,7 @@
          <p>
             <span class="OM-view_switcher"/>
             <a class="OM-name" href="{ $path-to-docs }#{ $model-label}_{ @name }">
-               <xsl:value-of select="@name"/>
+               <xsl:value-of select="(@group-name,@name)[1]"/>
             </a>
             <xsl:text>: </xsl:text>
             <xsl:call-template name="cardinality-note"/>


### PR DESCRIPTION
# Committer Notes

Fixed JSON model map docs, where they mistakenly present a single name not a group name for objects that can be grouped.

A good test is `system-characteristics/annotations` in the SSP model. It showed as singular "annotation", which is wrong here.

