### PR TITLE
#673 - Updating readme for feedback on profile resolution spec

### DIFF
--- a/src/specifications/profile-resolution/readme.md
+++ b/src/specifications/profile-resolution/readme.md
@@ -1,29 +1,7 @@
-## Editing this specification
+## Providing feedback on this specification
 
-Find an oXygen project file inside the file `profile-resolution-spec.xpr`.
+The OSCAL team welcomes feedback on the work in progress in this subdirectory, whether it be questions, points for clarification, critiques or suggestions.
 
-Features of the setup:
+Please post Issues in Github or questions to the OSCAL mailing list, or ask about them on our Gitter channel. (See https://pages.nist.gov/OSCAL/contact/ for links.)
 
-* XML authoring using raw tags or alternatively, in a structured editing environment with outlining, layout, formatting and UI widgets
-* One-button production of a self-contained HTML file for preview in a browser
-* Another button for production of a version for the web site (targeting NIST/USWDS/Hugo - in development
-* Schematron support for ad-hoc rules
-* Lightweight tagging is an HTML core plus a little healthy XML goodness for a few specification-oriented semantics
-
-## Setup:
-
-Extract the contents of `profile-resolution-spec-xpr.zip`: it is an `xpr` (oXygen project) file
-
-Open the project in oXygen
-
-Open the Specification working file in oXygen `profile=resolution-working-specml.xml`
-
-Use the View tab buttons at the bottom of the screen to switch between 'Text' and 'Author' views.
-
-Don't forget other oXygen features such as the outline view, support for editing the CSS, etc. etc.
-
-## Schematron
-
-So far, the Schematron performs only one test: it complains if the section numbering goes too deep.
-
-The RNC schema does introduce ID/IDREF relations, which oXygen exploits
+The specifications are being edited in an ad-hoc XML back end format, a lightweight extension to HTML tagging. If you wish to edit the files directly, we have stylesheets for presentation and HTML conversion along with Schematron for validation (runtime or at check points); please contact us.

--- a/src/specifications/profile-resolution/readme.md
+++ b/src/specifications/profile-resolution/readme.md
@@ -1,6 +1,6 @@
 ## Providing feedback on this specification
 
-The OSCAL team welcomes feedback on the work in progress in this subdirectory, whether it be questions, points for clarification, critiques or suggestions.
+The OSCAL team welcomes feedback on the work in progress in this subdirectory, whether it be questions, points for clarification, critiques or suggestions. A rendered version of the Profile Resolution specification maintained here appears on the OSCAL web site, at location https://pages.nist.gov/OSCAL/documentation/specification/processing/profile-resolution/.
 
 Please post Issues in Github or questions to the OSCAL mailing list, or ask about them on our Gitter channel. (See https://pages.nist.gov/OSCAL/contact/ for links.)
 

--- a/src/utils/util/resolver-pipeline/readme.md
+++ b/src/utils/util/resolver-pipeline/readme.md
@@ -1,9 +1,6 @@
 ## Resolver pipeline
 
-See folder OSCAL/docs/content/documentation/specification/processing for specification and examples.
-
-
-Resolution is conceived as a set of XSLT transformations to be performed in sequence, applied to defined inputs (a **source profile** with imported **catalog** sources) to produce defined outputs (a **profile resolution result** in the form of a catalog, also called a **baseline**).
+Profile resolution is implemented here as a set of XSLT transformations to be performed in sequence, applied to defined inputs (a **source profile** with imported **catalog** sources) to produce defined outputs (a **profile resolution result** in the form of a catalog, also called a **baseline**).
 
 The sequence reflects and roughly corresponds to the three steps in profile resolution described for OSCAL in the [Profile Resolution Specification](https://pages.nist.gov/OSCAL/documentation/specification/processing/profile-resolution/):
 
@@ -17,14 +14,16 @@ For demonstration, the expected interim results for test files are kept in the t
 
 Note that these interim results are *not always valid to any OSCAL schema* while at the same time they are quite close to OSCAL profile and catalog syntax.
 
+Testing files for profile resolution in general are kept [with the specification](https://github.com/usnistgov/OSCAL/tree/master/src/specifications/profile-resolution). The testing files in this subdirectory are only for this implementation.
+
 ### Invoking the XSLT:
 
 Use a recent version of Saxon for best results -- although we would also be *very interested* to hear from users of other XSLT engines conformant to the 3.1 family of XML standards (XSLT/XPath/XDM/XQuery).
 
-Load Saxon with your document and stylesheet as follows (for example):
+The main entry point for the transformation pipeline is the dynamic build XSLT called `oscal-profile-RESOLVE.xsl`, which invokes the core transformation steps in sequence, taking the source profile document as primary input. Load Saxon with your document and this stylesheet as follows (for example):
 
 ```bash
->  java -cp saxon-he-10.0.jar net.sf.saxon.Transform -t -s:YOUR_PROFILE_DOCUMENT.xml% -xsl:path/to/oscal-profile-RESOLVE.xsl -o:YOUR_RESULT_BASELINE.xml
+>  java -cp saxon-he-10.0.jar net.sf.saxon.Transform -t -s:YOUR_PROFILE_DOCUMENT.xml -xsl:path/to/oscal-profile-RESOLVE.xsl -o:YOUR_RESULT_BASELINE.xml
 ```
 
 Alternatively, set up the bindings in an IDE or programmed environment that has XSLT 3.1 support.
@@ -33,4 +32,4 @@ Note that URIs (addresses) given in a profile document must link correctly as ab
 
 ###
 
-A captured and serialized profile resolution will take the same form as an OSCAL catalog, and be valid to the catalog schema for correctly formed inputs.
+A captured and serialized profile resolution will take the form of an OSCAL catalog, and be valid to the catalog schema for correctly formed inputs.

--- a/src/utils/util/resolver-pipeline/readme.md
+++ b/src/utils/util/resolver-pipeline/readme.md
@@ -1,6 +1,6 @@
 ## Resolver pipeline
 
-Profile resolution is implemented here as a set of XSLT transformations to be performed in sequence, applied to defined inputs (a **source profile** with imported **catalog** sources) to produce defined outputs (a **profile resolution result** in the form of a catalog, also called a **baseline**).
+Profile resolution is implemented here as a set of XSLT transformations to be performed in sequence, applied to defined inputs (a **source profile** with imported **catalog** sources) to produce defined outputs (a **profile resolution result** in the form of a catalog). The word **baseline** is also used to refer to a particular profile in application, whether in its unprocessed form or its resolved, serialized form.
 
 The sequence reflects and roughly corresponds to the three steps in profile resolution described for OSCAL in the [Profile Resolution Specification](https://pages.nist.gov/OSCAL/documentation/specification/processing/profile-resolution/):
 

--- a/src/utils/util/resolver-pipeline/readme.md
+++ b/src/utils/util/resolver-pipeline/readme.md
@@ -3,66 +3,34 @@
 See folder OSCAL/docs/content/documentation/specification/processing for specification and examples.
 
 
-Resolution is conceived as a sequence of three XSLT transformations to be performed in sequence
+Resolution is conceived as a set of XSLT transformations to be performed in sequence, applied to defined inputs (a **source profile** with imported **catalog** sources) to produce defined outputs (a **profile resolution result** in the form of a catalog, also called a **baseline**).
 
-on defined inputs for defined outputs
+The sequence reflects and roughly corresponds to the three steps in profile resolution described for OSCAL in the [Profile Resolution Specification](https://pages.nist.gov/OSCAL/documentation/specification/processing/profile-resolution/):
 
-the sequence corresponds to the three steps in profile resolution for OSCAL:
+- **selection** (importing catalogs or profiles and selecting controls from them)
 
-**selection** (importing catalogs or profiles and selecting controls from them)
+- **organization (merging)** i.e. specifying how selected controls are to be organized in representation
 
-**organization (merging)** i.e. specifying how selected controls are to be organized in representation
+- **modification** - setting parameters and potentially supplementing, amending or editing control text
 
-**modification** - setting parameters and potentially amending/editing control text
-
-The expected interim results for test files are kept in the testing/\* folders
+For demonstration, the expected interim results for test files are kept in the testing/\* folders
 
 Note that these interim results are *not always valid to any OSCAL schema* while at the same time they are quite close to OSCAL profile and catalog syntax.
 
+### Invoking the XSLT:
 
-graph LR
+Use a recent version of Saxon for best results -- although we would also be *very interested* to hear from users of other XSLT engines conformant to the 3.1 family of XML standards (XSLT/XPath/XDM/XQuery).
 
-P --> metadata
-P --> import1
-P --> import2
-P --> import3
-P --> merge
-P --> modify
-P --> back-matter
+Load Saxon with your document and stylesheet as follows (for example):
 
-P --> import1--> profile.A1
-profile.A1 --> catalog.A
-P --> import2 --> catalog.A
-P --> import3 
-import3 --> catalog.B
+```bash
+>  java -cp saxon-he-10.0.jar net.sf.saxon.Transform -t -s:YOUR_PROFILE_DOCUMENT.xml% -xsl:path/to/oscal-profile-RESOLVE.xsl -o:YOUR_RESULT_BASELINE.xml
+```
 
-graph LR
+Alternatively, set up the bindings in an IDE or programmed environment that has XSLT 3.1 support.
 
-P --> import1[Selection]--> profile.A1[Selection]
-profile.A1 --> catalog.A[CPG from Catalog A]
-P --> import2[Selection] --> catalog.A
-P --> import3[Selection] 
-import3 --> catalog.B[CPG from Catalog B]
+Note that URIs (addresses) given in a profile document must link correctly as absolute or relative paths to their imported catalogs, as demonstrated in examples.
 
-graph LR
+###
 
-P[Profile] --> import1[Selection]--> profile.A1[Profile]
-profile.A1 --> importA1.1[Selection]
-importA1.1 --> catalog.A1[CPG from Catalog A]
-P --> import2[Selection] --> catalog.A2[CPG from Catalog A]
-P --> import3[Selection] 
-import3 --> catalog.B[CPG from Catalog B]
-
-CPG is "controls, parameters and groups" remember parameters can be loose (i.e. not appearing in a control where it is invoked, or not directly in a control at all.)
-
-merging disparate controls with a single origin into an original order is a goal of 'as-is' but can only be achieved if controls have some idea of what a "single origin" is.
-
-Processors can define for themselves what constitutes "document identity" for these purposes, but any of these might serve:
-document URI
-instance ID
-canonical (catalog) ID
-document property such as DOI
-
-
-
-
+A captured and serialized profile resolution will take the same form as an OSCAL catalog, and be valid to the catalog schema for correctly formed inputs.


### PR DESCRIPTION
Two important readme documents have been updated and improved in this PR:

- how to provide feedback on the Profile Resolution Spec
- how to run the prototype XSLT profile resolver pipeline

# Committer Notes

Issue #673 points out that we have inoperative instructions in a readme, referring to resources we are no longer making available through this channel (oXygen editing setup). This patch corrects that.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

n/a
