### PR TITLE
Adjusted 'prose' cardinality in control-common metaschema

### DIFF
--- a/src/metaschema/oscal_control-common_metaschema.xml
+++ b/src/metaschema/oscal_control-common_metaschema.xml
@@ -72,7 +72,7 @@
          <assembly ref="annotation" max-occurs="unbounded">
             <group-as name="annotations" in-json="ARRAY"/>
          </assembly>
-         <define-field name="prose" as-type="markup-multiline" in-xml="UNWRAPPED" min-occurs="1">
+         <define-field name="prose" as-type="markup-multiline" in-xml="UNWRAPPED">
             <formal-name>Part Text</formal-name>
             <description>Permits multiple paragraphs, lists, tables etc.</description>
          </define-field>


### PR DESCRIPTION
# Committer Notes

Relaxes requirement on 'prose' field in control common metaschema definitions.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
