### PR TITLE
914 remove by key

### DIFF
--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -727,6 +727,14 @@
             </model>
          </define-assembly>
       </model>
+      <constraint>
+         <is-unique name="unique-ssp-assessment-assets-component" target="component">
+            <key-field target="@uuid"/>
+            <remarks>
+               <p>Since multiple assessment <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
+            </remarks>
+         </is-unique>
+      </constraint>
    </define-assembly>
 
    <!-- CHANGE: Removed exclude-activity assembly. Duplicating include-actviity assembly instead. -->

--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -669,7 +669,7 @@
       <model>
          <assembly ref="system-component" min-occurs="0" max-occurs="unbounded">
             <use-name>component</use-name>
-            <group-as name="components" in-json="BY_KEY"/>
+            <group-as name="components" in-json="ARRAY"/>
             <remarks>
                <p>Used to add any components for tools used during the assessment. These are represented here to avoid mixing with system components.</p>
                <p>The technology tools used by the assessor to perform the assessment, such as vulnerability scanners. In the assessment plan these are the intended tools. In the assessment results, these are the actual tools used, including any differences from the assessment plan.</p>

--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -156,13 +156,21 @@
                </assembly>
                <assembly ref="responsible-role" max-occurs="unbounded">
                   <!-- CHANGE: Removed "role-id" and "party-uuid" in favor of the standard "responsible-role". -->
-                  <group-as name="responsible-roles" in-json="BY_KEY"/>
+                  <group-as name="responsible-roles" in-json="ARRAY"/>
                   <remarks>
                      <p>Identifies the roles, and optionally the parties, associated with this step that is part of an assessment activity.</p>
                   </remarks>
                </assembly>
                <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
             </model>
+            <constraint>
+               <is-unique name="unique-step-responsible-role" target="responsible-role">
+                  <key-field target="role-id"/>
+                  <remarks>
+                     <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+                  </remarks>
+               </is-unique>
+            </constraint>
          </define-assembly>
          <assembly ref="reviewed-controls">
             <use-name>related-controls</use-name>
@@ -172,7 +180,7 @@
          </assembly>
          <assembly ref="responsible-role" max-occurs="unbounded">
             <!-- CHANGE: Removed "role-id" and "party-uuid" in favor of the standard "responsible-role". -->
-            <group-as name="responsible-roles" in-json="BY_KEY"/>
+            <group-as name="responsible-roles" in-json="ARRAY"/>
             <remarks>
                <p>Identifies the roles, and optionally the parties, associated with this assessment activity.</p>
             </remarks>
@@ -190,6 +198,12 @@
             <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
             <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
          </allowed-values>
+         <is-unique name="unique-activity-responsible-role" target="responsible-role">
+            <key-field target="role-id"/>
+            <remarks>
+               <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+            </remarks>
+         </is-unique>
       </constraint>
    </define-assembly>
 
@@ -309,7 +323,7 @@
                   <group-as name="links" in-json="ARRAY"/>
                </assembly>
                <assembly ref="responsible-role" max-occurs="unbounded">
-                  <group-as name="responsible-roles" in-json="BY_KEY"/>
+                  <group-as name="responsible-roles" in-json="ARRAY"/>
                   <remarks>
                      <p>Identifies the person or organization responsible for performing a specific role defined by the activity.</p>
                   </remarks>
@@ -325,6 +339,14 @@
                </choice>
                <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
             </model>
+            <constraint>
+               <is-unique name="unique-associated-activity-responsible-role" target="responsible-role">
+                  <key-field target="role-id"/>
+                  <remarks>
+                     <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+                  </remarks>
+               </is-unique>
+            </constraint>
          </define-assembly>
          <assembly ref="assessment-subject" max-occurs="unbounded">
             <use-name>subject</use-name>
@@ -334,7 +356,7 @@
             </remarks>
          </assembly>
          <assembly ref="responsible-role" max-occurs="unbounded">
-            <group-as name="responsible-roles" in-json="BY_KEY"/>
+            <group-as name="responsible-roles" in-json="ARRAY"/>
             <remarks>
                <p>Identifies the person or organization responsible for performing a specific role related to the task.</p>
             </remarks>

--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -182,7 +182,7 @@
             <!-- CHANGE: Removed "role-id" and "party-uuid" in favor of the standard "responsible-role". -->
             <group-as name="responsible-roles" in-json="ARRAY"/>
             <remarks>
-               <p>Identifies the roles, and optionally the parties, associated with this assessment activity.</p>
+               <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
             </remarks>
          </assembly>
          <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
@@ -201,7 +201,7 @@
          <is-unique name="unique-activity-responsible-role" target="responsible-role">
             <key-field target="@role-id"/>
             <remarks>
-               <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+               <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
             </remarks>
          </is-unique>
       </constraint>
@@ -343,7 +343,7 @@
                <is-unique name="unique-associated-activity-responsible-role" target="responsible-role">
                   <key-field target="@role-id"/>
                   <remarks>
-                     <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+                     <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
                   </remarks>
                </is-unique>
             </constraint>
@@ -710,13 +710,18 @@
                         <group-as name="links" in-json="ARRAY"/>
                      </assembly>
                      <assembly ref="responsible-party" max-occurs="unbounded">
-                        <group-as name="responsible-parties" in-json="BY_KEY"/>
-                        <remarks>
-                           <p>This construct is used to either: 1) associate a party or parties to a role defined on the component using the <code>responsible-role</code> construct, or 2) to define a party or parties that are responsible for a role defined within the context of the containing <code>inventory-item</code>.</p>
-                        </remarks>
+                        <group-as name="responsible-parties" in-json="ARRAY"/>
                      </assembly>
                      <field ref="remarks" in-xml="WITH_WRAPPER"/>
                   </model>
+                  <constraint>
+                     <is-unique name="unique-ssp-uses-component-responsible-party" target="responsible-party">
+                        <key-field target="@role-id"/>
+                        <remarks>
+                           <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                        </remarks>
+                     </is-unique>
+                  </constraint>
                </define-assembly>
                <field ref="remarks" in-xml="WITH_WRAPPER"/>
             </model>
@@ -971,7 +976,7 @@
             <group-as name="links" in-json="ARRAY"/>
          </assembly>
          <assembly ref="responsible-party" max-occurs="unbounded">
-            <group-as name="responsible-parties" in-json="BY_KEY"/>
+            <group-as name="responsible-parties" in-json="ARRAY"/>
             <remarks>
                <p>Identifies the person or organization responsible for performing a specific role defined by the activity.</p>
             </remarks>
@@ -1004,6 +1009,14 @@
          </define-assembly>
          <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
       </model>
+      <constraint>
+         <is-unique name="unique-ssp-related-task-responsible-party" target="responsible-party">
+            <key-field target="@role-id"/>
+            <remarks>
+               <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+            </remarks>
+         </is-unique>
+      </constraint>
    </define-assembly>
 
    <define-field name="threat-id" as-type="uri">

--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -165,7 +165,7 @@
             </model>
             <constraint>
                <is-unique name="unique-step-responsible-role" target="responsible-role">
-                  <key-field target="role-id"/>
+                  <key-field target="@role-id"/>
                   <remarks>
                      <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
                   </remarks>
@@ -199,7 +199,7 @@
             <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
          </allowed-values>
          <is-unique name="unique-activity-responsible-role" target="responsible-role">
-            <key-field target="role-id"/>
+            <key-field target="@role-id"/>
             <remarks>
                <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
             </remarks>
@@ -341,7 +341,7 @@
             </model>
             <constraint>
                <is-unique name="unique-associated-activity-responsible-role" target="responsible-role">
-                  <key-field target="role-id"/>
+                  <key-field target="@role-id"/>
                   <remarks>
                      <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
                   </remarks>

--- a/src/metaschema/oscal_assessment-plan_metaschema.xml
+++ b/src/metaschema/oscal_assessment-plan_metaschema.xml
@@ -67,7 +67,7 @@
                 </model>
                 <constraint>
                     <is-unique name="unique-ap-local-definitions-user" target="user">
