### PR TITLE
Make cross-reference names more consistent

### DIFF
--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -606,10 +606,10 @@
       </define-flag>
 -->
       <!-- CHANGED: Flattened assembly by: adding "uuid-ref" flag. Removing "subject/subjects". -->
-      <define-flag name="uuid-ref" as-type="uuid" required="yes">
-         <formal-name>UUID Reference</formal-name>
-         <description>A pointer to a component, inventory-item, location, party, user, or resource using it's UUID.</description>
-      </define-flag>
+      <flag ref="subject-uuid" required="yes"/>
+      <flag ref="subject-type" required="yes">
+         <use-name>type</use-name>
+      </flag>
       <model>
          <assembly ref="property" max-occurs="unbounded">
             <group-as name="props" in-json="ARRAY"/>
@@ -620,28 +620,34 @@
          <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
       </model>
    </define-assembly>
-
+   
+   <define-flag name="subject-uuid" as-type="uuid" scope="local">
+      <formal-name>Subject Universally Unique Identifier Reference</formal-name>
+      <description>A pointer to a component, inventory-item, location, party, user, or resource using it's UUID.</description>
+   </define-flag>
+   
+   <define-flag name="subject-type" as-type="NCName" scope="local">
+      <formal-name>Subject Universally Unique Identifier Reference Type</formal-name>
+      <description>Used to indicate the type of object pointed to by the <code>uuid-ref</code> within a subject.</description>
+      <constraint>
+         <allowed-values allow-other="yes">
+            <enum value="component">Component</enum>
+            <enum value="inventory-item">Inventory Item</enum>
+            <enum value="location">Location</enum>
+            <enum value="party">Interview Party</enum>
+            <enum value="user">User</enum>
+            <enum value="resource">Resource or Artifact</enum>
+         </allowed-values>
+      </constraint>
+   </define-flag>
+   
    <define-assembly name="subject-reference" scope="local">
       <formal-name>Identifies the Subject</formal-name>
       <description>A pointer to a resource based on its universally unique identifier (UUID). Use type to indicate whether the identified resource is a component, inventory item, location, user, or something else.</description>
-      <define-flag name="uuid-ref" as-type="uuid" required="yes">
-         <formal-name>UUID Reference</formal-name>
-         <description>A pointer to a component, inventory-item, location, party, user, or resource using it's UUID.</description>
-      </define-flag>
-      <define-flag name="type" as-type="NCName" required="yes">
-         <formal-name>Universally Unique Identifier Reference Type</formal-name>
-         <description>Used to indicate the type of object pointed to by the <code>uuid-ref</code>.</description>
-         <constraint>
-            <allowed-values allow-other="yes">
-               <enum value="component">Component</enum>
-               <enum value="inventory-item">Inventory Item</enum>
-               <enum value="location">Location</enum>
-               <enum value="party">Interview Party</enum>
-               <enum value="user">User</enum>
-               <enum value="resource">Resource or Artifact</enum>
-            </allowed-values>
-         </constraint>
-      </define-flag>
+      <flag ref="subject-uuid" required="yes"/>
+      <flag ref="subject-type" required="yes">
+         <use-name>type</use-name>
+      </flag>
       <model>
          <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
             <!-- QUESTION: Is this needed, since the title from the target can be used? -->
@@ -758,7 +764,7 @@
             <p>The target will always be a reference to: 1) a control statement, or 2) a control objective. In the former case, there is always a single top-level statement within a control. Thus, if the entire control is targeted, this statement identifier can be used.</p>
          </remarks>
       </define-flag>
-      <define-flag name="id-ref" as-type="NCName" required="yes">
+      <define-flag name="target-id" as-type="NCName" required="yes">
          <formal-name>Finding Target Identifier Reference</formal-name>
          <description>Identifies the specific target qualified by the <code>type</code>.</description>
       </define-flag>
@@ -951,8 +957,8 @@
             </allowed-values>
          </constraint>
       </define-flag>
