### PR TITLE
Updated SSP metaschema for leveraged-authorizations

### DIFF
--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -1146,6 +1146,13 @@
          <assembly ref="annotation" max-occurs="unbounded">
             <group-as name="annotations" in-json="ARRAY"/>
          </assembly>
+         <assembly ref="export" min-occurs="0" max-occurs="1" />
+         <assembly ref="inherited" min-occurs="0" max-occurs="unbounded">
+            <group-as name="inherited-group"/>
+         </assembly>
+         <assembly ref="satisfied" min-occurs="0" max-occurs="unbounded">
+            <group-as name="satisfied-group"/>
+         </assembly>
          <field ref="link" max-occurs="unbounded">
             <group-as name="links" in-json="ARRAY"/>
             <!-- TODO: Model specific link relationships -->
@@ -1174,4 +1181,80 @@
          <field ref="remarks" in-xml="WITH_WRAPPER"/>
       </model>
    </define-assembly>
+   
+   <define-assembly name="export">
+      <formal-name>Export</formal-name>
+      <description>Identifies content intended for external consumption, such as with leveraged organizations.</description>
+      <model>
+         <field ref="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER"/>
+         <assembly ref="provided" min-occurs="0" max-occurs="unbounded">
+            <group-as name="provided-group"/>
+         </assembly>
+         <assembly ref="responsibility" min-occurs="0" max-occurs="unbounded">
+            <group-as name="responsibilities"/>
+         </assembly>
+      </model>
+   </define-assembly>
+
+   <define-assembly name="provided">
+      <formal-name>Provided</formal-name>
+      <description>Describes a capability which may be inherited by a leveraging system.</description>
+      <flag ref="uuid" required="yes" />
+      <model>
+         <field ref="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER"/>
+         <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
+            <group-as name="responsible-roles" in-json="BY_KEY"/>
+         </assembly>
+      </model>
+   </define-assembly>
+   
+   <define-assembly name="responsibility">
+      <formal-name>Responsibility</formal-name>
+      <description>Describes a responsibiity imposed on a leveraging system.</description>
+      <flag ref="uuid" required="yes" />
+      <flag ref="provided-uuid" required="no" />
+      <model>
+         <field ref="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER"/>
+         <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
+            <group-as name="responsible-roles" in-json="BY_KEY"/>
+         </assembly>
+      </model>
+   </define-assembly>
+   
+   <define-flag name="provided-uuid">
+      <formal-name>Provided UUID</formal-name>
+      <description>Identifies a 'provided' assembly associated with this assembly.</description>
+   </define-flag>
+
+   <define-assembly name="inherited">
+      <formal-name>Inherited</formal-name>
+      <description>Describes a responsibiity imposed on a leveraging system.</description>
+      <flag ref="uuid" required="yes" />
+      <flag ref="provided-uuid" required="no" />
+      <model>
+         <field ref="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER"/>
+         <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
+            <group-as name="responsible-roles" in-json="BY_KEY"/>
+         </assembly>
+      </model>
+   </define-assembly>
+   
+   <define-assembly name="satisfied">
+      <formal-name>Satisfied</formal-name>
+      <description>Describes how this system satisfies a responsibiity imposed by a leveraged system.</description>
+      <flag ref="uuid" required="yes" />
+      <flag ref="responsibility-uuid" required="no" />
+      <model>
+         <field ref="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER"/>
+         <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
+            <group-as name="responsible-roles" in-json="BY_KEY"/>
+         </assembly>
+      </model>
+   </define-assembly>
+   
+   <define-flag name="responsibility-uuid">
+      <formal-name>Provided UUID</formal-name>
+      <description>Identifies a 'provided' assembly associated with this assembly.</description>
+   </define-flag>
+
 </METASCHEMA>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -1024,7 +1024,6 @@
       <flag ref="uuid" required="yes"/>
       <flag ref="control-id" required="yes"/>
       <model>
-         <field ref="description"/>
          <field ref="prop" max-occurs="unbounded">
             <group-as name="properties" in-json="ARRAY"/>
          </field>
@@ -1086,7 +1085,6 @@
       </flag>
       <flag ref="uuid" required="yes"/>
       <model>
-         <field ref="description"/>
 
          <field ref="prop" max-occurs="unbounded">
             <group-as name="properties" in-json="ARRAY"/>
@@ -1187,12 +1185,23 @@
       <description>Identifies content intended for external consumption, such as with leveraged organizations.</description>
       <model>
          <field ref="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER"/>
+         <field ref="prop" max-occurs="unbounded">
+            <group-as name="properties" in-json="ARRAY"/>
+         </field>
+         <assembly ref="annotation" max-occurs="unbounded">
+            <group-as name="annotations"/>
+         </assembly>
+         <field ref="link" max-occurs="unbounded">
+            <group-as name="links" in-json="ARRAY"/>
+            <!-- TODO: Model specific link relationships -->
+         </field>
          <assembly ref="provided" min-occurs="0" max-occurs="unbounded">
             <group-as name="provided-group"/>
          </assembly>
          <assembly ref="responsibility" min-occurs="0" max-occurs="unbounded">
             <group-as name="responsibilities"/>
          </assembly>
+         <field ref="remarks" in-xml="WITH_WRAPPER"/>
       </model>
    </define-assembly>
 