-                        <key-field target="uuid"/>
+                        <key-field target="@uuid"/>
                         <remarks>
                             <p>A given <code>uuid</code> must be assigned only once to a user.</p>
                         </remarks>

--- a/src/metaschema/oscal_assessment-plan_metaschema.xml
+++ b/src/metaschema/oscal_assessment-plan_metaschema.xml
@@ -48,7 +48,7 @@
                     </assembly>
                     <assembly ref="system-user" min-occurs="0" max-occurs="unbounded">
                         <use-name>user</use-name>
-                        <group-as name="users" in-json="BY_KEY"/>
+                        <group-as name="users" in-json="ARRAY"/>
                         <remarks>
                             <p>Used to add any users, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
                         </remarks>
@@ -65,6 +65,14 @@
                     </assembly>
                     <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
                 </model>
+                <constraint>
+                    <is-unique name="unique-ap-local-definitions-user" target="user">
+                        <key-field target="uuid"/>
+                        <remarks>
+                            <p>A given <code>uuid</code> must be assigned only once to a user.</p>
+                        </remarks>
+                    </is-unique>
+                </constraint>
             </define-assembly>
             <define-assembly name="terms-and-conditions">
                 <formal-name>Assessment Plan Terms and Conditions</formal-name>

--- a/src/metaschema/oscal_assessment-plan_metaschema.xml
+++ b/src/metaschema/oscal_assessment-plan_metaschema.xml
@@ -35,7 +35,7 @@
                 <model>
                     <assembly ref="system-component" min-occurs="0" max-occurs="unbounded">
                         <use-name>component</use-name>
-                        <group-as name="components" in-json="BY_KEY"/>
+                        <group-as name="components" in-json="ARRAY"/>
                         <remarks>
                             <p>Used to add any components, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
                         </remarks>
@@ -66,6 +66,12 @@
                     <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
                 </model>
                 <constraint>
+                    <is-unique name="unique-ap-local-definitions-component" target="component">
+                        <key-field target="@uuid"/>
+                        <remarks>
+                            <p>Since multiple <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
+                        </remarks>
+                    </is-unique>
                     <is-unique name="unique-ap-local-definitions-user" target="user">
                         <key-field target="@uuid"/>
                         <remarks>

--- a/src/metaschema/oscal_assessment-results_metaschema.xml
+++ b/src/metaschema/oscal_assessment-results_metaschema.xml
@@ -141,7 +141,7 @@
         </model>
         <constraint>
           <is-unique name="unique-ar-local-definitions-user" target="user">
-            <key-field target="uuid"/>
+            <key-field target="@uuid"/>
             <remarks>
               <p>A given <code>uuid</code> must be assigned only once to a user.</p>
             </remarks>
@@ -153,8 +153,7 @@
         <remarks>
           <p>The Assessment Results <code>control-selection</code> ignores any control selection in the Assessment Plan and re-selects controls from the baseline identified by the SSP.</p>
           <p>The Assessment Results <code>control-objective-selection</code> ignores any control objective selection in the Assessment Plan and re-selects control objectives from the baseline identified by the SSP.</p>
-          <p>Any additional control objectives defined in the Assessment Plan <code>local-definitions</code> do not need to be re-defined in the Assessment Results <code>local-definitions</code>; however, if they were explicitly referenced with an Assessment Plan <code>control-objective-selection</code>, they need to be selected again in the Assessment Results <code>control-objective-selection</code>.
-          </p>
+          <p>Any additional control objectives defined in the Assessment Plan <code>local-definitions</code> do not need to be re-defined in the Assessment Results <code>local-definitions</code>; however, if they were explicitly referenced with an Assessment Plan <code>control-objective-selection</code>, they need to be selected again in the Assessment Results <code>control-objective-selection</code>.</p>
         </remarks>
       </assembly>
 

--- a/src/metaschema/oscal_assessment-results_metaschema.xml
+++ b/src/metaschema/oscal_assessment-results_metaschema.xml
@@ -163,7 +163,7 @@
         <group-as name="attestations" in-json="ARRAY"/>
         <model>
           <assembly ref="responsible-party" max-occurs="unbounded">
-            <group-as name="responsible-parties" in-json="BY_KEY"/>
+            <group-as name="responsible-parties" in-json="ARRAY"/>
           </assembly>
           <assembly ref="assessment-part" min-occurs="1" max-occurs="unbounded">
             <!-- TODO: defined allowed parts: authorization-statement -->
@@ -171,6 +171,14 @@
             <group-as name="parts" in-json="ARRAY"/>
           </assembly>
         </model>
+        <constraint>
+          <is-unique name="unique-ar-attestation-responsible-party" target="responsible-party">
+            <key-field target="@role-id"/>
+            <remarks>
+              <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+            </remarks>
+          </is-unique>
+        </constraint>
       </define-assembly>
       <!-- CHANGED: removed "schedule" and replaced with "assessment-log" -->
       <define-assembly name="assessment-log">

--- a/src/metaschema/oscal_assessment-results_metaschema.xml
+++ b/src/metaschema/oscal_assessment-results_metaschema.xml
@@ -121,7 +121,7 @@
           </assembly>
           <assembly ref="system-user" min-occurs="0" max-occurs="unbounded">
             <use-name>user</use-name>
-            <group-as name="users" in-json="BY_KEY"/>
+            <group-as name="users" in-json="ARRAY"/>
             <remarks>
               <p>Used to add any users, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
             </remarks>
@@ -139,6 +139,14 @@
             <group-as name="tasks" in-json="ARRAY"/>
           </assembly>
         </model>
+        <constraint>
+          <is-unique name="unique-ar-local-definitions-user" target="user">
+            <key-field target="uuid"/>
+            <remarks>
+              <p>A given <code>uuid</code> must be assigned only once to a user.</p>
+            </remarks>
+          </is-unique>
+        </constraint>
       </define-assembly>
       <!-- CHANGED: "objectives" to "reviewed-controls" -->
       <assembly ref="reviewed-controls" min-occurs="1" max-occurs="1">

--- a/src/metaschema/oscal_assessment-results_metaschema.xml
+++ b/src/metaschema/oscal_assessment-results_metaschema.xml
@@ -108,7 +108,7 @@
         <model>
           <assembly ref="system-component" min-occurs="0" max-occurs="unbounded">
             <use-name>component</use-name>
-            <group-as name="components" in-json="BY_KEY"/>
+            <group-as name="components" in-json="ARRAY"/>
             <remarks>
               <p>Used to add any components, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
             </remarks>
@@ -140,6 +140,12 @@
           </assembly>
         </model>
         <constraint>
+          <is-unique name="unique-ar-local-definitions-component" target="component">
+            <key-field target="@uuid"/>
+            <remarks>
+              <p>Since multiple <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
+            </remarks>
+          </is-unique>
           <is-unique name="unique-ar-local-definitions-user" target="user">
             <key-field target="@uuid"/>
             <remarks>

--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -368,7 +368,7 @@
         <group-as name="responsible-roles" in-json="ARRAY"/>
       </assembly>
       <assembly ref="statement" max-occurs="unbounded">
-        <group-as name="statements" in-json="BY_KEY"/>
+        <group-as name="statements" in-json="ARRAY"/>
       </assembly>
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
@@ -379,12 +379,17 @@
           <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
+      <is-unique name="unique-component-definition-implemented-requirement-statement" target="statement">
+        <key-field target="statement-id"/>
+        <remarks>
+          <p>Since <code>statement</code> entries can be referenced using the statement's statement-id, each statement must be referenced only once.</p>
+        </remarks>
+      </is-unique>
     </constraint>
   </define-assembly>
   <define-assembly name="statement" scope="local">
     <formal-name>Control Statement Implementation</formal-name>
     <description>Identifies which statements within a control are addressed.</description>
-    <json-key flag-name="statement-id"/>
     <flag ref="statement-id" required="yes">
       <remarks>
         <p>A reference to the specific implemented statement associated with a control.</p>