-      <define-flag name="uuid-ref" as-type="uuid" required="yes">
-         <formal-name>Actor UUID Reference</formal-name>
+      <define-flag name="actor-uuid" as-type="uuid" required="yes">
+         <formal-name>Actor Universally Unique Identifier Reference</formal-name>
          <description>A pointer to the tool or person based on the associated type.</description>
       </define-flag>
       <define-flag name="role-id" as-type="NCName">

--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -344,23 +344,23 @@
       <define-assembly name="remove">
             <formal-name>Removal</formal-name>
             <description>Specifies objects to be removed from a control based on specific aspects of the object that must all match.</description>
-            <define-flag name="name-ref" as-type="NCName">
+            <define-flag name="by-name" as-type="NCName">
                   <formal-name>Reference by (assigned) name</formal-name>
                   <description>Identify items to remove by matching their assigned name</description>
             </define-flag>
-            <define-flag name="class-ref" as-type="NCName">
+            <define-flag name="by-class" as-type="NCName">
                   <formal-name>Reference by class</formal-name>
                   <description>Identify items to remove by matching their <code>class</code>.</description>
             </define-flag>
-            <define-flag name="id-ref" as-type="NCName">
+            <define-flag name="by-id" as-type="NCName">
                   <formal-name>Reference by ID</formal-name>
                   <description>Identify items to remove indicated by their <code>id</code>.</description>
             </define-flag>
-            <define-flag name="item-name" as-type="NCName">
+            <define-flag name="by-item-name" as-type="NCName">
                   <formal-name>Item Name Reference</formal-name>
                   <description>Identify items to remove by the name of the item's information element name, e.g. <code>title</code> or <code>prop</code></description>
             </define-flag>
-            <define-flag name="ns-ref" as-type="NCName">
+            <define-flag name="by-ns" as-type="NCName">
                   <formal-name>Item Namespace Reference</formal-name>
                   <description>Identify items to remove by the item's <code>ns</code>, which is the namespace associated with a <code>part</code>, or <code>prop</code>.</description>
             </define-flag>
@@ -384,7 +384,7 @@
                         </allowed-values>
                   </constraint>
             </define-flag>
-            <define-flag name="id-ref" as-type="NCName">
+            <define-flag name="by-id" as-type="NCName">
                   <formal-name>Reference by ID</formal-name>
                   <description>Target location of the addition.</description>
             </define-flag>

--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-modify.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-modify.xsl
@@ -11,7 +11,7 @@
 <!-- XSLT 2.0 so as to validate against XSLT 3.0 constructs -->
 
     <xsl:key name="alteration-for-control-id" match="alter"         use="@control-id"/>
-    <xsl:key name="addition-by-id-ref"        match="add"           use="@id-ref"/>
+    <xsl:key name="addition-by-id-ref"        match="add"           use="@by-id"/>
     <xsl:key name="parameter-setting-for-id"  match="set-parameter" use="@param-id"/>
 
     <xsl:variable name="oscal-ns" select="'http://csrc.nist.gov/ns/oscal'"/>
@@ -60,13 +60,13 @@
         <xsl:copy>
             <xsl:copy-of select="@*"/>
             <xsl:apply-templates select="title" mode="#current"/>
-            <!-- condition not(@id-ref != $id) includes any addition without an @id-ref, or whose @id-ref is the control id -->
-            <xsl:copy-of select="$modifications/key('alteration-for-control-id',$id,.)/add[not(@id-ref != $id)][@position=('before','starting')]/*"/>
+            <!-- condition not(@by-id != $id) includes any addition without an @by-id, or whose @by-id is the control id -->
+            <xsl:copy-of select="$modifications/key('alteration-for-control-id',$id,.)/add[not(@by-id != $id)][@position=('before','starting')]/*"/>
 
             <xsl:apply-templates select="* except title" mode="#current"/>
             <!--<xsl:message expand-text="true">{ string-join((* except title)/(name() || '#' || @id), ', ') }</xsl:message>-->
 
