### PR TITLE
Adjusted 'in-xml' settings

### DIFF
--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -20,7 +20,7 @@
       <model>
          <assembly ref="metadata"/>
          <assembly ref="back-matter"/>
-         <field ref="description"/>
+         <field ref="description" in-xml="WITH_WRAPPER"/>
          <field ref="remarks" in-xml="WITH_WRAPPER"/>
          <field ref="party-id"/>
          <assembly ref="annotation"/>
@@ -68,7 +68,7 @@
                </allowed-values>
             </flag>
          </assembly>
-         <field ref="remarks"/>
+         <field ref="remarks" in-xml="WITH_WRAPPER"/>
       </model>
    </define-assembly>
    <define-assembly name="back-matter">
@@ -513,7 +513,7 @@
             <group-as name="rlinks"/>
          </assembly>
          <field ref="base64"/>
-         <field ref="remarks"/>
+         <field ref="remarks" in-xml="WITH_WRAPPER"/>
       </model>
       <remarks>
          <p>Use of resource allows for information that pertains to, authenticates, or supplements the document it is included in.</p>


### PR DESCRIPTION
#528 describes how we need more consistency in the XML representation of certain (markup-multiline) assemblies. This PR addresses it by adding wrapping to the specification for `description` and `remarks` elements where they did not have it.

No data had to be altered to be valid to the adjusted models.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch. **Schema docs should update with this change**
