### PR TITLE
Added simple control call link checker Schematron cf Issue #534

### DIFF
--- a/src/utils/schematron/oscal-profile-catalog-sources.sch
+++ b/src/utils/schematron/oscal-profile-catalog-sources.sch
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt3"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:sqf="http://www.schematron-quickfix.com/validator/process"
+  xmlns:oscal="http://csrc.nist.gov/ns/oscal/1.0">
+  
+<!-- Quick little Schematron for checking link integrity from
+     profile //call/@control-id *only*
+     and *only* when catalogs, not profiles, are sourced.
+  
+  A more complete error check will resolve profile sources as well as query catalogs.
+  
+  -->
+  <sch:ns uri="http://csrc.nist.gov/ns/oscal/1.0" prefix="oscal"/>
+
+  <xsl:key name="resource-fetch" match="oscal:resource" use="'#' || @id"/>
+  
+  <xsl:function name="oscal:get-import" as="document-node()?">
+    <xsl:param name="import" as="element(oscal:import)"/>
+    <xsl:variable name="source" select="($import/key('resource-fetch',@href)/oscal:rlink/@href,$import/@href[. castable as xs:anyURI])[1]"/>
+    <xsl:sequence select="document($source, $import)"/>
+  </xsl:function>
+  
+  <sch:pattern>
+    <sch:rule context="oscal:import">
+      <sch:let name="importing" value="oscal:get-import(.)"/>
+      
+      <sch:assert test="exists($importing)">Nothing found at <sch:value-of select="@href"/>...</sch:assert>
+      <sch:assert role="warning" test="exists($importing/oscal:catalog)">Not importing a catalog.</sch:assert>
+    </sch:rule>
+    <sch:rule context="oscal:import/*/oscal:call">
+      <sch:let name="importing" value="oscal:get-import(../parent::oscal:import)"/>
+      <sch:let name="not-a-catalog" value="empty($importing/oscal:catalog)"/>
+      
+      <sch:assert test="$not-a-catalog or (@control-id = $importing//oscal:control/@id)">No control found with @id='<sch:value-of select="@control-id"/>'</sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  
+    
+</sch:schema>

--- a/src/utils/schematron/oscal-profile-sources.sch
+++ b/src/utils/schematron/oscal-profile-sources.sch
@@ -6,6 +6,7 @@
   
   <sch:ns uri="http://csrc.nist.gov/ns/oscal/1.0" prefix="oscal"/>
 
+<!-- (This XSLT is broken until profile resolution is (re)stabilized -->
   <xsl:include href="../../../lib/XSLT/profile-resolver.xsl"/>
   <!-- included xslt has <xsl:key name="element-by-id" match="*[exists(@id)]" use="@id"/> -->
 <!--


### PR DESCRIPTION
# Committer Notes

Addressing the requirements of #534, this PR adds a small Schematron for simple link checking on profiles.

It is able to detect, when a profile imports from a catalog, whether controls are actually present in the catalog, when called (imported) by a profile.

It doesn't do fancier checking like checking against profile resolutions, or analysis. See the neighbor Schematron `oscal-profile-sources.sch` for this (while it depends on now-outmoded profile resolution).

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? (see Issue #534)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
