### PR TITLE
Fix risk log documentation

### DIFF
--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -1169,29 +1169,29 @@
             <model>
                <define-assembly name="entry" min-occurs="1" max-occurs="unbounded">
                   <formal-name>Risk Log Entry</formal-name>
-                  <description>Identifies the result of a task that occurred as part of executing an assessment plan or an assessment event that occurred in producing the assessment results.</description>
+                  <description>Identifies the result of a task that occurred as part of managing an identified risk.</description>
                   <group-as name="entries" in-json="ARRAY"/>
                   <define-flag name="uuid" required="yes" as-type="uuid">
                      <formal-name>Risk Log Entry Universally Unique Identifier</formal-name>
-                     <description>Uniquely identifies an assessment event. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for this schedule across revisions of the document.</description>
+                     <description>Uniquely identifies a risk log entry. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for this schedule across revisions of the document.</description>
                   </define-flag>
                   <model>
                      <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
-                        <formal-name>Action Title</formal-name>
-                        <description>The title for this event.</description>
+                        <formal-name>Title</formal-name>
+                        <description>The title for this risk log entry.</description>
                      </define-field>
                      <!-- CHANGE: Added WITH_WRAPPER to description -->
                      <define-field name="description" min-occurs="0" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-                        <formal-name>Action Description</formal-name>
-                        <description>A human-readable description of this event.</description>
+                        <formal-name>Risk Task Description</formal-name>
+                        <description>A human-readable description of what was done regarding the risk.</description>
                      </define-field>
                      <define-field name="start" as-type="dateTime-with-timezone" min-occurs="1" max-occurs="1">
                         <formal-name>Start</formal-name>
-                        <description>Identifies the start date and time of an event.</description>
+                        <description>Identifies the start date and time of the event.</description>
                      </define-field>
                      <define-field name="end" as-type="dateTime-with-timezone" max-occurs="1">
                         <formal-name>End</formal-name>
-                        <description>Identifies the end date and time of an event. If the event is a point in time, the start and end will be the same date and time.</description>
+                        <description>Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time.</description>
                      </define-field>
                      <assembly ref="property" max-occurs="unbounded">
                         <group-as name="props" in-json="ARRAY"/>
@@ -1209,7 +1209,7 @@
                         </remarks>
                      </field>
                      <define-assembly name="related-response" max-occurs="unbounded">
-                        <formal-name>Action Reference</formal-name>
+                        <formal-name>Risk Response Reference</formal-name>
                         <description>Identifies an individual risk response that this log entry is for.</description>
                         <group-as name="related-responses" in-json="ARRAY"/>
                         <define-flag name="response-uuid" required="yes" as-type="uuid">

--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -1169,7 +1169,7 @@
             <model>
                <define-assembly name="entry" min-occurs="1" max-occurs="unbounded">
                   <formal-name>Risk Log Entry</formal-name>
-                  <description>Identifies the result of a task that occurred as part of managing an identified risk.</description>
+                  <description>dentifies an individual risk response that occurred as part of managing an identified risk.</description>
                   <group-as name="entries" in-json="ARRAY"/>
                   <define-flag name="uuid" required="yes" as-type="uuid">
                      <formal-name>Risk Log Entry Universally Unique Identifier</formal-name>

--- a/src/metaschema/oscal_complete_metaschema.xml
+++ b/src/metaschema/oscal_complete_metaschema.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
+  <schema-name>OSCAL System Security Plan (SSP) Model</schema-name>
+  <schema-version>1.0.0-rc2</schema-version>
+  <short-name>oscal-complete</short-name>
+  <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+ 
+  <import href="oscal_catalog_metaschema.xml"/>
+  <import href="oscal_profile_metaschema.xml"/>
+  <import href="oscal_component_metaschema.xml"/>
+  <import href="oscal_ssp_metaschema.xml"/>
+  <import href="oscal_assessment-plan_metaschema.xml"/>
+  <import href="oscal_assessment-results_metaschema.xml"/>
+  <import href="oscal_poam_metaschema.xml"/>
+</METASCHEMA>


### PR DESCRIPTION
# Committer Notes

Adjusting documentation for the risk log, which was copied from the assessment log and never updated to reflect the risk log semantics.

Resolves #907.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
