### PR TITLE
Tightened declaration of flags for identifiers to 'NCName'

### DIFF
--- a/src/content/fedramp.gov/xml/FedRAMP_HIGH-baseline-resolved-profile_catalog.xml
+++ b/src/content/fedramp.gov/xml/FedRAMP_HIGH-baseline-resolved-profile_catalog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0" id="4045631f-a7f3-48b7-9228-052cb2a2e8fe">
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0" id="uuid-4045631f-a7f3-48b7-9228-052cb2a2e8fe">
   <metadata>
     <title>FedRAMP High Baseline [RESOLVED]</title>
     <published>2019-11-27T00:00:00.000-05:00</published>

--- a/src/content/fedramp.gov/xml/FedRAMP_LI-SaaS-baseline-resolved-profile_catalog.xml
+++ b/src/content/fedramp.gov/xml/FedRAMP_LI-SaaS-baseline-resolved-profile_catalog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0" id="8b898586-6ae4-4685-8e32-600755fe556b">
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0" id="uuid-8b898586-6ae4-4685-8e32-600755fe556b">
   <metadata>
     <title>FedRAMP Tailored Low Impact Software as a Service (LI-SaaS) Baseline [RESOLVED]</title>
     <published>2019-11-27T00:00:00.000-05:00</published>

--- a/src/content/fedramp.gov/xml/FedRAMP_LOW-baseline-resolved-profile_catalog.xml
+++ b/src/content/fedramp.gov/xml/FedRAMP_LOW-baseline-resolved-profile_catalog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0" id="5456659f-da22-4d01-a1fa-f0e51f84e363">
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0" id="uuid-5456659f-da22-4d01-a1fa-f0e51f84e363">
   <metadata>
     <title>FedRAMP Low Baseline [RESOLVED]</title>
     <published>2019-11-27T00:00:00.000-05:00</published>

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -602,7 +602,7 @@
         example) the results of profile resolution.</p>
       </remarks>
    </define-flag>
-   <define-flag name="id" as-type="string">
+   <define-flag name="id" as-type="NCName">
       <formal-name>Identifier</formal-name>
       <description>Unique identifier of the containing object</description>
       <remarks>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -101,7 +101,7 @@
          <assembly ref="data-flow"/>
          <assembly ref="responsible-party" max-occurs="unbounded">
             <group-as name="responsible-parties" in-json="BY_KEY"/>
-            <flag name="role-id">
+            <flag name="role-id" as-type="NCName">
                <formal-name>Role identifier</formal-name>
                <description>Indicates the role assigned to the responsible party.</description>
                <allowed-values allow-other="yes">
@@ -593,7 +593,7 @@
          <p>Permissible values to be determined closer to the application, such as by a receiving authority.</p>
       </remarks>
    </define-assembly>
-   <define-field name="role-id">
+   <define-field name="role-id" as-type="NCName">
       <formal-name>Role Identifier Reference</formal-name>
       <description>A reference to the roles served by the user.</description>
       <allowed-values allow-other="yes">
@@ -711,7 +711,7 @@
          <assembly ref="responsible-role" max-occurs="unbounded">
             <description>Defines a role that has responsibility for the component.</description>
             <group-as name="responsible-roles" in-json="BY_KEY"/>
-            <flag name="role-id">
+            <flag name="role-id" as-type="NCName">
                <formal-name>Role identifier</formal-name>
                <description>Indicates the role assigned to the responsible party.</description>
                <allowed-values allow-other="yes">
@@ -865,7 +865,7 @@
          </field>
          <assembly ref="responsible-party" max-occurs="unbounded">
             <group-as name="responsible-parties" in-json="BY_KEY"/>
-            <flag name="role-id">
+            <flag name="role-id" as-type="NCName">
                <formal-name>Role identifier</formal-name>
                <description>Indicates the role assigned to the responsible party.</description>
                <allowed-values allow-other="yes">
@@ -964,7 +964,7 @@
          </field>
          <assembly ref="responsible-party" max-occurs="unbounded">
             <group-as name="responsible-parties" in-json="BY_KEY"/>
-            <flag name="role-id">
+            <flag name="role-id" as-type="NCName">
                <formal-name>Role identifier</formal-name>
                <description>Indicates the role assigned to the responsible party.</description>
                <allowed-values allow-other="yes">
@@ -1053,7 +1053,7 @@
          </field>
          <assembly ref="responsible-party" max-occurs="unbounded">
             <group-as name="responsible-parties" in-json="BY_KEY"/>
-            <flag name="role-id">
+            <flag name="role-id" as-type="NCName">
                <formal-name>Role identifier</formal-name>
                <description>Indicates the role assigned to the responsible party.</description>
                <allowed-values allow-other="yes">
@@ -1118,7 +1118,7 @@
 -->
          <assembly ref="responsible-role" max-occurs="unbounded">
             <group-as name="responsible-roles" in-json="BY_KEY"/>
-            <flag name="role-id">
+            <flag name="role-id" as-type="NCName">
                <formal-name>Role identifier</formal-name>
                <description>Indicates the role assigned to the responsible party.</description>
                <allowed-values allow-other="yes">
@@ -1168,7 +1168,7 @@
 -->            <!-- TODO: Implement parameters -->
          <assembly ref="responsible-role" max-occurs="unbounded">
             <group-as name="responsible-roles" in-json="BY_KEY"/>
-            <flag name="role-id">
+            <flag name="role-id" as-type="NCName">
                <formal-name>Role identifier</formal-name>
                <description>Indicates the role assigned to the responsible party.</description>
                <allowed-values allow-other="yes">
@@ -1242,7 +1242,7 @@
          </field>
          <assembly ref="responsible-role" max-occurs="unbounded">
             <group-as name="responsible-roles" in-json="BY_KEY"/>
-            <flag name="role-id">
+            <flag name="role-id" as-type="NCName">
                <formal-name>Role identifier</formal-name>
                <description>Indicates the role assigned to the responsible party.</description>
                <allowed-values allow-other="yes">


### PR DESCRIPTION
# Committer Notes

Enforcing better consistency over definitions of flags intended as IDs or pointers to IDs - XML `NCName` instead of strings. See Issue #551.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
