### PR TITLE
Enhancements to M2->M3 data conversion utility

### DIFF
--- a/src/release/content-upgrade/add-uuids.xsl
+++ b/src/release/content-upgrade/add-uuids.xsl
@@ -28,7 +28,7 @@
     
     <!-- Copying and adding uuid -->
     <xsl:template xmlns:uuid="java:java.util.UUID" match="resource/@id | party/@id |
-        location/@id | party/@id | resource/@id | diagram/@id | user/@id | component/@id |
+        location/@id | party/@id | resource/@id | diagram/@id | user/@id | component/@id | information-type/@id |
         protocol/@id | inventory-item/@id | implemented-requirement/@id | statement/@id | by-component/@id">
         <xsl:copy-of select="."/>
         <xsl:call-template name="uuid"/>

--- a/src/release/content-upgrade/oscal-m2-m3-elements.xsl
+++ b/src/release/content-upgrade/oscal-m2-m3-elements.xsl
@@ -110,9 +110,11 @@
     </xsl:template>
     
     <xsl:template match="org-id">
-        <member-of-organization>
-            <xsl:apply-templates/>
-        </member-of-organization>
+        <xsl:if test="matches(., '\S')">
+            <member-of-organization>
+                <xsl:apply-templates/>
+            </member-of-organization>
+        </xsl:if>
     </xsl:template>
     
     
@@ -162,7 +164,7 @@
     
 <!-- Following are mappings for SSP elements  -->
     
-    <xsl:template match="information-type | component">
+    <xsl:template match="information-type | component | authorized-privilege">
         <xsl:copy>
             <xsl:apply-templates select="@* except @name, @name"/>
             <xsl:apply-templates/>
@@ -182,7 +184,7 @@
         </title>
     </xsl:template>
     
-    <xsl:template match="information-type/@name | component/@name">
+    <xsl:template match="information-type/@name | component/@name | authorized-privilege/@name">
         <title>
             <xsl:sequence select="string(.)"/>
         </title>

--- a/src/release/content-upgrade/rewrite-links.xsl
+++ b/src/release/content-upgrade/rewrite-links.xsl
@@ -19,7 +19,7 @@
     
     <!-- Removing resource/@id -->
     <xsl:template match="resource/@id | party/@id |
-        location/@id | party/@id | resource/@id | diagram/@id | user/@id | component/@id |
+        location/@id | party/@id | resource/@id | diagram/@id | user/@id | component/@id | information-type/@id |
         protocol/@id | inventory-item/@id | implemented-requirement/@id | statement/@id | by-component/@id"/>
     
     <!-- Wherever a link or anchor points to a resource, it will point to its UUID -->


### PR DESCRIPTION
# Committer Notes

Added handling for Milestone 2 constructs (not given in earlier samples) in conversion utility to M3:

* `@name` on `authorized-privilege` becomes `title`
* `information-type/@id` becomes `@uuid`

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