--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -278,7 +278,7 @@
         -->
       </assembly>
       <assembly ref="incorporates-component" max-occurs="unbounded">
-        <group-as name="incorporates-components" in-json="BY_KEY"/>
+        <group-as name="incorporates-components" in-json="ARRAY"/>
       </assembly>
       <assembly ref="control-implementation" max-occurs="unbounded">
         <group-as name="control-implementations" in-json="ARRAY"/>
@@ -289,9 +289,18 @@
 -->
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
+    <constraint>
+      <is-unique name="unique-component-definition-capability-incorporates-component" target="incorporates-component">
+        <key-field target="component-uuid"></key-field>
+        <remarks>
+          <p>A given <code>component</code> must not be referenced more than once within the same <code>capability</code>.</p>
+        </remarks>
+      </is-unique>
+    </constraint>
   </define-assembly>
   <define-assembly name="incorporates-component">
     <formal-name>Incorporates Component</formal-name>
+    <!-- TODO: needs a description -->
     <description>TBD</description>
     <json-key flag-name="component-uuid"/>
     <define-flag required="yes" name="component-uuid" as-type="uuid">

--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -98,7 +98,7 @@
       </assembly>
       <assembly ref="responsible-role" max-occurs="unbounded">
         <!-- CHANGE: from responsible-party to responsible-role -->
-        <group-as name="responsible-roles" in-json="BY_KEY"/>
+        <group-as name="responsible-roles" in-json="ARRAY"/>
       </assembly>
       <assembly ref="protocol" max-occurs="unbounded">
         <!-- TODO: protocol (tcp/UDP), port range, service name, purpose, used by -->
@@ -225,7 +225,12 @@
       <!-- =       If interconnection is not appropriate for component-defintion, we'll need different = -->
       <!-- =           component-type lists for the two models.                                        = -->
       <!-- ========================================================================================================== -->
-
+      <is-unique name="unique-defined-component-responsible-role" target="responsible-role">
+        <key-field target="role-id"/>
+        <remarks>
+          <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+        </remarks>
+      </is-unique>
     </constraint>
     <remarks>
       <p>Components may be products, services, APIs, policies, processes, plans, guidance, standards, or other tangible items that enable security and/or privacy.</p>
@@ -332,6 +337,7 @@
         <group-as name="implemented-requirements" in-json="ARRAY"/>
       </assembly>
     </model>
+    <constraint></constraint>
     <remarks>
       <p>Use of <code>set-parameter</code> in this context, sets the parameter for all related controls referenced in an <code>implemented-requirement</code>. If the same parameter is also set in a specific <code>implemented-requirement</code>, then the new value will override this value.</p>
     </remarks>
@@ -354,25 +360,28 @@
       </assembly>
       <assembly ref="link" max-occurs="unbounded">
         <group-as name="links" in-json="ARRAY"/>
-        <!-- TODO: Model specific link relationships -->
-      </assembly>
-      <!--
-         <assembly ref="using"/>
--->
-      <!-- TODO: Implement parameters -->
-      <assembly ref="responsible-role" max-occurs="unbounded">
-        <group-as name="responsible-roles" in-json="BY_KEY"/>
       </assembly>
       <assembly ref="set-parameter" max-occurs="unbounded">
         <group-as name="set-parameters" in-json="BY_KEY"/>
+      </assembly>
+      <assembly ref="responsible-role" max-occurs="unbounded">
+        <group-as name="responsible-roles" in-json="ARRAY"/>
       </assembly>
       <assembly ref="statement" max-occurs="unbounded">
         <group-as name="statements" in-json="BY_KEY"/>
       </assembly>
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
+    <constraint>
+      <is-unique name="unique-component-definition-implemented-requirement-responsible-role" target="responsible-role">
+        <key-field target="role-id"/>
+        <remarks>
+          <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+        </remarks>
+      </is-unique>
+    </constraint>
   </define-assembly>
-  <define-assembly name="statement">
+  <define-assembly name="statement" scope="local">
     <formal-name>Control Statement Implementation</formal-name>
     <description>Identifies which statements within a control are addressed.</description>
     <json-key flag-name="statement-id"/>
@@ -382,8 +391,8 @@
       </remarks>
     </flag>
     <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>Control Statement Implementation Identifier</formal-name>
-      <description>A unique identifier for a specific control implementation.</description>
+      <formal-name>Control Statement Reference Universally Unique Identifier</formal-name>
+      <description>A globally unique identifier that can be used to reference this control statement entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.</description>
     </define-flag>
     <model>
       <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
@@ -395,20 +404,20 @@
       </assembly>
       <assembly ref="link" max-occurs="unbounded">
         <group-as name="links" in-json="ARRAY"/>
-        <!-- TODO: Model specific link relationships -->
       </assembly>
-      <!--            <assembly ref="using"/>
--->
-      <!-- TODO: Implement parameters -->
       <assembly ref="responsible-role" max-occurs="unbounded">
-        <group-as name="responsible-roles" in-json="BY_KEY"/>
+        <group-as name="responsible-roles" in-json="ARRAY"/>
       </assembly>
-      <!--         <assembly ref="by-capability" max-occurs="unbounded">
-            <group-as name="by-capabilities" in-json="BY_KEY"/>
-         </assembly>
--->
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
+    <constraint>
+      <is-unique name="unique-component-definition-statement-responsible-role" target="responsible-role">
+        <key-field target="role-id"/>
+        <remarks>
+          <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+        </remarks>
+      </is-unique>
+    </constraint>
   </define-assembly>
   <!--
   <define-assembly name="supported-profile">

--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -344,13 +344,20 @@
         <!-- TODO: Model specific link relationships -->
       </assembly>
       <assembly ref="set-parameter" max-occurs="unbounded">
-        <group-as name="set-parameters" in-json="BY_KEY"/>
+        <group-as name="set-parameters" in-json="ARRAY"/>
       </assembly>
       <assembly ref="implemented-requirement" min-occurs="1" max-occurs="unbounded">
         <group-as name="implemented-requirements" in-json="ARRAY"/>
       </assembly>
     </model>
-    <constraint></constraint>
+    <constraint>
+      <is-unique name="unique-component-definition-control-implementation-set-parameter" target="set-parameter">
+        <key-field target="@param-id"/>
+        <remarks>
+          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+        </remarks>
+      </is-unique>
+    </constraint>
     <remarks>
       <p>Use of <code>set-parameter</code> in this context, sets the parameter for all related controls referenced in an <code>implemented-requirement</code>. If the same parameter is also set in a specific <code>implemented-requirement</code>, then the new value will override this value.</p>
     </remarks>
@@ -375,7 +382,7 @@
         <group-as name="links" in-json="ARRAY"/>
       </assembly>
       <assembly ref="set-parameter" max-occurs="unbounded">
-        <group-as name="set-parameters" in-json="BY_KEY"/>
+        <group-as name="set-parameters" in-json="ARRAY"/>
       </assembly>
       <assembly ref="responsible-role" max-occurs="unbounded">
         <group-as name="responsible-roles" in-json="ARRAY"/>
@@ -386,6 +393,12 @@
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
     <constraint>
+      <is-unique name="unique-component-definition-implemented-requirement-set-parameter" target="set-parameter">
+        <key-field target="@param-id"/>
+        <remarks>
+          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+        </remarks>
+      </is-unique>
       <is-unique name="unique-component-definition-implemented-requirement-responsible-role" target="responsible-role">
         <key-field target="@role-id"/>
         <remarks>

--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -234,7 +234,7 @@
       <is-unique name="unique-defined-component-responsible-role" target="responsible-role">
         <key-field target="@role-id"/>
         <remarks>
-          <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+          <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
     </constraint>
@@ -402,7 +402,7 @@
       <is-unique name="unique-component-definition-implemented-requirement-responsible-role" target="responsible-role">
         <key-field target="@role-id"/>
         <remarks>
-          <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+          <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
       <is-unique name="unique-component-definition-implemented-requirement-statement" target="statement">