-            <xsl:copy-of select="$modifications/key('alteration-for-control-id',$id,.)/add[not(@id-ref != $id)][not(@position = ('before','starting'))]/*"/>
+            <xsl:copy-of select="$modifications/key('alteration-for-control-id',$id,.)/add[not(@by-id != $id)][not(@position = ('before','starting'))]/*"/>
         </xsl:copy>
     </xsl:template>
 
@@ -121,20 +121,20 @@
         <xsl:sequence select="some $r in $removals satisfies oscal:remove-match($who,$r)"/>
     </xsl:function>
 
-    <!-- <remove item-name="" id-ref="" class-ref="" name-ref="" ns-ref=""/>-->
+    <!-- <remove by-item-name="" by-id="" by-class="" by-name="" by-ns=""/>-->
 
     <xsl:function name="oscal:remove-match">
         <xsl:param name="who" as="node()"/>
         <xsl:param name="removal" as="element(remove)"/>
-        <xsl:variable name="item-okay"  select="empty($removal/@item-name) or ($removal/@item-name = local-name($who))"/>
-        <xsl:variable name="id-okay"    select="empty($removal/@id-ref)    or ($removal/@id-ref = $who/@id)"/>
-        <xsl:variable name="name-okay"  select="empty($removal/@name-ref)  or ($removal/@name-ref/normalize-space(.) = $who/@name/normalize-space(.))"/>
-        <xsl:variable name="ns-okay"    select="empty($removal/@ns-ref[not(normalize-space(.) = $oscal-ns)])
-            or ($removal/@ns-ref/normalize-space(.) = $who/@ns/normalize-space(.))"/>
-        <xsl:variable name="oscal-ns-okay"    select="empty($removal/@ns-ref[normalize-space(.) = $oscal-ns])
+        <xsl:variable name="item-okay"  select="empty($removal/@by-item-name) or ($removal/@by-item-name = local-name($who))"/>
+        <xsl:variable name="id-okay"    select="empty($removal/@by-id)    or ($removal/@by-id = $who/@id)"/>
+        <xsl:variable name="name-okay"  select="empty($removal/@by-name)  or ($removal/@by-name/normalize-space(.) = $who/@name/normalize-space(.))"/>
+        <xsl:variable name="ns-okay"    select="empty($removal/@by-ns[not(normalize-space(.) = $oscal-ns)])
+            or ($removal/@by-ns/normalize-space(.) = $who/@ns/normalize-space(.))"/>
+        <xsl:variable name="oscal-ns-okay"    select="empty($removal/@by-ns[normalize-space(.) = $oscal-ns])
             or (($who/@ns/normalize-space(.) = $oscal-ns) or empty($who/@ns))"/>
-        <xsl:variable name="class-okay" select="empty($removal/@class-ref) or ($removal/@class-ref = oscal:classes($who))"/>
-        <xsl:sequence select="exists($removal/(@item-name|@id-ref|@name-ref|@ns-ref|@class-ref)) and ($item-okay and $id-okay and $name-okay and $ns-okay and $oscal-ns-okay and $class-okay)"/>
+        <xsl:variable name="class-okay" select="empty($removal/@by-class) or ($removal/@by-class = oscal:classes($who))"/>
+        <xsl:sequence select="exists($removal/(@by-item-name|@by-id|@by-name|@by-ns|@by-class)) and ($item-okay and $id-okay and $name-okay and $ns-okay and $oscal-ns-okay and $class-okay)"/>
     </xsl:function>
 
 </xsl:stylesheet>


### PR DESCRIPTION
# Committer Notes

In "select-subject-by-id" renamed "uuid-ref" to "subject-uuid" to be more consistent with other cross-references in OSCAL.
Added a required "type" to all subject references.
Renamed attributes in profile "add" and "remove" to eliminate the "-ref" suffix and add the "by-" prefix. Also updated profile resolver code to work with these changes.

Resolves #898.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
