### PR TITLE
removed assessment-subject from root of AR

### DIFF
--- a/docs/content/documentation/schema/profile-layer/profile/_index.md
+++ b/docs/content/documentation/schema/profile-layer/profile/_index.md
@@ -87,6 +87,6 @@ Multiple examples of baselines expressed using the OSCAL profile model can be fo
 |:---|:---|
 | NIST SP 800-53 rev 5 | \[[XML]({{< param "contentRepoPath" >}}/nist.gov/SP800-53/rev5/xml/)\] \[[JSON]({{< param "contentRepoPath" >}}/nist.gov/SP800-53/rev5/json/)\] \[[YAML]({{< param "contentRepoPath" >}}/nist.gov/SP800-53/rev5/yaml/)\]
 | NIST SP 800-53 rev 4 | \[[XML]({{< param "contentRepoPath" >}}/nist.gov/SP800-53/rev4/xml/)\] \[[JSON]({{< param "contentRepoPath" >}}/nist.gov/SP800-53/rev4/json/)\] \[[YAML]({{< param "contentRepoPath" >}}/nist.gov/SP800-53/rev4/yaml/)\]
-| FedRAMP Baselines | \[[XML](https://github.com/gsa/fedramp-automation/blob/master/baselines/xml/)\] \[[JSON](https://github.com/gsa/fedramp-automation/blob/master/baselines/json/)\] \[[YAML](https://github.com/gsa/fedramp-automation/blob/master/baselines/yaml/)\]
+| FedRAMP Baselines | \[[XML](https://github.com/gsa/fedramp-automation/blob/master/baselines/rev4/xml/)\] \[[JSON](https://github.com/gsa/fedramp-automation/blob/master/baselines/rev4/json/)\] \[[YAML](https://github.com/gsa/fedramp-automation/blob/master/baselines/rev4/yaml/)\]
 
 You will also find the "resolved" version of each profile. These files end with the suffix `-resolved-profile_catalog` to indicate that the profile [resolution process](/documentation/processing/profile-resolution/) has been performed to generate a catalog containing only the selected and tailored controls defined by the profile.

--- a/src/metaschema/oscal_assessment-results_metaschema.xml
+++ b/src/metaschema/oscal_assessment-results_metaschema.xml
@@ -148,9 +148,13 @@
                <p>Any additional control objectives defined in the Assessment Plan <code>local-definitions</code> do not need to be re-defined in the Assessment Results <code>local-definitions</code>; however, if they were explicitly referenced with an Assessment Plan <code>control-objective-selection</code>, they need to be selected again in the Assessment Results <code>control-objective-selection</code>.</p>
             </remarks>
          </assembly>
+
+         <!-- CHANGED: Removed "assessment-subjects" from AR. should be defined in AP or in AR/local-definitions, but not at AR root.         
          <assembly ref="assessment-subject" min-occurs="0" max-occurs="unbounded">
             <group-as name="assessment-subjects" in-json="ARRAY"/>
          </assembly>
+         
+-->
          <!-- To augment the assessment plan -->
          <assembly ref="assessment-assets" min-occurs="0" max-occurs="1">
             <remarks>


### PR DESCRIPTION
# Committer Notes

As coordinated with @david-waltermire-nist, removed assessment-subject from root of AR. 
Assessment Subject should be defined in root of AP, or local-definitions of AR.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