@@ -445,7 +445,7 @@
       <is-unique name="unique-component-definition-statement-responsible-role" target="responsible-role">
         <key-field target="@role-id"/>
         <remarks>
-          <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+          <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
     </constraint>

--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -44,7 +44,7 @@
         <group-as name="components" in-json="BY_KEY"/>
       </assembly>
       <assembly ref="capability" max-occurs="unbounded">
-        <group-as name="capabilities" in-json="BY_KEY"/>
+        <group-as name="capabilities" in-json="ARRAY"/>
       </assembly>
       <assembly ref="back-matter"/>
     </model>
@@ -52,6 +52,12 @@
       <index name="index-system-component-uuid" target="component">
         <key-field target="@uuid"/>
       </index>
+      <is-unique name="unique-component-definition-capability" target="capability">
+        <key-field target="@uuid"/>
+        <remarks>
+          <p>A given <code>component</code> must not be referenced more than once within the same <code>capability</code>.</p>
+        </remarks>
+      </is-unique>
     </constraint>
   </define-assembly>
 
@@ -226,7 +232,7 @@
       <!-- =           component-type lists for the two models.                                        = -->
       <!-- ========================================================================================================== -->
       <is-unique name="unique-defined-component-responsible-role" target="responsible-role">
-        <key-field target="role-id"/>
+        <key-field target="@role-id"/>
         <remarks>
           <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
         </remarks>
@@ -253,7 +259,6 @@
   <define-assembly name="capability">
     <formal-name>Capability</formal-name>
     <description>A grouping of other components and/or capabilities.</description>
-    <json-key flag-name="uuid"/>
     <define-flag required="yes" name="uuid" as-type="uuid">
       <formal-name>Capability Identifier</formal-name>
       <description>A unique identifier for a capability.</description>
@@ -291,7 +296,7 @@
     </model>
     <constraint>
       <is-unique name="unique-component-definition-capability-incorporates-component" target="incorporates-component">
-        <key-field target="component-uuid"></key-field>
+        <key-field target="@component-uuid"></key-field>
         <remarks>
           <p>A given <code>component</code> must not be referenced more than once within the same <code>capability</code>.</p>
         </remarks>
@@ -302,7 +307,6 @@
     <formal-name>Incorporates Component</formal-name>
     <!-- TODO: needs a description -->
     <description>TBD</description>
-    <json-key flag-name="component-uuid"/>
     <define-flag required="yes" name="component-uuid" as-type="uuid">
       <formal-name>Component Reference</formal-name>
       <description>A reference to a component by its identifier</description>
@@ -383,13 +387,13 @@
     </model>
     <constraint>
       <is-unique name="unique-component-definition-implemented-requirement-responsible-role" target="responsible-role">
-        <key-field target="role-id"/>
+        <key-field target="@role-id"/>
         <remarks>
           <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
       <is-unique name="unique-component-definition-implemented-requirement-statement" target="statement">
-        <key-field target="statement-id"/>
+        <key-field target="@statement-id"/>
         <remarks>
           <p>Since <code>statement</code> entries can be referenced using the statement's statement-id, each statement must be referenced only once.</p>
         </remarks>
@@ -426,7 +430,7 @@
     </model>
     <constraint>
       <is-unique name="unique-component-definition-statement-responsible-role" target="responsible-role">
-        <key-field target="role-id"/>
+        <key-field target="@role-id"/>
         <remarks>
           <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
         </remarks>

--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -41,7 +41,7 @@
       </assembly>
       <assembly ref="defined-component" max-occurs="unbounded">
         <use-name>component</use-name>
-        <group-as name="components" in-json="BY_KEY"/>
+        <group-as name="components" in-json="ARRAY"/>
       </assembly>
       <assembly ref="capability" max-occurs="unbounded">
         <group-as name="capabilities" in-json="ARRAY"/>
@@ -51,6 +51,9 @@
     <constraint>
       <index name="index-system-component-uuid" target="component">
         <key-field target="@uuid"/>
+        <remarks>
+          <p>Since multiple <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
+        </remarks>
       </index>
       <is-unique name="unique-component-definition-capability" target="capability">
         <key-field target="@uuid"/>
@@ -73,7 +76,6 @@
   <define-assembly name="defined-component">
     <formal-name>Component</formal-name>
     <description>A defined component that can be part of an implemented system.</description>
-    <json-key flag-name="uuid"/>
     <define-flag name="uuid" as-type="uuid" required="yes">
       <formal-name>Component Identifier</formal-name>
       <description>The unique identifier for the component.</description>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -75,7 +75,7 @@
                         </model>
                   </define-assembly>
                   <assembly ref="responsible-role" max-occurs="unbounded">
-                        <group-as name="responsible-roles" in-json="BY_KEY"/>
+                        <group-as name="responsible-roles" in-json="ARRAY"/>
                   </assembly>
                   <assembly ref="protocol" max-occurs="unbounded">
                         <group-as name="protocols" in-json="ARRAY"/>
@@ -215,7 +215,12 @@
                         <enum value="incoming">Data from the remote system flows into this system.</enum>
                         <enum value="outgoing">Data from this system flows to the remote system.</enum>
                   </allowed-values>
-
+                  <is-unique name="unique-system-component-responsible-role" target="responsible-role">
+                        <key-field target="role-id"/>
+                        <remarks>
+                              <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+                        </remarks>
+                  </is-unique>
             </constraint>
             <remarks>
                   <p>Components may be products, services, application programming interface (APIs), policies, processes, plans, guidance, standards, or other tangible items that enable security and/or privacy.</p>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../build/metaschema/toolchains/xslt-M4/validate/metaschema-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <!DOCTYPE METASCHEMA [
-   <!ENTITY allowed-values-responsible-roles-operations SYSTEM "shared-constraints/allowed-values-responsible-roles-operations.ent">
-<!ENTITY allowed-values-responsible-roles-component-production SYSTEM "shared-constraints/allowed-values-responsible-roles-component-production.ent">
-<!ENTITY allowed-values-property-name-asset-type-values SYSTEM "shared-constraints/allowed-values-property-name-asset-type-values.ent">
-<!ENTITY allowed-values-component_component_property-name SYSTEM "shared-constraints/allowed-values-component_component_property-name.ent">
-<!ENTITY allowed-values-component_component_software SYSTEM "shared-constraints/allowed-values-component_component_software.ent">
-<!ENTITY allowed-values-component_component_service SYSTEM "shared-constraints/allowed-values-component_component_service.ent">
-<!ENTITY allowed-values-component_inventory-item_property-name SYSTEM "shared-constraints/allowed-values-component_inventory-item_property-name.ent">
-<!ENTITY allowed-values-component_component_link-rel SYSTEM "shared-constraints/allowed-values-component_component_link-rel.ent">
-<!ENTITY allowed-values-component-type SYSTEM "shared-constraints/allowed-values-component-type.ent">
+      <!ENTITY allowed-values-responsible-roles-operations SYSTEM "shared-constraints/allowed-values-responsible-roles-operations.ent">
+      <!ENTITY allowed-values-responsible-roles-component-production SYSTEM "shared-constraints/allowed-values-responsible-roles-component-production.ent">
+      <!ENTITY allowed-values-property-name-asset-type-values SYSTEM "shared-constraints/allowed-values-property-name-asset-type-values.ent">
+      <!ENTITY allowed-values-component_component_property-name SYSTEM "shared-constraints/allowed-values-component_component_property-name.ent">
+      <!ENTITY allowed-values-component_component_software SYSTEM "shared-constraints/allowed-values-component_component_software.ent">
+      <!ENTITY allowed-values-component_component_service SYSTEM "shared-constraints/allowed-values-component_component_service.ent">
+      <!ENTITY allowed-values-component_inventory-item_property-name SYSTEM "shared-constraints/allowed-values-component_inventory-item_property-name.ent">
+      <!ENTITY allowed-values-component_component_link-rel SYSTEM "shared-constraints/allowed-values-component_component_link-rel.ent">
+      <!ENTITY allowed-values-component-type SYSTEM "shared-constraints/allowed-values-component-type.ent">
 ]>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd" abstract="yes">
