### PR TITLE
updated maven version to 3.6.3 to fix missing 3.6.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1 # use CircleCI 2.1
 references:
   common_environment: &common_environment
     environment:
-      MAVEN_VERSION: 3.6.2
+      MAVEN_VERSION: 3.6.3
       SAXON_VERSION: 9.9.0-1
       JSON_CLI_VERSION: 0.0.1-SNAPSHOT
       CICD_DIR: git-oscal/build/ci-cd
@@ -75,7 +75,7 @@ commands:
           command: |
             # update maven version
             cd /opt
-            sudo wget "https://www-us.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+            sudo wget "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
             sudo tar -xvzf "apache-maven-${MAVEN_VERSION}-bin.tar.gz"
             sudo mv "apache-maven-${MAVEN_VERSION}" maven
             export M2_HOME=/opt/maven

--- a/docs/content/contribute/devlunch.md
+++ b/docs/content/contribute/devlunch.md
@@ -5,9 +5,9 @@ description: Contact Us
 
 {{% usa-intro %}}To increase communication with the OSCAL community, the NIST OSCAL team is hosting a one-hour teleconference every two weeks starting on Thursday, December 5th 2019 @ noon EST.{{% /usa-intro %}}Global
 
-Note: We have had a change in the teleconferencing solution we are using for this meeting. We are switching from WebEx to Bluejeans. As a result, we have setup a single meeting for the Thursday, December 5th 2019 teleconference. Meeting info for the next teleconference on Thursday, December 19th, 2019 will be posted here in before that meeting. Please check back for updated details.
+Note: (12/19/2019) We have had a change in the teleconferencing solution we are using for this meeting. We are switching from WebEx to Bluejeans. As a result, we have setup a single meeting for the Thursday, December 5th 2019 teleconference. Meeting info for the next teleconference on Thursday, December 19th, 2019 will be posted here in before that meeting. Please check back for updated details.
 
-{{% usa-tag %}}Meeting Info{{% /usa-tag %}} [Bluejeans Details](https://bluejeans.com/446080647) including a calender link (ICS file)
+{{% usa-tag %}}Meeting Info{{% /usa-tag %}} [Bluejeans Details](https://bluejeans.com/855987397) including a calender link (ICS file)
 {{% usa-tag %}}Call-in Numbers{{% /usa-tag %}}:
 
 > +1.408.317.9254 (US (San Jose))


### PR DESCRIPTION
# Committer Notes

Fixed a build bug causing the maven dependency to not be found. Changed the retrieval URL to use the maven release archive, which keeps historic versions. Also upgraded to maven 3.6.3.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
