### PR TITLE
Update Hugo dependency to correct version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ references:
       SCHEMATRON_HOME: git-schematron
       TERM: xterm
       BUNDLER_VERSION: 2.0.2
+      HUGO_VERSION: 0.69.2
     working_directory: ~/oscal
   attach_build_workspace: &attach_build_workspace
     attach_workspace:
@@ -110,11 +111,11 @@ commands:
       - run:
           name: Get Hugo
           command: |
-            wget https://github.com/gohugoio/hugo/releases/download/v0.69.0/hugo_extended_0.69.0_Linux-64bit.deb
+            wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb
       - run:
           name: Install Hugo
           command: |
-            sudo apt-get install ./hugo_extended_0.69.0_Linux-64bit.deb
+            sudo apt-get install ./hugo_extended_${HUGO_VERSION}_Linux-64bit.deb
   install-pip-lxml:
     description: "Installs Python lxml package"
     steps:

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-ARG HUGO_VERSION=0.69.0
+ARG HUGO_VERSION=0.69.2
 
 RUN mkdir /hugo && \
   cd /hugo && \


### PR DESCRIPTION
# Committer Notes

Hugo version 0.69.0 incorrectly handles ancestor pages. This has been fixed in 0.69.2. This PR updates the Hugo version used to 0.69.2.

Fixes #660.