@@ -27,7 +27,6 @@
       <define-assembly name="system-component">
             <formal-name>Component</formal-name>
             <description>A defined component that can be part of an implemented system.</description>
-            <json-key flag-name="uuid"/>
             <define-flag name="uuid" as-type="uuid" required="yes">
                   <formal-name>Component Identifier</formal-name>
                   <description>The unique identifier for the component.</description>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -216,7 +216,7 @@
                         <enum value="outgoing">Data from this system flows to the remote system.</enum>
                   </allowed-values>
                   <is-unique name="unique-system-component-responsible-role" target="responsible-role">
-                        <key-field target="role-id"/>
+                        <key-field target="@role-id"/>
                         <remarks>
                               <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
                         </remarks>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -335,7 +335,6 @@
       <define-assembly name="system-user">
             <formal-name>System User</formal-name>
             <description>A type of user that interacts with the system based on an associated role.</description>
-            <json-key flag-name="uuid"/>
             <define-flag name="uuid" as-type="uuid" required="yes">
                   <formal-name>User Universally Unique Identifier</formal-name>
                   <description>The unique identifier for the user class.</description>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -624,7 +624,6 @@
       <define-assembly name="set-parameter">
             <formal-name>Set Parameter Value</formal-name>
             <description>Identifies the parameter that will be set by the enclosed value.</description>
-            <json-key flag-name="param-id"/>
             <flag ref="param-id" required="yes"/>
             <model>
                   <define-field name="parameter-value" as-type="string" min-occurs="1" max-occurs="unbounded">

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -218,7 +218,7 @@
                   <is-unique name="unique-system-component-responsible-role" target="responsible-role">
                         <key-field target="@role-id"/>
                         <remarks>
-                              <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+                              <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
                         </remarks>
                   </is-unique>
             </constraint>
@@ -442,7 +442,7 @@
                         <group-as name="links" in-json="ARRAY"/>
                   </assembly>
                   <assembly ref="responsible-party" max-occurs="unbounded">
-                        <group-as name="responsible-parties" in-json="BY_KEY"/>
+                        <group-as name="responsible-parties" in-json="ARRAY"/>
                   </assembly>
                   <define-assembly name="implemented-component" max-occurs="unbounded">
                         <!-- TODO: Sync constraints with system-component; maybe remove this? (CHANGED (BJR): Dave-See Gitter for details on this. -->
@@ -482,7 +482,7 @@
                                     <group-as name="links" in-json="ARRAY"/>
                               </assembly>
                               <assembly ref="responsible-party" max-occurs="unbounded">
-                                    <group-as name="responsible-parties" in-json="BY_KEY"/>
+                                    <group-as name="responsible-parties" in-json="ARRAY"/>
                                     <remarks>
                                           <p>This construct is used to either: 1) associate a party or parties to a role defined on the component using the <code>responsible-role</code> construct, or 2) to define a party or parties that are responsible for a role defined within the context of the containing <code>inventory-item</code>.
                                           </p>
@@ -510,6 +510,12 @@
 
                               <!-- TODO: constrain party-id references to parties defined in the document. (BJR Unsure how to do this. )-->
 
+                              <is-unique name="unique-implemented-component-responsible-party" target="responsible-party">
+                                    <key-field target="@role-id"/>
+                                    <remarks>
+                                          <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                                    </remarks>
+                              </is-unique>
                         </constraint>
                   </define-assembly>
                   <field ref="remarks" in-xml="WITH_WRAPPER"/>
@@ -577,6 +583,12 @@
                   <index-has-key name="index-metadata-party-uuid" target="responsible-party">
                         <key-field target="@party-uuid"></key-field>
                   </index-has-key>
+                  <is-unique name="unique-inventory-item-responsible-party" target="responsible-party">
+                        <key-field target="@role-id"/>
+                        <remarks>
+                              <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                        </remarks>
+                  </is-unique>
             </constraint>
       </define-assembly>
 

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -730,7 +730,6 @@
     <define-assembly name="responsible-role">
         <formal-name>Responsible Role</formal-name>
         <description>A reference to one or more roles with responsibility for performing a function relative to the containing object.</description>
-        <json-key flag-name="role-id"/>
         <define-flag name="role-id" as-type="NCName" required="yes">
             <formal-name>Responsible Role ID</formal-name>
             <description>The role that is responsible for the business function.</description>

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -49,7 +49,7 @@
                 <group-as name="parties" in-json="ARRAY"/>
             </assembly>
             <assembly ref="responsible-party" max-occurs="unbounded">
-                <group-as name="responsible-parties" in-json="BY_KEY"/>
+                <group-as name="responsible-parties" in-json="ARRAY"/>
             </assembly>
             <field ref="remarks" in-xml="WITH_WRAPPER"/>
         </model>
@@ -93,6 +93,12 @@
             <index id="index-metadata-party-organizations-uuid" name="index-metadata-party-organizations-uuid" target="party[@type='organization']">
                 <key-field target="@uuid"/>
             </index>
+            <is-unique name="unique-metadata-responsible-party" target="responsible-party">
+                <key-field target="@role-id"/>
+                <remarks>
+                    <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </is-unique>
             <allowed-values id="allowed-metadata-responsibe-party-role-ids" target="responsible-party/@role-id" allow-other="yes">
                 <enum value="prepared-by">Indicates the organization that created this content.</enum>
                 <enum value="prepared-for">Indicates the organization for which this content was created.</enum>
@@ -697,7 +703,6 @@
     <define-assembly name="responsible-party">
         <formal-name>Responsible Party</formal-name>
         <description>A reference to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object.</description>
-        <json-key flag-name="role-id"/>
         <define-flag required="yes" name="role-id" as-type="NCName">
             <formal-name>Responsible Role</formal-name>
             <description>The role that the party is responsible for.</description>

--- a/src/metaschema/oscal_poam_metaschema.xml
+++ b/src/metaschema/oscal_poam_metaschema.xml
@@ -59,7 +59,7 @@
         <model>
             <assembly ref="system-component" min-occurs="0" max-occurs="unbounded">
                 <use-name>component</use-name>
-                <group-as name="components" in-json="BY_KEY"/>
+                <group-as name="components" in-json="ARRAY"/>
                 <remarks>
                     <p>Used to add any components, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
                 </remarks>
@@ -72,6 +72,14 @@
             </assembly>
             <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
         </model>
+        <constraint>
+            <is-unique name="unique-poam-local-definitions-component" target="component">
+                <key-field target="@uuid"/>
+                <remarks>
+                    <p>Since multiple <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
     </define-assembly>
 
     <define-assembly name="poam-item">

--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -189,7 +189,7 @@
             <formal-name>Modify controls</formal-name>
             <description>Set parameters or amend controls in resolution</description>
             <model>
-                  <define-assembly name="set-parameter">
+                  <define-assembly name="set-parameter" max-occurs="unbounded">
                         <formal-name>Parameter Setting</formal-name>
                         <description>A parameter setting, to be propagated to points of insertion</description>
                         <json-key flag-name="param-id"/>

--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -192,8 +192,7 @@
                   <define-assembly name="set-parameter" max-occurs="unbounded">
                         <formal-name>Parameter Setting</formal-name>
                         <description>A parameter setting, to be propagated to points of insertion</description>
-                        <json-key flag-name="param-id"/>
-                        <group-as name="set-parameters" in-json="BY_KEY"/>
+                        <group-as name="set-parameters" in-json="ARRAY"/>
                         <define-flag required="yes" name="param-id" as-type="NCName">
                               <!-- This is an id because the idenfier is assigned and managed by humans. -->
                               <formal-name>Parameter ID</formal-name>
@@ -246,6 +245,14 @@
                                     </assembly>
                               </choice>
                         </model>
