### PR TITLE
Restored broken links from flags to their fields/assemblies.

### DIFF
--- a/build/metaschema/lib/metaschema-jsondocs-hugo-uswds.xsl
+++ b/build/metaschema/lib/metaschema-jsondocs-hugo-uswds.xsl
@@ -44,7 +44,7 @@
          <xsl:apply-templates select="allowed-values"/>
          <xsl:for-each-group select="key('references',@name)/parent::*" group-by="true()">
             <p><xsl:text>Appears as a property on: </xsl:text>
-               <xsl:for-each-group select="current-group()" group-by="@ref">
+               <xsl:for-each-group select="current-group()" group-by="(@ref|@name)">
                   <xsl:if test="position() gt 1 and last() ne 2">, </xsl:if>
                   <xsl:if test="position() gt 1 and position() eq last()"> and </xsl:if>
                   <xsl:apply-templates select="." mode="link-here"/>

--- a/build/metaschema/lib/metaschema-xmldocs-hugo-uswds.xsl
+++ b/build/metaschema/lib/metaschema-xmldocs-hugo-uswds.xsl
@@ -43,7 +43,7 @@
          <xsl:apply-templates select="allowed-values"/>
          <xsl:for-each-group select="key('references',@name)/parent::*" group-by="true()">
             <p><xsl:text>This attribute appears on: </xsl:text>
-               <xsl:for-each-group select="current-group()" group-by="@ref">
+               <xsl:for-each-group select="current-group()" group-by="(@ref|@name)">
                   <xsl:if test="position() gt 1 and last() ne 2">, </xsl:if>
                   <xsl:if test="position() gt 1 and position() eq last()"> and </xsl:if>
                   <xsl:apply-templates select="." mode="link-here"/>


### PR DESCRIPTION
# Committer Notes

Repairs a bug preventing links from flag definitions to the field and assembly definitions that call the flag. Reported as #549.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
