### PR TITLE
Updating submodules to use HTTP instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "docs/themes/uswds"]
 	path = docs/themes/uswds
-	url = git@github.com:usnistgov/hugo-uswds.git
+	url = https://github.com/usnistgov/hugo-uswds.git
 	branch = master
 	update = rebase
 [submodule "build/metaschema"]
 	path = build/metaschema
-	url = git@github.com:usnistgov/metaschema.git
+	url = https://github.com/usnistgov/metaschema.git
 	branch = master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,3 +102,39 @@ The project cards for each sprint will be in one of the following states:
 - "Done" - Once the contributed work has been reviewed and the pull request has been merged, the user story will be marked as "Done".
 
 Note: A pull request must be submitted for all goals before an issue will be moved to the "under review" status. If any goals or acceptance criteria have not been met, then the user story will be commented on to provide feedback, and the issue will be returned to the "In progress" state.
+
+## Git Client Setup
+
+### Initializing Git submodules
+
+This GitHub repository makes use of Git submodules to mount other repositories as subdirectories.
+
+When cloning this repo for the first time, you need to initialize the submodules that this repository depends on. To do this you must execute the following command:
+
+```
+git submodule update --init
+```
+
+You can perform the clone and submodule initialization in a single step by using the following command:
+
+```
+git clone --recurse-submodules https://github.com/usnistgov/OSCAL.git
+```
+
+### Configuring Submodules to Use SSH
+
+Some clients will make use of Git over SSH with a private SSH key for GitHub projects. For convenience, the submodules are configured to use HTTP instead of SSH. To override this default behavior, you will need to configure your Git client to use SSH instead of HTTP using the following command:
+
+```
+git config --global url."git@github.com:".insteadOf https://github.com/
+```
+
+This instructs your Git client to dynamically replace the HTTP-based URLs with the proper SSH URL when using GitHub.
+
+### Updating submodules
+
+Submodule contents will be periodically updated. To ensure you have the latest commits for a configured submodule, you will need to run the following command:
+
+```
+git submodule update --init --recursive
+```

--- a/build/README.md
+++ b/build/README.md
@@ -50,7 +50,7 @@ A Docker container configuration is provided that establishes the runtime enviro
 
 ## Manual Setup of the Build Environment
 
-The following steps are known to work on [Ubuntu](https://ubuntu.com/) (tested in [18.04 LTS](http://old-releases.ubuntu.com/releases/18.04.4/).
+The following steps are known to work on [Ubuntu](https://ubuntu.com/) (tested in [18.04 LTS](http://old-releases.ubuntu.com/releases/bionic/).
 
 1. Setup environment variables
 


### PR DESCRIPTION
# Committer Notes

Fixing submodule URLs to use HTTP by default closing #753.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