+                        <constraint>
+                              <is-unique name="unique-profile-modify-set-parameter" target="set-parameter">
+                                    <key-field target="@param-id"/>
+                                    <remarks>
+                                          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+                                    </remarks>
+                              </is-unique>
+                        </constraint>
                   </define-assembly>
                   <assembly ref="alter" max-occurs="unbounded">
                         <group-as name="alters" in-json="ARRAY"/>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -391,7 +391,7 @@
     </model>
     <constraint>
       <is-unique name="unique-ssp-authorization-boundary-diagram" target="diagram">
-        <key-field target="uuid"/>
+        <key-field target="@uuid"/>
         <remarks>
           <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
         </remarks>
@@ -401,7 +401,6 @@
   <define-assembly name="diagram">
     <formal-name>Diagram</formal-name>
     <description>A graphic that provides a visual representation the system, or some aspect of it.</description>
-    <json-key flag-name="uuid"/>
     <define-flag name="uuid" as-type="uuid" required="yes">
       <formal-name>Diagram ID</formal-name>
       <description>The identifier for this diagram.</description>
@@ -475,7 +474,7 @@
     </model>
     <constraint>
       <is-unique name="unique-ssp-network-architecture-diagram" target="diagram">
-        <key-field target="uuid"/>
+        <key-field target="@uuid"/>
         <remarks>
           <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
         </remarks>
@@ -505,7 +504,7 @@
     </model>
     <constraint>
       <is-unique name="unique-ssp-data-flow-diagram" target="diagram">
-        <key-field target="uuid"/>
+        <key-field target="@uuid"/>
         <remarks>
           <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
         </remarks>
@@ -638,7 +637,7 @@
       <!-- TODO: only allow a single "this-system" component -->
 
       <is-unique name="unique-ssp-system-implementation-user" target="user">
-        <key-field target="uuid"/>
+        <key-field target="@uuid"/>
         <remarks>
           <p>A given <code>uuid</code> must be assigned only once to a user.</p>
         </remarks>
@@ -725,19 +724,19 @@
         </remarks>
       </has-cardinality>
       <is-unique name="unique-ssp-implemented-requirement-responsible-role" target="responsible-role">
-        <key-field target="role-id"/>
+        <key-field target="@role-id"/>
         <remarks>
           <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
       <is-unique name="unique-ssp-implemented-requirement-statement" target="statement">
-        <key-field target="statement-id"/>
+        <key-field target="@statement-id"/>
         <remarks>
           <p>Since <code>statement</code> entries can be referenced using the statement's statement-id, each statement must be referenced only once.</p>
         </remarks>
       </is-unique>
       <is-unique name="unique-ssp-implemented-requirement-by-component" target="by-component">
-        <key-field target="component-uuid"/>
+        <key-field target="@component-uuid"/>
         <remarks>
           <p>Since <code>by-component</code> can reference <code>component</code> entries using the component's uuid, each component must be referenced only once. This ensures that all implementation statements are contained in the same <code>by-component</code> entry.</p>
         </remarks>
@@ -776,13 +775,13 @@
             &allowed-values-responsible-roles-operations;
       </allowed-values>
       <is-unique name="unique-ssp-statement-responsible-role" target="responsible-role">
-        <key-field target="role-id"/>
+        <key-field target="@role-id"/>
         <remarks>
           <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
       <is-unique name="unique-ssp-implemented-requirement-statement-by-component" target="by-component">
-        <key-field target="component-uuid"/>
+        <key-field target="@component-uuid"/>
         <remarks>
           <p>Since <code>by-component</code> can reference <code>component</code> entries using the component's uuid, each component must be referenced only once. This ensures that all implementation statements are contained in the same <code>by-component</code> entry.</p>
         </remarks>
@@ -865,7 +864,7 @@
             </model>
             <constraint>
               <is-unique name="unique-provided-responsible-role" target="responsible-role">
-                <key-field target="role-id"/>
+                <key-field target="@role-id"/>
                 <remarks>
                   <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
                 </remarks>
@@ -903,7 +902,7 @@
             </model>
             <constraint>
               <is-unique name="unique-responsibility-responsible-role" target="responsible-role">
-                <key-field target="role-id"/>
+                <key-field target="@role-id"/>
                 <remarks>
                   <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
                 </remarks>
@@ -950,7 +949,7 @@
         </model>
         <constraint>
           <is-unique name="unique-inherited-responsible-role" target="responsible-role">
-            <key-field target="role-id"/>
+            <key-field target="@role-id"/>
             <remarks>
               <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
             </remarks>
@@ -986,7 +985,7 @@
         </model>
         <constraint>
           <is-unique name="unique-satisfied-responsible-role" target="responsible-role">
-            <key-field target="role-id"/>
+            <key-field target="@role-id"/>
             <remarks>
               <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
             </remarks>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -379,7 +379,7 @@
         <!-- TODO: Model specific link relationships? -->
       </assembly>
       <assembly ref="diagram" max-occurs="unbounded">
-        <group-as name="diagrams" in-json="BY_KEY"/>
+        <group-as name="diagrams" in-json="ARRAY"/>
         <remarks>
           <p>A visual depiction of the system's authorization boundary.</p>
         </remarks>
@@ -389,6 +389,14 @@
         <description>Commentary about the system's authorization boundary that enhances the diagram.</description>
       </define-field>
     </model>
+    <constraint>
+      <is-unique name="unique-ssp-authorization-boundary-diagram" target="diagram">
+        <key-field target="uuid"/>
+        <remarks>
+          <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
+        </remarks>
+      </is-unique>
+    </constraint>
   </define-assembly>
   <define-assembly name="diagram">
     <formal-name>Diagram</formal-name>
@@ -461,10 +469,19 @@
         <!-- TODO: Model specific link relationships? -->
       </assembly>
       <assembly ref="diagram" max-occurs="unbounded">
-        <group-as name="diagrams" in-json="BY_KEY"/>
+        <group-as name="diagrams" in-json="ARRAY"/>
       </assembly>
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
+    <constraint>
+      <is-unique name="unique-ssp-network-architecture-diagram" target="diagram">
+        <key-field target="uuid"/>
+        <remarks>
+          <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
+        </remarks>
+      </is-unique>
+    </constraint>
+    
   </define-assembly>
   <define-assembly name="data-flow">
     <formal-name>Data Flow</formal-name>
@@ -482,10 +499,18 @@
         <!-- TODO: Model specific link relationships? -->
       </assembly>
       <assembly ref="diagram" max-occurs="unbounded">
-        <group-as name="diagrams" in-json="BY_KEY"/>
+        <group-as name="diagrams" in-json="ARRAY"/>
       </assembly>
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
+    <constraint>
+      <is-unique name="unique-ssp-data-flow-diagram" target="diagram">
+        <key-field target="uuid"/>
+        <remarks>
+          <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
+        </remarks>
+      </is-unique>
+    </constraint>
   </define-assembly>
 
   <!-- ################################################################ -->

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -666,7 +666,7 @@
         <group-as name="statements" in-json="ARRAY"/>
       </assembly>
       <assembly ref="by-component" min-occurs="0" max-occurs="unbounded">
-        <group-as name="by-components" in-json="BY_KEY"/>
+        <group-as name="by-components" in-json="ARRAY"/>
       </assembly>
       <!-- TODO: Implement parameters -->
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
@@ -711,6 +711,12 @@
           <p>Since <code>statement</code> entries can be referenced using the statement's statement-id, each statement must be referenced only once.</p>
         </remarks>
       </is-unique>
+      <is-unique name="unique-ssp-implemented-requirement-by-component" target="by-component">
+        <key-field target="component-uuid"/>
+        <remarks>
+          <p>Since <code>by-component</code> can reference <code>component</code> entries using the component's uuid, each component must be referenced only once. This ensures that all implementation statements are contained in the same <code>by-component</code> entry.</p>
+        </remarks>
+      </is-unique>
     </constraint>
   </define-assembly>
   <define-assembly name="statement" scope="local">
@@ -736,7 +742,7 @@
         <group-as name="responsible-roles" in-json="ARRAY"/>
       </assembly>
       <assembly ref="by-component" max-occurs="unbounded">
