### PR TITLE
Fix typos and glitches in metaschema to resolve issue #875

### DIFF
--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -482,7 +482,7 @@
             <group-as name="control-objective-selections" in-json="ARRAY"/>
             <model>
                <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-                  <formal-name>Control Ojectives Description</formal-name>
+                  <formal-name>Control Objectives Description</formal-name>
                   <description>A human-readable description of this collection of control objectives.</description>
                </define-field>
                <field ref="property" min-occurs="0" max-occurs="unbounded">

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -268,7 +268,7 @@
       </define-flag>
       <model>
          <define-field name="title" as-type="markup-line">
-            <formal-name>title field</formal-name>
+            <formal-name>Protocol Title</formal-name>
             <description>A human readable name for the protocol (e.g., Transport Layer Security).</description>
          </define-field>
          <assembly ref="port-range" max-occurs="unbounded">
@@ -387,7 +387,7 @@
       <description>Identifies a specific system privilege held by the user, along with an associated description and/or rationale for the privilege.</description>
       <model>
          <define-field name="title" as-type="markup-line" min-occurs="1">
-            <formal-name>title field</formal-name>
+            <formal-name>Privilege Title</formal-name>
             <description>A human readable name for the privilege.</description>
          </define-field>
          <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">


### PR DESCRIPTION
# Committer Notes

Fixed the typo in oscal_assessment-common_metaschema.xmland ensured unique formal names in the oscal_implementation-common-metaschema.xml.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
