### PR TITLE
Replace ssh transport for modules with https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "docs/themes/uswds"]
 	path = docs/themes/uswds
-	url = git@github.com:usnistgov/hugo-uswds.git
+	url = https://github.com/usnistgov/hugo-uswds.git
 	branch = master
 	update = rebase
 [submodule "build/metaschema"]
 	path = build/metaschema
-	url = git@github.com:usnistgov/metaschema.git
+	url = https://github.com/usnistgov/metaschema.git
 	branch = master


### PR DESCRIPTION
All module repos are public and open-source, so HTTPS transport is
friendlier for 3rd-party devs that are not core contributors, either from
NIST or elsewhere.

# Committer Notes

{Please provide a brief description of what this PR accomplishes. Be sure to reference any issues addressed. If the PR is a work-in-progress submitted for early review, please include [WIP] at the beginning of the title or mark the PR as DRAFT.}

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
