### PR TITLE
Modifying configuration of JSON Schema docs pages (toc)

### DIFF
--- a/docs/content/documentation/schema/assessment-layer/assessment-plan/json-schema.md
+++ b/docs/content/documentation/schema/assessment-layer/assessment-plan/json-schema.md
@@ -6,7 +6,7 @@ weight: 20
 sidenav:
   title: JSON Format Reference
   toc:
-    headingselectors: "h2.assembly-header"
+    headingselectors: "h2.toc1, h3.toc2"
 aliases:
   - /documentation/schema/assessment-plan/json-schema/
 ---

--- a/docs/content/documentation/schema/assessment-results-layer/assessment-results/json-schema.md
+++ b/docs/content/documentation/schema/assessment-results-layer/assessment-results/json-schema.md
@@ -6,7 +6,7 @@ weight: 20
 sidenav:
   title: JSON Format Reference
   toc:
-    headingselectors: "h2.assembly-header"
+    headingselectors: "h2.toc1, h3.toc2"
 aliases:
   - /documentation/schema/assessment-results/json-schema/
 ---

--- a/docs/content/documentation/schema/assessment-results-layer/poam/json-schema.md
+++ b/docs/content/documentation/schema/assessment-results-layer/poam/json-schema.md
@@ -6,7 +6,7 @@ weight: 20
 sidenav:
   title: JSON Format Reference
   toc:
-    headingselectors: "h2.assembly-header"
+    headingselectors: "h2.toc1, h3.toc2"
 aliases:
   - /documentation/schema/poam/json-schema/
 ---

--- a/docs/content/documentation/schema/catalog-layer/catalog/json-schema.md
+++ b/docs/content/documentation/schema/catalog-layer/catalog/json-schema.md
@@ -8,7 +8,7 @@ weight: 20
 sidenav:
   title: JSON Format Reference
   toc:
-    headingselectors: "h2.assembly-header"
+    headingselectors: "h2.toc1, h3.toc2"
 aliases:
   - /documentation/schema/catalog/json-schema/
 ---

--- a/docs/content/documentation/schema/implementation-layer/component/json-schema.md
+++ b/docs/content/documentation/schema/implementation-layer/component/json-schema.md
@@ -8,7 +8,7 @@ weight: 20
 sidenav:
   title: JSON Format Reference
   toc:
-    headingselectors: "h2.assembly-header"
+    headingselectors: "h2.toc1, h3.toc2"
 aliases:
   - /documentation/schema/component/json-schema/
 ---

--- a/docs/content/documentation/schema/implementation-layer/ssp/json-schema.md
+++ b/docs/content/documentation/schema/implementation-layer/ssp/json-schema.md
@@ -8,7 +8,7 @@ weight: 20
 sidenav:
   title: JSON Format Reference
   toc:
-    headingselectors: "h2.assembly-header"
+    headingselectors: "h2.toc1, h3.toc2"
 aliases:
   - /documentation/schema/ssp/json-schema/
 ---

--- a/docs/content/documentation/schema/profile-layer/profile/json-schema.md
+++ b/docs/content/documentation/schema/profile-layer/profile/json-schema.md
@@ -8,7 +8,7 @@ weight: 20
 sidenav:
   title: JSON Format Reference
   toc:
-    headingselectors: "h2.assembly-header"
+    headingselectors: "h2.toc1, h3.toc2"
 aliases:
   - /documentation/schema/profile/json-schema/
 ---


### PR DESCRIPTION
# Committer Notes

Includes configuration change to docs production under Hugo, supporting ToC generation over JSON Schema docs pages.

WIP towards usnistgov/OSCAL#725.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
