### PR TITLE
Metaschema Updates - id to uuid fixes, poam tweaks

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -107,7 +107,7 @@ The following steps are known to work on Ubuntu [18.04 LTS](http://releases.ubun
 
 1. Install Schematron Skeleton
 
-    The build environment uses the [ISO Schematron](https://www.google.com/search?q=schematron.com) Skeleton to generate Schematron schemas used for some validation operations.
+    The build environment uses the [ISO Schematron](http://schematron.com) Skeleton to generate Schematron schemas used for some validation operations.
 
     To install the Schematron Skeleton, run the following:
 

--- a/build/README.md
+++ b/build/README.md
@@ -107,7 +107,7 @@ The following steps are known to work on Ubuntu [18.04 LTS](http://releases.ubun
 
 1. Install Schematron Skeleton
 
-    The build environment uses the [ISO Schematron](http://schematron.com/) Skeleton to generate Schematron schemas used for some validation operations.
+    The build environment uses the ISO Schematron(http://schematron.com/) Skeleton to generate Schematron schemas used for some validation operations.
 
     To install the Schematron Skeleton, run the following:
 

--- a/build/README.md
+++ b/build/README.md
@@ -107,7 +107,7 @@ The following steps are known to work on Ubuntu [18.04 LTS](http://releases.ubun
 
 1. Install Schematron Skeleton
 
-    The build environment uses the ISO Schematron(http://schematron.com/) Skeleton to generate Schematron schemas used for some validation operations.
+    The build environment uses the [ISO Schematron](https://www.google.com/search?q=schematron.com) Skeleton to generate Schematron schemas used for some validation operations.
 
     To install the Schematron Skeleton, run the following:
 

--- a/src/content/fedramp.gov/xml/FedRAMP_HIGH-baseline_profile.xml
+++ b/src/content/fedramp.gov/xml/FedRAMP_HIGH-baseline_profile.xml
@@ -1099,10 +1099,10 @@
          <constraint>information processing, information data, AND information services</constraint>
       </set-parameter>
       <set-parameter param-id="sa-9.5_prm_2">
-         <constraint>US/US Territories or geographic locations where there is US jurisdiction</constraint>
+         <constraint>U.S./U.S. Territories or geographic locations where there is U.S. jurisdiction</constraint>
       </set-parameter>
       <set-parameter param-id="sa-9.5_prm_3">
-         <constraint>ALL HIGH Impact Data, Systems, or Services</constraint>
+         <constraint>all High Impact Data, Systems, or Services</constraint>
       </set-parameter>
       <set-parameter param-id="sa-10_prm_1">
          <constraint>development, implementation, AND operation</constraint>

--- a/src/content/fedramp.gov/xml/FedRAMP_HIGH-baseline_profile.xml
+++ b/src/content/fedramp.gov/xml/FedRAMP_HIGH-baseline_profile.xml
@@ -1098,6 +1098,12 @@
       <set-parameter param-id="sa-9.5_prm_1">
          <constraint>information processing, information data, AND information services</constraint>
       </set-parameter>
+      <set-parameter param-id="sa-9.5_prm_2">
+         <constraint>US/US Territories or geographic locations where there is US jurisdiction</constraint>
+      </set-parameter>
+      <set-parameter param-id="sa-9.5_prm_3">
+         <constraint>ALL HIGH Impact Data, Systems, or Services</constraint>
+      </set-parameter>
       <set-parameter param-id="sa-10_prm_1">
          <constraint>development, implementation, AND operation</constraint>
       </set-parameter>
@@ -9677,7 +9683,7 @@
          <title>NIST Special Publication (SP) 800-53</title>
          <prop name="version" ns="https://fedramp.gov/ns/oscal">Revision 4</prop>
          <prop name="keep">always</prop>
-         <rlink media-type="application/xml" href="../../nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml"/>
+         <rlink media-type="application/xml" href="https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.0-milestone3/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml"/>
       </resource>
    </back-matter>
 </profile>

--- a/src/content/ssp-example/json/ssp-example.json
+++ b/src/content/ssp-example/json/ssp-example.json
@@ -54,6 +54,7 @@
             "system-information": {
                 "information-types": [
                     {
+                        "uuid": "7d28ac6e-5970-4f4c-a508-5a3715f0f02b",
                         "title": "System and Network Monitoring",
                         "information-type-ids": {
                             "https://doi.org/10.6028/NIST.SP.800-60v2r1": {"id": "C.3.5.8"}
@@ -128,13 +129,13 @@
                     "component-type": "software",
                     "responsible-roles": {
                         "provider": {
-                            "party-ids": ["96c362ee-a012-4e07-92f3-486ab303b0e7"]
+                            "party-uuids": ["96c362ee-a012-4e07-92f3-486ab303b0e7"]
                         },
                         "asset-owner": {
-                            "party-ids": ["3b2a5599-cc37-403f-ae36-5708fa804b27"]
+                            "party-uuids": ["3b2a5599-cc37-403f-ae36-5708fa804b27"]
                         },
                         "asset-administrator": {
-                            "party-ids": ["833ac398-5c9a-4e6b-acba-2a9c11399da0"]
+                            "party-uuids": ["833ac398-5c9a-4e6b-acba-2a9c11399da0"]
                         }
                     }
                 },
@@ -155,7 +156,7 @@
                     ],
                     "responsible-roles": {
                         "maintainer": {
-                            "party-ids": ["ec485dcf-2519-43f5-8e7d-014cc315332d"]
+                            "party-uuids": ["ec485dcf-2519-43f5-8e7d-014cc315332d"]
                         }
                     }
                 },
@@ -172,7 +173,7 @@
                     ],
                     "responsible-roles": {
                         "maintainer": {
-                            "party-ids": ["0f0c15ed-565e-4ce9-8670-b54853d0bf03"]
+                            "party-uuids": ["0f0c15ed-565e-4ce9-8670-b54853d0bf03"]
                         }
                     },
                     "links": [
@@ -196,7 +197,7 @@
                     ],
                     "responsible-roles": {
                         "maintainer": {
-                            "party-ids": ["0f0c15ed-565e-4ce9-8670-b54853d0bf03"]
+                            "party-uuids": ["0f0c15ed-565e-4ce9-8670-b54853d0bf03"]
                         }
                     },
                     "links": [
@@ -220,7 +221,7 @@
                     ],
                     "responsible-roles": {
                         "maintainer": {
-                            "party-ids": ["0f0c15ed-565e-4ce9-8670-b54853d0bf03"]
+                            "party-uuids": ["0f0c15ed-565e-4ce9-8670-b54853d0bf03"]
                         }
                     },
                     "links": [

--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -31,7 +31,6 @@
          <assembly ref="import-ssp" />
          <assembly ref="import-ap" />
          <assembly ref="objectives" />
-         <assembly ref="assessment-subjects" />
          <assembly ref="assets" />
          <assembly ref="assessment-activities" />
          <assembly ref="results" />
@@ -1107,5 +1106,47 @@
       <formal-name>Objective ID</formal-name>
       <description>Points to an assessment objective.</description>
    </define-flag>
+   
+   <define-assembly name="part">
+      <formal-name>Part</formal-name>
+      <description>A partition or component of a control or part</description>
+      <flag ref="uuid"/>
+      <flag ref="name" required="yes"/>
+      <flag ref="ns"/>
+      <flag ref="class"/>
+      <model>
+         <field ref="title"/>
+         <field ref="prop" max-occurs="unbounded">
+            <group-as name="properties" in-json="ARRAY"/>
+            <flag ref="name">
+               <allowed-values allow-other="yes">
+                  <enum value="method">An assessment method.</enum>
+               </allowed-values>
+            </flag>
+         </field>
+         <field ref="prose" in-xml="UNWRAPPED"/>
+         <assembly ref="part" max-occurs="unbounded">
+            <group-as name="parts" in-json="ARRAY"/>
+         </assembly>
+         <field ref="link" max-occurs="unbounded">
+            <group-as name="links" in-json="ARRAY"/>
+         </field>
+         <any/>
+      </model>
+      <remarks>
+         <p>A <code>part</code> provides for logical partitioning of prose, and can be thought of as a grouping structure (e.g., section). A <code>part</code> can have child parts allowing for arbitrary nesting of prose content (e.g., statement hierarchy). A <code>part</code> can contain <code>prop</code> objects that allow for enriching prose text with structured name/value information.</p>
+         <p>A <code>part</code> can be assigned an optional <code>uuid</code>, which allows for internal and external references to the textual concept contained within a <code>part</code>. A <code>id</code> provides a means for an OSCAL profile, or a higher layer OSCAL model to reference a specific part within a <code>catalog</code>. For example, an <code>id</code> can be used to reference or to make modifications to a control statement in a profile.</p>
+         <p>Use of <code>part</code> and <code>prop</code> provides for a wide degree of extensibility within the OSCAL catalog model. The optional <code>ns</code> provides a means to qualify a part's <code>name</code>, allowing for organization-specific vocabularies to be defined with clear semantics. Any organization that extends OSCAL in this way should consistently assign a <code>ns</code> value that represents the organization, making a given namespace qualified <code>name</code> unique to that organization. This allows the combination of <code>ns</code> and <code>name</code> to always be unique and unambiguous, even when mixed with extensions from other organizations. Each organization is responsible for governance of their own extensions, and is strongly encouraged to publish their extensions as standards to their user community. If no <code>ns</code> is provided, the name is expected to be in the "OSCAL" namespace.</p>
+         <p>To ensure a <code>ns</code> is unique to an organization and naming conflicts are avoided, a URI containing a DNS or other globally defined organization name should be used. For example, if FedRAMP and DoD both extend OSCAL, FedRAMP will use the <code>ns</code> "https://fedramp.gov", while DoD will use the <code>ns</code> "https://defense.gov" for any organization specific <code>name</code>.</p>
+         <p>Tools that process OSCAL content are not required to interpret unrecognized OSCAL extensions; however, OSCAL-compliant tools should not modify or remove unrecognized extensions, unless there is a compelling reason to do so, such as data sensitivity.</p>
+      </remarks>
+      <example>
+         <description>Multiple Parts with Different Organization-Specific Names</description>
+         <o:part name="statement" id="statement-A">
+            <o:part ns="https://fedramp.gov" name="status" id="statement-A-FedRAMP">Something FedRAMP Cares About</o:part>
+            <o:part ns="https://defense.gov" name="status" id="statement-A-DoD">Something DoD Cares About</o:part>
+         </o:part>
+      </example>
+   </define-assembly>   
 
 </METASCHEMA>

--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -79,7 +79,9 @@
          <assembly ref="control-objectives" min-occurs="0" max-occurs="unbounded">
             <group-as name="control-objective-group" in-json="ARRAY"/>
          </assembly>
-         <assembly ref="objective" min-occurs="0" max-occurs="1" />
+         <assembly ref="objective" min-occurs="0" max-occurs="unbounded">
+            <group-as name="objectives"/>
+         </assembly>
          <assembly ref="method" min-occurs="0" max-occurs="unbounded">
             <group-as name="method-definitions" in-json="ARRAY"/>
          </assembly>

--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -626,8 +626,11 @@
             <description>Provided as means of extending the OSCAL syntax.</description>
             <group-as name="annotations" in-json="ARRAY"/>
          </assembly>
-         <field ref="date-time-stamp" min-occurs="1" max-occurs="1" >
+         <field ref="collected" min-occurs="1" max-occurs="1" >
             <description>Date/time stamp identifying when the finding information was collected.</description>
+         </field>
+         <field ref="expires" min-occurs="0" max-occurs="1" >
+            <description>Date/time identifying when the finding information is out-of-date and no longer valid. Typically used with continuous assessment scenarios.</description>
          </field>
          <assembly ref="objective-status" min-occurs="0" max-occurs="1"  />
          <field ref="implementation-statement-uuid" min-occurs="0" max-occurs="1" />
@@ -650,14 +653,24 @@
 
    <define-field name="implementation-statement-uuid" as-type="uuid">
       <formal-name>Implementation Statement UUID</formal-name>
-      <description>Identifies the implementation statement in the SSP to which this finding is related. </description>
+      <description>Identifies the implementation statement in the SSP to which this finding is related.</description>
    </define-field>
 
    <define-field name="date-time-stamp" as-type="dateTime-with-timezone">
       <formal-name>Date/Time Stamp</formal-name>
-      <description>Date/time stamp identifying when the information was collected.</description>
+      <description>Date/time stamp of the associated information.</description>
    </define-field>
 
+   <define-field name="collected" as-type="dateTime-with-timezone">
+      <formal-name>Date/Time Collected</formal-name>
+      <description>Date/time stamp identifying when the information was collected.</description>
+   </define-field>
+   
+   <define-field name="expires" as-type="dateTime-with-timezone">
+      <formal-name>Date/Time Expires</formal-name>
+      <description>Date/time identifying when the information expires. Typically used with continuous assessment scenarios.</description>
+   </define-field>
+   
    <define-assembly name="objective-status">
       <formal-name>Implementation Status</formal-name>
       <description>Captures an assessors conclusions as to whether an objective is fully satisfied.</description>
@@ -782,7 +795,6 @@
       <description>A pointer to a relevant item, using it's UUID.</description>
    </define-flag>
    
-   
    <define-field name="observation-method">
       <formal-name>Observation Method</formal-name>
       <description>Identifies how the observation was made.</description>
@@ -846,6 +858,7 @@
          <assembly ref="mitigating-factor" min-occurs="0" max-occurs="unbounded">
             <group-as name="mitigating-factors" in-json="ARRAY"/>
          </assembly>
+         <field ref="remediation-deadline" min-occurs="0" max-occurs="1" />
          <assembly ref="remediation" min-occurs="0" max-occurs="unbounded">
             <group-as name="remediation-group" in-json="ARRAY"/>
          </assembly>
@@ -861,6 +874,11 @@
          <p>For the FedRAMP SAR, must have prop @name='risk-reduction-auto-approve' @ns='fedramp', with a value of "yes" or "no". If missing, or no value, the default is "no".</p>
       </remarks>
    </define-assembly>
+
+   <define-field name="remediation-deadline" as-type="dateTime-with-timezone">
+      <formal-name>Remediation Deadline</formal-name>
+      <description>The date/time by which the risk must be closed.</description>
+   </define-field>
 
    <define-field name="risk-metric">
       <formal-name>Risk Metric</formal-name>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -131,7 +131,7 @@
                 <group-as name="links" in-json="ARRAY"/>
             </field>
             <field ref="party-uuid" max-occurs="unbounded">
-                <group-as name="party-ids" in-json="ARRAY"/>
+                <group-as name="party-uuids" in-json="ARRAY"/>
             </field>
             <field ref="remarks" in-xml="WITH_WRAPPER"/>
         </model>

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -233,7 +233,7 @@
             <enum value="marking">A label or descriptor that is tied to a sensitivity or classification marking system. An optional class can be used to define the specific marking system used for the associated value.</enum>
          </allowed-values>
       </flag>
-      <flag ref="uuid"/>
+      <flag ref="uuid" required="no"/>
       <flag ref="ns"/>
       <flag ref="class"/>
       <remarks>
@@ -252,7 +252,7 @@
       <!-- TODO: Add support for this -->
 <!--      <json-value-key key-flag-name="name" value-flag-name="value" /> -->
       <flag ref="name" required="yes"/>
-      <flag ref="uuid"/>
+      <flag ref="uuid" required="no"/>
       <flag ref="ns"/>
       <flag name="value" as-type="string">
          <formal-name>Value</formal-name>

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -233,7 +233,7 @@
             <enum value="marking">A label or descriptor that is tied to a sensitivity or classification marking system. An optional class can be used to define the specific marking system used for the associated value.</enum>
          </allowed-values>
       </flag>
-      <flag ref="id"/>
+      <flag ref="uuid"/>
       <flag ref="ns"/>
       <flag ref="class"/>
       <remarks>
@@ -252,7 +252,7 @@
       <!-- TODO: Add support for this -->
 <!--      <json-value-key key-flag-name="name" value-flag-name="value" /> -->
       <flag ref="name" required="yes"/>
-      <flag ref="id"/>
+      <flag ref="uuid"/>
       <flag ref="ns"/>
       <flag name="value" as-type="string">
          <formal-name>Value</formal-name>

--- a/src/metaschema/oscal_poam_metaschema.xml
+++ b/src/metaschema/oscal_poam_metaschema.xml
@@ -33,7 +33,7 @@
          </assembly>
          <field ref="system-id" min-occurs="0" max-occurs="1" />
          <assembly ref="local-definitions" min-occurs="0" max-occurs="1" />
-         <assembly ref="results"  min-occurs="1" max-occurs="1" />
+         <assembly ref="poam-items"  min-occurs="1" max-occurs="1" />
          <assembly ref="back-matter" min-occurs="0" max-occurs="1" />
       </model>
       <remarks>
@@ -57,6 +57,68 @@
       </model>
    </define-assembly>
    
+   <define-assembly name="poam-items">
+      <formal-name>POA&amp;M Items</formal-name>
+      <description>This identifies initial and residual risks, deviations, and disposition.</description>
+      <model>
+         <field ref="title"  min-occurs="1" max-occurs="1" />
+         <field ref="description"  min-occurs="1" max-occurs="1" />
+         <field ref="prop"  min-occurs="0" max-occurs="unbounded">
+            <description>Provided as means of extending the OSCAL syntax.</description>
+            <group-as name="properties" in-json="ARRAY"/>
+         </field>
+         <assembly ref="annotation" min-occurs="0" max-occurs="unbounded">
+            <description>Provided as means of extending the OSCAL syntax.</description>
+            <group-as name="annotations" in-json="ARRAY"/>
+         </assembly>
+         <field ref="start" min-occurs="1" max-occurs="1" >
+            <description>Date/time stamp identifying the start of the evidence collection reflected in these results.</description>
+         </field>
+         <field ref="end" min-occurs="1" max-occurs="1">
+            <description>Date/time stamp identifying the end of the evidence collection reflected in these results. In a continuous motoring scenario, this may contain the same value as start if appropriate.</description>
+         </field>
+         <assembly ref="poam-item" min-occurs="1" max-occurs="unbounded">
+            <group-as name="poam-item-group" in-json="ARRAY"/>
+         </assembly>
+         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1" />
+      </model>
+   </define-assembly>
    
+   <define-assembly name="poam-item">
+      <formal-name>POA&amp;M Item</formal-name>
+      <description>Describes an individual POA&amp;M item.</description>
+      <flag ref="uuid" required="yes" />
+      <model>
+         <field ref="title"  min-occurs="1" max-occurs="1" />
+         <field ref="description"  min-occurs="1" max-occurs="1" />
+         <field ref="prop"  min-occurs="0" max-occurs="unbounded">
+            <description>Provided as means of extending the OSCAL syntax.</description>
+            <group-as name="properties" in-json="ARRAY"/>
+         </field>
+         <assembly ref="annotation" min-occurs="0" max-occurs="unbounded">
+            <description>Provided as means of extending the OSCAL syntax.</description>
+            <group-as name="annotations" in-json="ARRAY"/>
+         </assembly>
+         <field ref="date-time-stamp" min-occurs="1" max-occurs="1" >
+            <description>Date/time stamp identifying when the finding information was collected.</description>
+         </field>
+         <assembly ref="objective-status" min-occurs="0" max-occurs="1"  />
+         <field ref="implementation-statement-uuid" min-occurs="0" max-occurs="1" />
+         <assembly ref="observation" min-occurs="0" max-occurs="unbounded">
+            <group-as name="observations" in-json="ARRAY"/>
+         </assembly>
+         <field ref="threat-id"  min-occurs="0" max-occurs="unbounded">
+            <group-as name="threat-ids" in-json="ARRAY"/>
+         </field>
+         <assembly ref="risk" min-occurs="0" max-occurs="unbounded">
+            <group-as name="risks" in-json="ARRAY"/>
+         </assembly>
+         <field ref="party-uuid" min-occurs="0" max-occurs="unbounded">
+            <description>The person who collected the evidence or made the observation.</description>
+            <group-as name="party-uuids" in-json="ARRAY"/>
+         </field>
+         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1" />
+      </model>
+   </define-assembly>   
    
 </METASCHEMA>

--- a/src/metaschema/oscal_poam_metaschema.xml
+++ b/src/metaschema/oscal_poam_metaschema.xml
@@ -74,7 +74,7 @@
          <field ref="start" min-occurs="1" max-occurs="1" >
             <description>Date/time stamp identifying the start of the evidence collection reflected in these results.</description>
          </field>
-         <field ref="end" min-occurs="1" max-occurs="1">
+         <field ref="end" min-occurs="0" max-occurs="1">
             <description>Date/time stamp identifying the end of the evidence collection reflected in these results. In a continuous motoring scenario, this may contain the same value as start if appropriate.</description>
          </field>
          <assembly ref="poam-item" min-occurs="1" max-occurs="unbounded">

--- a/src/metaschema/oscal_poam_metaschema.xml
+++ b/src/metaschema/oscal_poam_metaschema.xml
@@ -99,8 +99,11 @@
             <description>Provided as means of extending the OSCAL syntax.</description>
             <group-as name="annotations" in-json="ARRAY"/>
          </assembly>
-         <field ref="date-time-stamp" min-occurs="1" max-occurs="1" >
+         <field ref="collected" min-occurs="1" max-occurs="1" >
             <description>Date/time stamp identifying when the finding information was collected.</description>
+         </field>
+         <field ref="expires" min-occurs="0" max-occurs="1" >
+            <description>Date/time identifying when the finding information is out-of-date and no longer valid. Typically used with continuous assessment scenarios.</description>
          </field>
          <assembly ref="objective-status" min-occurs="0" max-occurs="1"  />
          <field ref="implementation-statement-uuid" min-occurs="0" max-occurs="1" />

--- a/src/metaschema/oscal_poam_metaschema.xml
+++ b/src/metaschema/oscal_poam_metaschema.xml
@@ -75,7 +75,7 @@
             <description>Date/time stamp identifying the start of the evidence collection reflected in these results.</description>
          </field>
          <field ref="end" min-occurs="0" max-occurs="1">
-            <description>Date/time stamp identifying the end of the evidence collection reflected in these results. In a continuous motoring scenario, this may contain the same value as start if appropriate.</description>
+            <description>Date/time stamp identifying the end of the evidence collection reflected in these results. In a continuous monitoring scenario, this may be omitted or contain the same value as start if appropriate.</description>
          </field>
          <assembly ref="poam-item" min-occurs="1" max-occurs="unbounded">
             <group-as name="poam-item-group" in-json="ARRAY"/>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -187,7 +187,7 @@
    <define-assembly name="information-type">
       <formal-name>Information Type</formal-name>
       <description>Contains details about one information type that is stored, processed, or transmitted by the system, such as privacy information, and those defined in <a href="https://doi.org/10.6028/NIST.SP.800-60v2r1">NIST SP 800-60</a>.</description>
-      <flag ref="uuid"/>
+      <flag ref="uuid" required="yes"/>
       <model>
          <field ref="title" min-occurs="1">
             <description>A human readable name for the information type. This title should be meaningful within the context of the system.</description>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -187,7 +187,7 @@
    <define-assembly name="information-type">
       <formal-name>Information Type</formal-name>
       <description>Contains details about one information type that is stored, processed, or transmitted by the system, such as privacy information, and those defined in <a href="https://doi.org/10.6028/NIST.SP.800-60v2r1">NIST SP 800-60</a>.</description>
-      <flag ref="id"/>
+      <flag ref="uuid"/>
       <model>
          <field ref="title" min-occurs="1">
             <description>A human readable name for the information type. This title should be meaningful within the context of the system.</description>
@@ -345,7 +345,7 @@
    <define-assembly name="leveraged-authorization">
       <formal-name>Leveraged Authorization</formal-name>
       <description>A description of another authorized system from which this system inherits capabilities that satisfy security requirements. Another term for this concept is a <em>common control provider</em>.</description>
-      <flag ref="id"/>
+      <flag ref="uuid" required="yes" />
       <model>
          <field ref="title" min-occurs="1">
             <description>A human readable name for the leveraged authorization in the context of the system.</description>
@@ -920,8 +920,8 @@
    <define-assembly name="implemented-component">
       <formal-name>Implemented Component</formal-name>
       <description>The set of componenets that are implemented in a given system inventory item.</description>
-      <json-key flag-name="component-id"/>
-      <flag name="component-id" required="yes" as-type="uuid">
+      <json-key flag-name="component-uuid"/>
+      <flag name="component-uuid" required="yes" as-type="uuid">
          <formal-name>Component Identifier Reference</formal-name>
          <description>A reference to a component that is implemented as part of an inventory item.</description>
       </flag>
@@ -1132,8 +1132,8 @@
    <define-assembly name="by-component">
       <formal-name>Component Control Implementation</formal-name>
       <description>Defines how the referenced component implements a set of controls.</description>
-      <json-key flag-name="component-id"/>
-      <flag name="component-id" required="yes" as-type="uuid">
+      <json-key flag-name="component-uuid"/>
+      <flag name="component-uuid" required="yes" as-type="uuid">
          <formal-name>Component Reference</formal-name>
          <description>A reference to the component that is implementing a given control or control statement.</description>
       </flag>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -1171,6 +1171,7 @@
          <assembly ref="set-parameter" max-occurs="unbounded">
             <group-as name="parameter-settings" in-json="BY_KEY"/>
          </assembly>
+         <field ref="remarks" in-xml="WITH_WRAPPER"/>
       </model>
    </define-assembly>
 </METASCHEMA>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -187,7 +187,7 @@
    <define-assembly name="information-type">
       <formal-name>Information Type</formal-name>
       <description>Contains details about one information type that is stored, processed, or transmitted by the system, such as privacy information, and those defined in <a href="https://doi.org/10.6028/NIST.SP.800-60v2r1">NIST SP 800-60</a>.</description>
-      <flag ref="uuid" required="yes"/>
+      <flag ref="uuid"/>
       <model>
          <field ref="title" min-occurs="1">
             <description>A human readable name for the information type. This title should be meaningful within the context of the system.</description>

--- a/src/metaschema/readme.md
+++ b/src/metaschema/readme.md
@@ -71,7 +71,7 @@ To support this, flags used as addresses should be declared as type `ID`, provid
 ```
 
 ```
-<title>Water (H<sub>2</sub>0</title>
+<title>Water (H<sub>2</sub>0)</title>
 ```
  
 ```

--- a/src/metaschema/readme.md
+++ b/src/metaschema/readme.md
@@ -78,3 +78,4 @@ To support this, flags used as addresses should be declared as type `ID`, provid
 "title" : "Water (H~~2~~0)"
 ```
 
+


### PR DESCRIPTION
# Committer Notes

This addresses the id to uuid issues discussed in issue #691 as well as updates to the POA&M model discussed resulting from work on issue #639.
id to uuid changes include:
- All Models: prop and annotation changed id to uuid. Set uuid to optional (required="no").
- SSP Model: leveraged-authorization changed id to uuid
- SSP Model: information-type changed id to uuid
- SSP Model: changed component-id to component-uuid

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
