### PR TITLE
Added rels for metadata/revision/link

### DIFF
--- a/docs/content/contribute/_index.md
+++ b/docs/content/contribute/_index.md
@@ -22,7 +22,7 @@ We are excited that you want to contribute to the OSCAL project. We are striving
 We use GitHub as a collaboration platform for the development of the OSCAL models. Within the OSCAL GitHub repository you will find:
 
 - A [set of issues](https://github.com/usnistgov/OSCAL/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) for which we need your help. Feel free to pick from this list, or [reach out to us](/contact/) about any other ideas you might have.
-- [Guidelines](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) on contributing to this project.
+- [Guidelines](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) on contributing to this project.
 - A [project board](https://github.com/usnistgov/OSCAL/projects) that shows the issues the team is currently working on.
 
 You can connect with us and other developers working on OSCAL related projects on the [OSCAL Gitter](https://gitter.im/usnistgov-OSCAL/Lobby) or using the [oscal-dev@nist.gov mailing list](/contact/#oscal-mailing-lists).

--- a/docs/content/contribute/roadmap.md
+++ b/docs/content/contribute/roadmap.md
@@ -8,7 +8,7 @@ aliases:
   - /learnmore/roadmap/
 ---
 
-OSCAL is a community-driven, NIST-led project, with an [open invitation](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) to the community to participate in the framing and development of OSCAL. Feature requests can be [created and submitted](https://github.com/usnistgov/OSCAL/issues/new?assignees=&labels=User+Story%2C+enhancement&template=feature_request.md) directly into the project's GitHub repository. Feedback in the form of [bug reports](https://github.com/usnistgov/OSCAL/issues/new?assignees=&labels=bug&template=bug_report.md) are also encouraged and appreciated. If appropriate, we ask you add a comment to an [existing relevant issue](https://github.com/usnistgov/OSCAL/issues), and only create a new issue when no relevant issue exists. Before opening an issue, we ask that you review our [contributing guidelines](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md).
+OSCAL is a community-driven, NIST-led project, with an [open invitation](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) to the community to participate in the framing and development of OSCAL. Feature requests can be [created and submitted](https://github.com/usnistgov/OSCAL/issues/new?assignees=&labels=User+Story%2C+enhancement&template=feature_request.md) directly into the project's GitHub repository. Feedback in the form of [bug reports](https://github.com/usnistgov/OSCAL/issues/new?assignees=&labels=bug&template=bug_report.md) are also encouraged and appreciated. If appropriate, we ask you add a comment to an [existing relevant issue](https://github.com/usnistgov/OSCAL/issues), and only create a new issue when no relevant issue exists. Before opening an issue, we ask that you review our [contributing guidelines](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md).
 
 # Development Epics
 
@@ -98,7 +98,7 @@ This development phase focused on producing:
 - Updated stable version of the [system security plan](https://pages.nist.gov/OSCAL/documentation/schema/implementation-layer/ssp/) model which provides a structured representations of a system&#39;s control-based implementation. This model has been enhanced to support documenting how controls from an existing authorized system can be leveraged in another information system, which supports common control provider and platform as a service (PaaS) use cases.
 - Updated stable version of the [component definition](https://pages.nist.gov/OSCAL/documentation/schema/implementation-layer/component/) model which provides a structured representation of the controls that are supported in a given implementation of a hardware, software, service, policy, process, procedure, or compliance artifact (e.g., FIPS 140-2 validation).
 - Revised drafts of the [assessment plan](https://pages.nist.gov/OSCAL/documentation/schema/assessment-layer/assessment-plan/), [assessment results](https://pages.nist.gov/OSCAL/documentation/schema/assessment-results-layer/assessment-results/), [plan of action and milestones](https://pages.nist.gov/OSCAL/documentation/schema/assessment-results-layer/poam/) (POA&amp;M) models, which support the structured representation of information used for planning and documenting the results of an information system assessment or continuous monitoring activity. These models have been enhanced to better support continuous assessment; to provide more traceability between the assessment schedule, specific assessment activities, collected data, and resulting findings and identified risks; and to improve the extensibility of these models.
-- Updated tools to convert between OSCAL [XML](https://github.com/usnistgov/OSCAL/tree/master/xml) and [JSON](https://github.com/usnistgov/OSCAL/tree/master/json) formats, and to [up convert](https://github.com/usnistgov/OSCAL/tree/master/src/release/content-upgrade) content from milestone 3 to RC1.
+- Updated tools to convert between OSCAL [XML](https://github.com/usnistgov/OSCAL/tree/main/xml) and [JSON](https://github.com/usnistgov/OSCAL/tree/main/json) formats, and to [up convert](https://github.com/usnistgov/OSCAL/tree/main/src/release/content-upgrade) content from milestone 3 to RC1.
 
 These changes were made based on all the excellent feedback we received from the OSCAL community. The NIST OSCAL team is very thankful for all of the great feedback we have received.
 
@@ -127,7 +127,7 @@ This development phase provided updated stable versions of all OSCAL models, wit
 
 These changes were made based on all the excellent feedback we received from the OSCAL community. The NIST OSCAL team is very thankful for all of the great feedback we have received.
 
-Updated tools to convert between OSCAL [XML](https://github.com/usnistgov/OSCAL/tree/master/xml) and [JSON](https://github.com/usnistgov/OSCAL/tree/master/json) formats, and to [up convert](https://github.com/usnistgov/OSCAL/tree/master/src/release/content-upgrade) content from previous releases to RC2.
+Updated tools to convert between OSCAL [XML](https://github.com/usnistgov/OSCAL/tree/main/xml) and [JSON](https://github.com/usnistgov/OSCAL/tree/main/json) formats, and to [up convert](https://github.com/usnistgov/OSCAL/tree/main/src/release/content-upgrade) content from previous releases to RC2.
 
 This will be the final release candidate before the full release of OSCAL 1.0.0.
 

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -99,14 +99,11 @@
                 <enum value="content-approver">Indicates the organization responsible for all content represented in the "document".</enum>
             </allowed-values>
             <allowed-values target="link/@rel" allow-other="yes">
-                <enum value="canonical">The link identifies the authoritative location for this file.</enum>
-                <enum value="alternate">The link identifies an alternative location or format for this file.</enum>
-                <enum value="latest-version">This link identifies a resource containing the latest version in the version history. Defined by <a href="https://tools.ietf.org/html/rfc5829">RFC 5829</a>.
-                </enum>
-                <enum value="predecessor-version">This link identifies a resource containing the predecessor version in the version history. <a href="https://tools.ietf.org/html/rfc5829">RFC 5829</a>.
-                </enum>
-                <enum value="successor-version">This link identifies a resource containing the predecessor version in the version history. <a href="https://tools.ietf.org/html/rfc5829">RFC 5829</a>.
-                </enum>
+                <enum value="canonical">The link identifies the authoritative location for this file. Defined by <a href="https://tools.ietf.org/html/rfc6596">RFC 6596</a>.</enum>
+                <enum value="alternate">The link identifies an alternative location or format for this file. Defined by <a href="https://html.spec.whatwg.org/multipage/links.html#linkTypes">the HTML Living Standard</a></enum>
+                <enum value="latest-version">This link identifies a resource containing the latest version in the version history. Defined by <a href="https://tools.ietf.org/html/rfc5829">RFC 5829</a>.</enum>
+                <enum value="predecessor-version">This link identifies a resource containing the predecessor version in the version history. Defined by  <a href="https://tools.ietf.org/html/rfc5829">RFC 5829</a>.</enum>
+                <enum value="successor-version">This link identifies a resource containing the predecessor version in the version history. Defined by <a href="https://tools.ietf.org/html/rfc5829">RFC 5829</a>.</enum>
             </allowed-values>
         </constraint>
     </define-assembly>
@@ -132,9 +129,12 @@
             <field ref="remarks" in-xml="WITH_WRAPPER"/>
         </model>
         <constraint>
-            <has-cardinality target="published|last-modified|version|link[@rel='source']" min-occurs="1"/>
+            <has-cardinality target="published|last-modified|version|link[@rel='canonical']" min-occurs="1"/>
             <allowed-values target="link/@rel" allow-other="yes">
-                <enum value="source">Indicates that the href points to the source resource for the revision entry.</enum>
+                <enum value="canonical">The link identifies the authoritative location for this file. Defined by <a href="https://tools.ietf.org/html/rfc6596">RFC 6596</a>.</enum>
+                <enum value="alternate">The link identifies an alternative location or format for this file. Defined by <a href="https://html.spec.whatwg.org/multipage/links.html#linkTypes">the HTML Living Standard</a></enum>
+                <enum value="predecessor-version">This link identifies a resource containing the predecessor version in the version history. Defined by  <a href="https://tools.ietf.org/html/rfc5829">RFC 5829</a>.</enum>
+                <enum value="successor-version">This link identifies a resource containing the predecessor version in the version history. Defined by <a href="https://tools.ietf.org/html/rfc5829">RFC 5829</a>.</enum>
             </allowed-values>
         </constraint>
         <remarks>


### PR DESCRIPTION
# Committer Notes

- Added `canonical`, `alternate`, `predecessor-version`, and `successor-version` to `/o:metadata/o:revision/o:link/@rel`.
- Removed `source` for which `canonical` will be used instead from `/o:metadata/o:revision/o:link/@rel`.
- Fixed a couple references to `master` re-pointing them to `main`.

Resolves #919.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
