### PR TITLE
Make assessment findings optional

### DIFF
--- a/src/metaschema/oscal_assessment-results_metaschema.xml
+++ b/src/metaschema/oscal_assessment-results_metaschema.xml
@@ -243,10 +243,10 @@
       </assembly>
 
       <!-- CHANGE: move "risk" from finding -->
-      <assembly ref="risk" min-occurs="0" max-occurs="unbounded">
+      <assembly ref="risk" max-occurs="unbounded">
         <group-as name="risks" in-json="ARRAY"/>
       </assembly>
-      <assembly ref="finding" min-occurs="1" max-occurs="unbounded">
+      <assembly ref="finding" max-occurs="unbounded">
         <group-as name="findings" in-json="ARRAY"/>
       </assembly>
       <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>


### PR DESCRIPTION
# Committer Notes

Makes the findings array zero-to-unbounded.

Resolves #918.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