-        <group-as name="by-components" in-json="BY_KEY"/>
+        <group-as name="by-components" in-json="ARRAY"/>
       </assembly>
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
@@ -750,6 +756,13 @@
           <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
+      <is-unique name="unique-ssp-implemented-requirement-statement-by-component" target="by-component">
+        <key-field target="component-uuid"/>
+        <remarks>
+          <p>Since <code>by-component</code> can reference <code>component</code> entries using the component's uuid, each component must be referenced only once. This ensures that all implementation statements are contained in the same <code>by-component</code> entry.</p>
+        </remarks>
+      </is-unique>
+      
     </constraint>
   </define-assembly>
   <define-assembly name="by-component">

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -543,7 +543,7 @@
 
       <assembly ref="system-user" min-occurs="1" max-occurs="unbounded">
         <use-name>user</use-name>
-        <group-as name="users" in-json="BY_KEY"/>
+        <group-as name="users" in-json="ARRAY"/>
       </assembly>
       <assembly ref="system-component" min-occurs="1" max-occurs="unbounded">
         <use-name>component</use-name>
@@ -611,6 +611,13 @@
       </allowed-values>
 
       <!-- TODO: only allow a single "this-system" component -->
+
+      <is-unique name="unique-ssp-system-implementation-user" target="user">
+        <key-field target="uuid"/>
+        <remarks>
+          <p>A given <code>uuid</code> must be assigned only once to a user.</p>
+        </remarks>
+      </is-unique>
     </constraint>
   </define-assembly>
 

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -653,13 +653,13 @@
         <group-as name="set-parameters" in-json="BY_KEY"/>
       </assembly>
       <assembly ref="responsible-role" max-occurs="unbounded">
-        <group-as name="responsible-roles" in-json="BY_KEY"/>
-      </assembly>
-      <assembly ref="by-component" min-occurs="0" max-occurs="unbounded">
-        <group-as name="by-components" in-json="BY_KEY"/>
+        <group-as name="responsible-roles" in-json="ARRAY"/>
       </assembly>
       <assembly ref="statement" max-occurs="unbounded">
         <group-as name="statements" in-json="BY_KEY"/>
+      </assembly>
+      <assembly ref="by-component" min-occurs="0" max-occurs="unbounded">
+        <group-as name="by-components" in-json="BY_KEY"/>
       </assembly>
       <!-- TODO: Implement parameters -->
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
@@ -692,9 +692,15 @@
           <p>Since all implementation statements are defined at the by-component level (e.g., type=this-system), there must be at least one by-component.</p>
         </remarks>
       </has-cardinality>
+      <is-unique name="unique-ssp-implemented-requirement-responsible-role" target="responsible-role">
+        <key-field target="role-id"/>
+        <remarks>
+          <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+        </remarks>
+      </is-unique>
     </constraint>
   </define-assembly>
-  <define-assembly name="statement">
+  <define-assembly name="statement" scope="local">
     <formal-name>Specific Control Statement</formal-name>
     <description>Identifies which statements within a control are addressed.</description>
     <json-key flag-name="statement-id"/>
@@ -713,23 +719,25 @@
       </assembly>
       <assembly ref="link" max-occurs="unbounded">
         <group-as name="links" in-json="ARRAY"/>
-        <!-- TODO: Model specific link relationships -->
       </assembly>
-      <!-- CHANGED: removed "set-parameter" -->
-      <!-- CHANGED: removed "responsible-role" -->
+      <assembly ref="responsible-role" max-occurs="unbounded">
+        <group-as name="responsible-roles" in-json="ARRAY"/>
+      </assembly>
       <assembly ref="by-component" max-occurs="unbounded">
         <group-as name="by-components" in-json="BY_KEY"/>
       </assembly>
-      <!--         <assembly ref="by-capability" max-occurs="unbounded">
-            <group-as name="by-capabilities" in-json="BY_KEY"/>
-         </assembly>
--->
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
     <constraint>
       <allowed-values target="responsible-role/@role-id" allow-other="yes">
             &allowed-values-responsible-roles-operations;
       </allowed-values>
+      <is-unique name="unique-ssp-statement-responsible-role" target="responsible-role">
+        <key-field target="role-id"/>
+        <remarks>
+          <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+        </remarks>
+      </is-unique>
     </constraint>
   </define-assembly>
   <define-assembly name="by-component">
@@ -755,9 +763,7 @@
       </assembly>
       <assembly ref="link" max-occurs="unbounded">
         <group-as name="links" in-json="ARRAY"/>
-        <!-- TODO: Model specific link relationships -->
       </assembly>
-      <!-- CHANGED: resequenced "set-parameter" -->
       <assembly ref="set-parameter" max-occurs="unbounded">
         <group-as name="set-parameters" in-json="BY_KEY"/>
       </assembly>
@@ -803,10 +809,18 @@
                 <!-- TODO: Model specific link relationships -->
               </assembly>
               <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
-                <group-as name="responsible-roles" in-json="BY_KEY"/>
+                <group-as name="responsible-roles" in-json="ARRAY"/>
               </assembly>
               <field ref="remarks" in-xml="WITH_WRAPPER"/>
             </model>
+            <constraint>
+              <is-unique name="unique-provided-responsible-role" target="responsible-role">
+                <key-field target="role-id"/>
+                <remarks>
+                  <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+                </remarks>
+              </is-unique>
+            </constraint>
           </define-assembly>
           <define-assembly name="responsibility" max-occurs="unbounded">
             <formal-name>Control Implementation Responsibility</formal-name>
@@ -830,13 +844,21 @@
                 <!-- TODO: Model specific link relationships -->
               </assembly>
               <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
-                <group-as name="responsible-roles" in-json="BY_KEY"/>
+                <group-as name="responsible-roles" in-json="ARRAY"/>
                 <remarks>
                   <p>A role defined at the by-component level takes precedence over the same role defined on the parent implemented-requirement or on the referenced component. </p>
                 </remarks>
               </assembly>
               <field ref="remarks" in-xml="WITH_WRAPPER"/>
             </model>
+            <constraint>
+              <is-unique name="unique-responsibility-responsible-role" target="responsible-role">
+                <key-field target="role-id"/>
+                <remarks>
+                  <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+                </remarks>
+              </is-unique>
+            </constraint>
           </define-assembly>
           <field ref="remarks" in-xml="WITH_WRAPPER"/>
         </model>
@@ -873,9 +895,17 @@
             <!-- TODO: Model specific link relationships -->
           </assembly>
           <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
-            <group-as name="responsible-roles" in-json="BY_KEY"/>
+            <group-as name="responsible-roles" in-json="ARRAY"/>
           </assembly>
         </model>
+        <constraint>
+          <is-unique name="unique-inherited-responsible-role" target="responsible-role">
+            <key-field target="role-id"/>
+            <remarks>
+              <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+            </remarks>
+          </is-unique>
+        </constraint>
       </define-assembly>
       <define-assembly name="satisfied" max-occurs="unbounded">
         <formal-name>Satisfied Control Implementation Responsibility</formal-name>
@@ -900,13 +930,21 @@
             <!-- TODO: Model specific link relationships -->
           </assembly>
           <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
-            <group-as name="responsible-roles" in-json="BY_KEY"/>
+            <group-as name="responsible-roles" in-json="ARRAY"/>
           </assembly>
           <field ref="remarks" in-xml="WITH_WRAPPER"/>
         </model>
+        <constraint>
+          <is-unique name="unique-satisfied-responsible-role" target="responsible-role">
+            <key-field target="role-id"/>
+            <remarks>
+              <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+            </remarks>
+          </is-unique>
+        </constraint>
       </define-assembly>
       <assembly ref="responsible-role" max-occurs="unbounded">
-        <group-as name="responsible-roles" in-json="BY_KEY"/>
+        <group-as name="responsible-roles" in-json="ARRAY"/>
       </assembly>
       <!-- CHANGED: removed "set-parameter" -->
       <field ref="remarks" in-xml="WITH_WRAPPER"/>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -654,12 +654,20 @@
         <description>A statement describing important things to know about how this set of control satisfaction documentation is approached.</description>
       </define-field>
       <assembly ref="set-parameter" max-occurs="unbounded">