@@ -1202,9 +1211,20 @@
       <flag ref="uuid" required="yes" />
       <model>
          <field ref="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER"/>
+         <field ref="prop" max-occurs="unbounded">
+            <group-as name="properties" in-json="ARRAY"/>
+         </field>
+         <assembly ref="annotation" max-occurs="unbounded">
+            <group-as name="annotations"/>
+         </assembly>
+         <field ref="link" max-occurs="unbounded">
+            <group-as name="links" in-json="ARRAY"/>
+            <!-- TODO: Model specific link relationships -->
+         </field>
          <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
             <group-as name="responsible-roles" in-json="BY_KEY"/>
          </assembly>
+         <field ref="remarks" in-xml="WITH_WRAPPER"/>
       </model>
    </define-assembly>
    
@@ -1215,17 +1235,23 @@
       <flag ref="provided-uuid" required="no" />
       <model>
          <field ref="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER"/>
+         <field ref="prop" max-occurs="unbounded">
+            <group-as name="properties" in-json="ARRAY"/>
+         </field>
+         <assembly ref="annotation" max-occurs="unbounded">
+            <group-as name="annotations"/>
+         </assembly>
+         <field ref="link" max-occurs="unbounded">
+            <group-as name="links" in-json="ARRAY"/>
+            <!-- TODO: Model specific link relationships -->
+         </field>
          <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
             <group-as name="responsible-roles" in-json="BY_KEY"/>
          </assembly>
+         <field ref="remarks" in-xml="WITH_WRAPPER"/>
       </model>
    </define-assembly>
    
-   <define-flag name="provided-uuid">
-      <formal-name>Provided UUID</formal-name>
-      <description>Identifies a 'provided' assembly associated with this assembly.</description>
-   </define-flag>
-
    <define-assembly name="inherited">
       <formal-name>Inherited</formal-name>
       <description>Describes a responsibiity imposed on a leveraging system.</description>
@@ -1233,6 +1259,16 @@
       <flag ref="provided-uuid" required="no" />
       <model>
          <field ref="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER"/>
+         <field ref="prop" max-occurs="unbounded">
+            <group-as name="properties" in-json="ARRAY"/>
+         </field>
+         <assembly ref="annotation" max-occurs="unbounded">
+            <group-as name="annotations"/>
+         </assembly>
+         <field ref="link" max-occurs="unbounded">
+            <group-as name="links" in-json="ARRAY"/>
+            <!-- TODO: Model specific link relationships -->
+         </field>
          <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
             <group-as name="responsible-roles" in-json="BY_KEY"/>
          </assembly>
@@ -1246,11 +1282,27 @@
       <flag ref="responsibility-uuid" required="no" />
       <model>
          <field ref="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER"/>
+         <field ref="prop" max-occurs="unbounded">
+            <group-as name="properties" in-json="ARRAY"/>
+         </field>
+         <assembly ref="annotation" max-occurs="unbounded">
+            <group-as name="annotations"/>
+         </assembly>
+         <field ref="link" max-occurs="unbounded">
+            <group-as name="links" in-json="ARRAY"/>
+            <!-- TODO: Model specific link relationships -->
+         </field>
          <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
             <group-as name="responsible-roles" in-json="BY_KEY"/>
          </assembly>
+         <field ref="remarks" in-xml="WITH_WRAPPER"/>
       </model>
    </define-assembly>
+   
+   <define-flag name="provided-uuid">
+      <formal-name>Provided UUID</formal-name>
+      <description>Identifies a 'provided' assembly associated with this assembly.</description>
+   </define-flag>
    
    <define-flag name="responsibility-uuid">
       <formal-name>Provided UUID</formal-name>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -657,6 +657,10 @@
                   <enum value="isa-title">Title of the Interconnection Security Agreement (ISA).</enum>
                   <enum value="isa-date">Date of the Interconnection Security Agreement (ISA).</enum>
                   <enum value="isa-remote-system-name">The name of the remote interconnected system.</enum>
+                  <!-- names related to inherited component -->
+                  <enum value="implementation-point">Reletave placement of component ('inteneral' or 'external') to the system.</enum>
+                  <enum value="leveraged-authorization-uuid">Title of the Interconnection Security Agreement (ISA).</enum>
+                  <enum value="inherited-uuid">Title of the Interconnection Security Agreement (ISA).</enum>
                </allowed-values>
             </flag>
             <remarks>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -659,8 +659,8 @@
                   <enum value="isa-remote-system-name">The name of the remote interconnected system.</enum>
                   <!-- names related to inherited component -->
                   <enum value="implementation-point">Reletave placement of component ('inteneral' or 'external') to the system.</enum>
-                  <enum value="leveraged-authorization-uuid">Title of the Interconnection Security Agreement (ISA).</enum>
-                  <enum value="inherited-uuid">Title of the Interconnection Security Agreement (ISA).</enum>
+                  <enum value="leveraged-authorization-uuid">UUID of the related leveraged-authorization assembly in this SSP.</enum>
+                  <enum value="inherited-uuid">UUID of the component as it was assigned in the leveraged system's SSP.</enum>
                </allowed-values>
             </flag>
             <remarks>


### PR DESCRIPTION
# Committer Notes

Updates the SSP metaschema in support of revised leveraged authorization syntax.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
