### PR TITLE
Fixes to JSON Schema Generation

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,12 +1,17 @@
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG saxonversion
 ARG hugoversion
 
-RUN apt-get update && apt-get install -y wget apt-utils libxml2-utils jq maven nodejs npm build-essential python-pip git && apt-get clean
-RUN npm install -g prettyjson markdown-link-check json-diff ajv-cli
-RUN pip install lxml
+ENV TZ=US/Eastern
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get install -y wget apt-utils libxml2-utils jq maven nodejs npm build-essential python3-pip git && apt-get clean
+RUN npm install -g npm n
+RUN n latest
+RUN npm install -g markdown-link-check json-diff ajv-formats@"^1.5.x" ajv-cli@"^4.0.x" yaml-convert@"^1.0.x"
+RUN pip3 install lxml
 
 #RUN useradd --create-home --home-dir /home/user user
 #USER user

--- a/build/README.md
+++ b/build/README.md
@@ -92,7 +92,7 @@ The following steps are known to work on [Ubuntu](https://ubuntu.com/) (tested i
     To install the required Node.js modules globally (for all users), run the following:
 
     ```bash
-    sudo npm install -g prettyjson markdown-link-check json-diff ajv-cli
+    sudo npm install -g ajv-formats@"^1.5.x" ajv-cli@"^4.0.x" yaml-convert@"^1.0.x" markdown-link-check json-diff
     ```
 
     Or to install locally

--- a/build/ci-cd/copy-and-convert-content.sh
+++ b/build/ci-cd/copy-and-convert-content.sh
@@ -200,7 +200,7 @@ post_process_content() {
     if [ "$VERBOSE" = "true" ]; then
       echo -e "${P_INFO}Producing YAML '${P_END}${yaml_file_relative}${P_INFO}'.${P_END}"
     fi
-    prettyjson --nocolor=1 --indent=2 --inline-arrays=1 "$target_file" > "$yaml_file"
+    yaml-convert -y "$target_file" | (echo "---" && cat) > "$yaml_file"
 
     if [ "$VERBOSE" = "true" ]; then
       echo -e "${P_INFO}Translating relative paths in '${P_END}${yaml_file_relative}${P_INFO}'.${P_END}"


### PR DESCRIPTION
# Committer Notes

This commit fixes duplicate definition ids in the generated JSON schema which based on metaschema fixes in PR usnistgov/metaschema#116 (issues usnistgov/metaschema#18 and usnistgov/metaschema#113).

Also fixes YAML content conversion.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