-        <group-as name="set-parameters" in-json="BY_KEY"/>
+        <group-as name="set-parameters" in-json="ARRAY"/>
       </assembly>
       <assembly ref="implemented-requirement" min-occurs="1" max-occurs="unbounded">
         <group-as name="implemented-requirements" in-json="ARRAY"/>
       </assembly>
     </model>
+    <constraint>
+      <is-unique name="unique-ssp-control-implementation-set-parameter" target="set-parameter">
+        <key-field target="@param-id"/>
+        <remarks>
+          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+        </remarks>
+      </is-unique>
+    </constraint>
     <remarks>
       <p>Use of <code>set-parameter</code> in this context, sets the parameter for all related controls referenced in an <code>implemented-requirement</code>. If the same parameter is also set in a specific <code>implemented-requirement</code>, then the new value will override this value.</p>
     </remarks>
@@ -681,7 +689,7 @@
         <!-- TODO: Model specific link relationships -->
       </assembly>
       <assembly ref="set-parameter" max-occurs="unbounded">
-        <group-as name="set-parameters" in-json="BY_KEY"/>
+        <group-as name="set-parameters" in-json="ARRAY"/>
       </assembly>
       <assembly ref="responsible-role" max-occurs="unbounded">
         <group-as name="responsible-roles" in-json="ARRAY"/>
@@ -723,6 +731,12 @@
           <p>Since all implementation statements are defined at the by-component level (e.g., type=this-system), there must be at least one by-component.</p>
         </remarks>
       </has-cardinality>
+      <is-unique name="unique-ssp-implemented-requirement-set-parameter" target="set-parameter">
+        <key-field target="@param-id"/>
+        <remarks>
+          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+        </remarks>
+      </is-unique>
       <is-unique name="unique-ssp-implemented-requirement-responsible-role" target="responsible-role">
         <key-field target="@role-id"/>
         <remarks>
@@ -814,7 +828,7 @@
         <group-as name="links" in-json="ARRAY"/>
       </assembly>
       <assembly ref="set-parameter" max-occurs="unbounded">
-        <group-as name="set-parameters" in-json="BY_KEY"/>
+        <group-as name="set-parameters" in-json="ARRAY"/>
       </assembly>
       <assembly ref="implementation-status">
         <remarks>
@@ -1003,6 +1017,13 @@
             &allowed-values-responsible-roles-operations;
             &allowed-values-responsible-roles-component-production;
       </allowed-values>
+      <is-unique name="unique-ssp-by-component-set-parameter" target="set-parameter">
+        <key-field target="@param-id"/>
+        <remarks>
+          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+        </remarks>
+      </is-unique>
+      
     </constraint>
   </define-assembly>
 

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -663,7 +663,7 @@
         <group-as name="responsible-roles" in-json="ARRAY"/>
       </assembly>
       <assembly ref="statement" max-occurs="unbounded">
-        <group-as name="statements" in-json="BY_KEY"/>
+        <group-as name="statements" in-json="ARRAY"/>
       </assembly>
       <assembly ref="by-component" min-occurs="0" max-occurs="unbounded">
         <group-as name="by-components" in-json="BY_KEY"/>
@@ -705,12 +705,17 @@
           <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
+      <is-unique name="unique-ssp-implemented-requirement-statement" target="statement">
+        <key-field target="statement-id"/>
+        <remarks>
+          <p>Since <code>statement</code> entries can be referenced using the statement's statement-id, each statement must be referenced only once.</p>
+        </remarks>
+      </is-unique>
     </constraint>
   </define-assembly>
   <define-assembly name="statement" scope="local">
     <formal-name>Specific Control Statement</formal-name>
     <description>Identifies which statements within a control are addressed.</description>
-    <json-key flag-name="statement-id"/>
     <flag ref="statement-id" required="yes">
       <remarks>
         <p>A reference to the specific implemented statement associated with a control.</p>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -577,7 +577,7 @@
       </assembly>
       <assembly ref="system-component" min-occurs="1" max-occurs="unbounded">
         <use-name>component</use-name>
-        <group-as name="components" in-json="BY_KEY"/>
+        <group-as name="components" in-json="ARRAY"/>
       </assembly>
       <!--         <assembly ref="capability" max-occurs="unbounded">
             <group-as name="capabilities" in-json="BY_KEY"/>
@@ -813,7 +813,6 @@
     <!-- QUESTION: Should set-parameter be moved here to allow component-specific parameter settings? or "this-system" for the whole system? -->
     <formal-name>Component Control Implementation</formal-name>
     <description>Defines how the referenced component implements a set of controls.</description>
-    <json-key flag-name="component-uuid"/>
     <define-flag required="yes" name="component-uuid" as-type="uuid">
       <formal-name>Component Universally Unique Identifier Reference</formal-name>
       <description>A reference to the component that is implementing a given control or control statement.</description>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -113,7 +113,7 @@
       <assembly ref="network-architecture"/>
       <assembly ref="data-flow"/>
       <assembly ref="responsible-party" max-occurs="unbounded">
-        <group-as name="responsible-parties" in-json="BY_KEY"/>
+        <group-as name="responsible-parties" in-json="ARRAY"/>
       </assembly>
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
@@ -161,6 +161,12 @@
         </enum>
         <enum value="other">Any other type of cloud service model that is exclusive to the other choices.</enum>
       </allowed-values>
+      <is-unique name="unique-ssp-system-characteristics-responsible-party" target="responsible-party">
+        <key-field target="@role-id"/>
+        <remarks>
+          <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+        </remarks>
+      </is-unique>
       <allowed-values target="responsible-party/@role-id" allow-other="yes">
             &allowed-values-responsible-roles-system;
       </allowed-values>
@@ -740,7 +746,7 @@
       <is-unique name="unique-ssp-implemented-requirement-responsible-role" target="responsible-role">
         <key-field target="@role-id"/>
         <remarks>
-          <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+          <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
       <is-unique name="unique-ssp-implemented-requirement-statement" target="statement">
@@ -791,7 +797,7 @@
       <is-unique name="unique-ssp-statement-responsible-role" target="responsible-role">
         <key-field target="@role-id"/>
         <remarks>
-          <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+          <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
         </remarks>
       </is-unique>
       <is-unique name="unique-ssp-implemented-requirement-statement-by-component" target="by-component">
@@ -880,7 +886,7 @@
               <is-unique name="unique-provided-responsible-role" target="responsible-role">
                 <key-field target="@role-id"/>
                 <remarks>
-                  <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+                  <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
                 </remarks>
               </is-unique>
             </constraint>
@@ -918,7 +924,7 @@
               <is-unique name="unique-responsibility-responsible-role" target="responsible-role">
                 <key-field target="@role-id"/>
                 <remarks>
-                  <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+                  <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
                 </remarks>
               </is-unique>
             </constraint>
@@ -965,7 +971,7 @@
           <is-unique name="unique-inherited-responsible-role" target="responsible-role">
             <key-field target="@role-id"/>
             <remarks>
-              <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+              <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
             </remarks>
           </is-unique>
         </constraint>
@@ -1001,7 +1007,7 @@
           <is-unique name="unique-satisfied-responsible-role" target="responsible-role">
             <key-field target="@role-id"/>
             <remarks>
-              <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
+              <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
             </remarks>
           </is-unique>
         </constraint>
@@ -1023,7 +1029,6 @@
           <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
         </remarks>
       </is-unique>
-      
     </constraint>
   </define-assembly>
 


### PR DESCRIPTION
# Committer Notes

A quick search of the metaschemas with the XPath `//*:group-as[@in-json='BY_KEY']` shows the following places where `group-as in-json="BY_KEY"` is used. The following will track conversion to `ARRAY`:

- [x] responsible-role
- [x] responsible-party
- [x] components
- [x] users
- [x] capabilities
- [x] incorporates-components
- [x] set-parameters
- [x] statements
- [x] diagrams
- [x] by-components

Resolves #914.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
