### PR TITLE
Metaschema enhancements to string-based datatypes

### DIFF
--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" abstract="yes">
    <schema-name>OSCAL Assessment Layer Format -- Common Modules</schema-name>
-   <schema-version>1.0.0-rc2</schema-version>
+   <schema-version>1.0.0</schema-version>
    <short-name>oscal-assessment-common</short-name>
    <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+   <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
    <remarks>
       <p>This contains all modules common to the assessment plan, assessment results, and POAM models. </p>
       <p>The root of the OSCAL Assessment Plan format is <code>assessment-plan</code>.</p>

--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -215,7 +215,7 @@
          <formal-name>Task Universally Unique Identifier</formal-name>
          <description>Uniquely identifies this assessment task. </description>
       </define-flag>
-      <define-flag name="type" required="yes" as-type="NCName">
+      <define-flag name="type" required="yes" as-type="token">
          <formal-name>Task Type</formal-name>
          <description>The type of task.</description>
          <constraint>
@@ -494,7 +494,7 @@
       <description>Used to select a control for inclusion/exclusion based on one or more control identifiers. A set of statement identifiers can be used to target the inclusion/exclusion to only specific control statements providing more granularity over the specific statements that are within the asessment scope.</description>
       <flag ref="control-id" required="yes"/>
       <model>
-         <define-field name="statement-id" as-type="NCName" min-occurs="0" max-occurs="unbounded" >
+         <define-field name="statement-id" as-type="token" min-occurs="0" max-occurs="unbounded" >
             <formal-name>Include Specific Statements</formal-name>
             <description>Used to constrain the selection to only specificity identified statements.</description>
             <group-as name="statement-ids" in-json="ARRAY"/>
@@ -544,7 +544,7 @@
       <formal-name>Subject of Assessment</formal-name>
       <description>Identifies system elements being assessed, such as components, inventory items, and locations. In the assessment plan, this identifies a planned assessment subject. In the assessment results this is an actual assessment subject, and reflects any changes from the plan. exactly what will be the focus of this assessment. Any subjects not identified in this way are out-of-scope.</description>
       <!-- CHANGED: "name" to "type" -->
-      <define-flag name="type" as-type="NCName" required="yes">
+      <define-flag name="type" as-type="token" required="yes">
          <formal-name>Subject Type</formal-name>
          <description>Indicates the type of assessment subject, such as a component, inventory, item, location, or party represented by this selection statement.</description>
          <constraint>
@@ -627,7 +627,7 @@
       <description>A pointer to a component, inventory-item, location, party, user, or resource using it's UUID.</description>
    </define-flag>
    
-   <define-flag name="subject-type" as-type="NCName" scope="local">
+   <define-flag name="subject-type" as-type="token" scope="local">
       <formal-name>Subject Universally Unique Identifier Reference Type</formal-name>
       <description>Used to indicate the type of object pointed to by the <code>uuid-ref</code> within a subject.</description>
       <constraint>
@@ -765,7 +765,7 @@
             <p>The target will always be a reference to: 1) a control statement, or 2) a control objective. In the former case, there is always a single top-level statement within a control. Thus, if the entire control is targeted, this statement identifier can be used.</p>
          </remarks>
       </define-flag>
-      <define-flag name="target-id" as-type="NCName" required="yes">
+      <define-flag name="target-id" as-type="token" required="yes">
          <formal-name>Finding Target Identifier Reference</formal-name>
          <description>Identifies the specific target qualified by the <code>type</code>.</description>
       </define-flag>
@@ -785,7 +785,7 @@
          <assembly ref="link" max-occurs="unbounded">
             <group-as name="links" in-json="ARRAY"/>
          </assembly>
-         <define-field name="status" as-type="NCName" min-occurs="1" max-occurs="1">
+         <define-field name="status" as-type="token" min-occurs="1" max-occurs="1">
             <formal-name>Objective Status</formal-name>
             <description>A brief indication as to whether the objective is satisfied or not within a given system.</description>
             <!-- CHANGED: removed @system flag -->
@@ -846,7 +846,7 @@
             </constraint>
          </define-field>
 
-         <define-field name="type" as-type="NCName" max-occurs="unbounded">
+         <define-field name="type" as-type="token" max-occurs="unbounded">
             <!-- CHANGED "observation-type" to "type" -->
             <formal-name>Observation Type</formal-name>
             <description>Identifies the nature of the observation. More than one may be used to further qualify and enable filtering.</description>
@@ -946,7 +946,7 @@
    <define-assembly name="origin-actor">
       <formal-name>Originating Actor</formal-name>
       <description>The actor that produces an observation, a finding, or a risk. One or more actor type can be used to specify a person that is using a tool.</description>
-      <define-flag name="type" as-type="NCName" required="yes">
+      <define-flag name="type" as-type="token" required="yes">
          <formal-name>Actor Type</formal-name>
          <description>The kind of actor.</description>
          <constraint>
@@ -962,7 +962,7 @@
          <formal-name>Actor Universally Unique Identifier Reference</formal-name>
          <description>A pointer to the tool or person based on the associated type.</description>
       </define-flag>
-      <define-flag name="role-id" as-type="NCName">
+      <define-flag name="role-id" as-type="token">
          <formal-name>Actor Role</formal-name>
          <description>For a party, this can optionally be used to specify the role the actor was performing.</description>
       </define-flag>
@@ -1085,7 +1085,7 @@
          <assembly ref="link" max-occurs="unbounded">
             <group-as name="links" in-json="ARRAY"/>
          </assembly>
-         <define-field name="status" as-type="NCName" min-occurs="1">
+         <define-field name="status" as-type="token" min-occurs="1">
             <!-- CHANGED: from "risk-status" to "status" -->
             <formal-name>Status</formal-name>
             <description>Describes the status of the associated risk.</description>
@@ -1287,13 +1287,13 @@
          <formal-name>Party UUID Reference</formal-name>
          <description>A pointer to the party who is making the log entry.</description>
       </define-flag>
-      <define-flag name="role-id" as-type="NCName">
+      <define-flag name="role-id" as-type="token">
          <formal-name>Actor Role</formal-name>
          <description>A point to the role-id of the role in which the party is making the log entry.</description>
       </define-flag>
    </define-assembly>
 
-   <define-field name="risk-status" as-type="NCName">
+   <define-field name="risk-status" as-type="token">
       <!-- CHANGED: from "risk-status" to "status" -->
       <formal-name>Risk Status</formal-name>
       <description>Describes the status of the associated risk.</description>
@@ -1328,7 +1328,7 @@
             <formal-name>Facet</formal-name>
             <description>An individual characteristic that is part of a larger set produced by the same actor.</description>
             <group-as name="facets" in-json="ARRAY"/>
-            <define-flag name="name" as-type="NCName" required="yes">
+            <define-flag name="name" as-type="token" required="yes">
                <formal-name>Facet Name</formal-name>
                <description>The name of the risk metric within the specified system.</description>
             </define-flag>
@@ -1575,7 +1575,7 @@
          <description>Uniquely identifies this remediation. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given remediation across revisions.</description>
       </define-flag>
       <!-- CHANGED: type to lifecycle -->
-      <define-flag name="lifecycle" as-type="NCName" required="yes">
+      <define-flag name="lifecycle" as-type="token" required="yes">
          <formal-name>Remediation Intent</formal-name>
          <description>Identifies whether this is a recommendation, such as from an assessor or tool, or an actual plan accepted by the system owner.</description>
          <constraint>
@@ -1675,7 +1675,7 @@
       </constraint>
    </define-assembly>
 
-   <define-flag name="objective-id" as-type="NCName" scope="local">
+   <define-flag name="objective-id" as-type="token" scope="local">
       <!-- This is an id to sync with control syntax -->
       <formal-name>Objective ID</formal-name>
       <description>Points to an assessment objective.</description>
@@ -1691,7 +1691,7 @@
          <formal-name>Part Identifier</formal-name>
          <description>A unique identifier for a specific part instance. This identifier's uniqueness is document scoped and is intended to be consistent for the same part across minor revisions of the document.</description>
       </define-flag>
-      <define-flag name="name" as-type="NCName" required="yes">
+      <define-flag name="name" as-type="token" required="yes">
          <formal-name>Part Name</formal-name>
          <description>A textual label that uniquely identifies the part's semantic type.</description>
          <constraint>
@@ -1713,7 +1713,7 @@
             <p>When a <code>ns</code> is not provided, its value should be assumed to be <code>http://csrc.nist.gov/ns/oscal</code> and the name should be a name defined by the associated OSCAL model.</p>
          </remarks>
       </define-flag>
-      <define-flag name="class" as-type="NCName">
+      <define-flag name="class" as-type="token">
          <formal-name>Part Class</formal-name>
          <description>A textual label that provides a sub-type or characterization of the part's <code>name</code>. This can be used to further distinguish or discriminate between the semantics of multiple parts of the same control with the same <code>name</code> and <code>ns</code>.</description>
          <remarks>

--- a/src/metaschema/oscal_assessment-plan_metaschema.xml
+++ b/src/metaschema/oscal_assessment-plan_metaschema.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
     <schema-name>OSCAL Assessment Plan Model</schema-name>
-    <schema-version>1.0.0-rc2</schema-version>
+    <schema-version>1.0.0</schema-version>
     <short-name>oscal-ap</short-name>
     <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
     <remarks>
         <p>The OSCAL assessment plan format is used to describe the information typically provided by an assessor during the preparation for an assessment.</p>
         <p>The root of the OSCAL assessment plan format is <code>assessment-plan</code>.

--- a/src/metaschema/oscal_assessment-results_metaschema.xml
+++ b/src/metaschema/oscal_assessment-results_metaschema.xml
@@ -3,9 +3,10 @@
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
   <schema-name>OSCAL Assessment Results Model</schema-name>
-  <schema-version>1.0.0-rc2</schema-version>
+  <schema-version>1.0.0</schema-version>
   <short-name>oscal-ar</short-name>
   <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+  <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
   <remarks>
     <p>The OSCAL assessment results format is used to describe the information typically provided by an assessor following an assessment.</p>
     <p>The root of the OSCAL assessment results format is <code>assessment-results</code>.

--- a/src/metaschema/oscal_catalog_metaschema.xml
+++ b/src/metaschema/oscal_catalog_metaschema.xml
@@ -65,12 +65,12 @@
       <define-assembly name="group">
             <formal-name>Control Group</formal-name>
             <description>A group of controls, or of groups of controls.</description>
-            <define-flag name="id" as-type="NCName">
+            <define-flag name="id" as-type="token">
                   <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
                   <formal-name>Group Identifier</formal-name>
                   <description>A unique identifier for a specific group instance that can be used to reference the group within this and in other OSCAL documents. This identifier's uniqueness is document scoped and is intended to be consistent for the same group across minor revisions of the document.</description>
             </define-flag>
-            <define-flag name="class" as-type="NCName">
+            <define-flag name="class" as-type="token">
                   <formal-name>Group Class</formal-name>
                   <description>A textual label that provides a sub-type or characterization of the group.</description>
                   <remarks>
@@ -130,12 +130,12 @@
       <define-assembly name="control">
             <formal-name>Control</formal-name>
             <description>A structured information object representing a security or privacy control. Each security or privacy control within the Catalog is defined by a distinct control instance.</description>
-            <define-flag name="id" as-type="NCName" required="yes">
+            <define-flag name="id" as-type="token" required="yes">
                   <!-- This is an id because the idenfier is managed externally. -->
                   <formal-name>Control Identifier</formal-name>
                   <description>A unique identifier for a specific control instance that can be used to reference the control in other OSCAL documents. This identifier's uniqueness is document scoped and is intended to be consistent for the same control across minor revisions of the document.</description>
             </define-flag>
-            <define-flag name="class" as-type="NCName">
+            <define-flag name="class" as-type="token">
                   <formal-name>Control Class</formal-name>
                   <description>A textual label that provides a sub-type or characterization of the control.</description>
                   <remarks>

--- a/src/metaschema/oscal_catalog_metaschema.xml
+++ b/src/metaschema/oscal_catalog_metaschema.xml
@@ -8,9 +8,10 @@
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
       <schema-name>OSCAL Control Catalog Model</schema-name>
-      <schema-version>1.0.0-rc2</schema-version>
+      <schema-version>1.0.0</schema-version>
       <short-name>oscal-catalog</short-name>
       <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+      <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
       <remarks>
             <p>The OSCAL Control Catalog format can be used to describe a collection of security controls and related control enhancements, along with contextualizing documentation and metadata. The root of the Control Catalog format is <code>catalog</code>.
             </p>

--- a/src/metaschema/oscal_complete_metaschema.xml
+++ b/src/metaschema/oscal_complete_metaschema.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--<?xml-model href="../../build/metaschema/toolchains/xslt-M4/validate/metaschema-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>-->
+<!-- OSCAL GRAND UNIFIED MEGALOMETASCHEMA -->
+<!-- validate with XSD and Schematron (linked) -->
+<!DOCTYPE METASCHEMA [
+   <!ENTITY allowed-values-control-group-property-name SYSTEM "shared-constraints/allowed-values-control-group-property-name.ent">
+]>
+<METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
+      <schema-name>OSCAL Unified Model</schema-name>
+      <schema-version>1.0.0</schema-version>
+      <short-name>oscal-all</short-name>
+      <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+      <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
+      <remarks>
+            <p>The OSCAL Control Catalog format can be used to describe a collection of security controls and related control enhancements, along with contextualizing documentation and metadata. The root of the Control Catalog format is <code>catalog</code>.
+            </p>
+      </remarks>
+      <import href="oscal_catalog_metaschema.xml"/>
+      <import href="oscal_profile_metaschema.xml"/>
+      <import href="oscal_ssp_metaschema.xml"/>
+      <import href="oscal_component_metaschema.xml"/>
+      <import href="oscal_poam_metaschema.xml"/>
+      <import href="oscal_assessment-plan_metaschema.xml"/>
+      <import href="oscal_assessment-results_metaschema.xml"/>
+      
+</METASCHEMA>

--- a/src/metaschema/oscal_complete_metaschema.xml
+++ b/src/metaschema/oscal_complete_metaschema.xml
@@ -6,9 +6,9 @@
    <!ENTITY allowed-values-control-group-property-name SYSTEM "shared-constraints/allowed-values-control-group-property-name.ent">
 ]>
 <METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
-      <schema-name>OSCAL Unified Model</schema-name>
+      <schema-name>OSCAL Unified Model of Models</schema-name>
       <schema-version>1.0.0</schema-version>
-      <short-name>oscal-all</short-name>
+      <short-name>oscal-complete</short-name>
       <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
       <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
       <remarks>

--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -14,9 +14,10 @@
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
   <schema-name>OSCAL Component Definition Model</schema-name>
-  <schema-version>1.0.0-rc1</schema-version>
+  <schema-version>1.0.0</schema-version>
   <short-name>oscal-component-definition</short-name>
   <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+  <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
   <remarks>
     <p>The OSCAL Component Definition Model can be used to describe the implementation of controls in a <code>component</code> or a set of components grouped as a <code>capability</code>. A component can be either a <em>technical component</em>, or a <em>documentary component</em>. A technical component is a component that is implemented in hardware (physical or virtual) or software. A documentary component is a component implemented in a document, such as a process, procedure, or policy.</p>
     <p>The root of the OSCAL Implementation Component format is <code>component-definition</code>.

--- a/src/metaschema/oscal_control-common_metaschema.xml
+++ b/src/metaschema/oscal_control-common_metaschema.xml
@@ -19,12 +19,12 @@
         <define-assembly name="part">
                 <formal-name>Part</formal-name>
                 <description>A partition of a control's definition or a child of another part.</description>
-                <define-flag name="id" as-type="NCName">
+                <define-flag name="id" as-type="token">
                         <!-- This is an id because the idenfier is intended to be human-raadable. -->
                         <formal-name>Part Identifier</formal-name>
                         <description>A unique identifier for a specific part instance. This identifier's uniqueness is document scoped and is intended to be consistent for the same part across minor revisions of the document.</description>
                 </define-flag>
-                <define-flag name="name" as-type="NCName" required="yes">
+                <define-flag name="name" as-type="token" required="yes">
                         <formal-name>Part Name</formal-name>
                         <description>A textual label that uniquely identifies the part's semantic type.</description>
                         <constraint>
@@ -50,7 +50,7 @@
                                 <p>When a <code>ns</code> is not provided, its value should be assumed to be <code>http://csrc.nist.gov/ns/oscal</code> and the name should be a name defined by the associated OSCAL model.</p>
                         </remarks>
                 </define-flag>
-                <define-flag name="class" as-type="NCName">
+                <define-flag name="class" as-type="token">
                         <formal-name>Part Class</formal-name>
                         <description>A textual label that provides a sub-type or characterization of the part's <code>name</code>. This can be used to further distinguish or discriminate between the semantics of multiple parts of the same control with the same <code>name</code> and <code>ns</code>.
                         </description>
@@ -121,13 +121,13 @@
                 <description>Parameters provide a mechanism for the dynamic assignment of value(s) in a control.</description>
                 <!-- It is worth it abbreviate "param" in XML, while keeping "parameters" in JSON. -->
                 <use-name>param</use-name>
-                <define-flag name="id" as-type="NCName" required="yes">
+                <define-flag name="id" as-type="token" required="yes">
                         <!-- This is an id because the idenfier is intended to be human-raadable. -->
                         <formal-name>Parameter Identifier</formal-name>
                         <description>A unique identifier for a specific parameter instance. This identifier's uniqueness is document scoped and is intended to be consistent for the same parameter across minor revisions of the document.</description>
                 </define-flag>
                 <!-- TODO: What is the semantics of class here? -->
-                <define-flag name="class" as-type="NCName">
+                <define-flag name="class" as-type="token">
                         <formal-name>Parameter Class</formal-name>
                         <description>A textual label that provides a characterization of the parameter.</description>
                         <remarks>
@@ -225,7 +225,7 @@
                 </model>
         </define-assembly>
 
-        <define-field name="parameter-value" as-type="string">
+        <define-field name="parameter-value">
                 <!-- CHANGED type from "markup-line" to "string" since this is intended to be a scalar value -->
                 <formal-name>Parameter Value</formal-name>
                 <description>A parameter value or set of values.</description>
@@ -234,9 +234,15 @@
         <define-assembly name="parameter-selection">
                 <formal-name>Selection</formal-name>
                 <description>Presenting a choice among alternatives</description>
-                <define-flag name="how-many" as-type="string">
+                <define-flag name="how-many" as-type="token">
                         <formal-name>Parameter Cardinality</formal-name>
-                        <description>Describes the number of selections that must occur.</description>
+                        <description>Describes the number of selections that must occur. Without this setting, only one value should be assumed to be permitted.</description>
+                        <constraint>
+                                <allowed-values allow-other="no">
+                                        <enum value="one">Only one value is permitted.</enum>
+                                        <enum value="one-or-more">One or more values are permitted.</enum>
+                                </allowed-values>
+                        </constraint>
                 </define-flag>
                 <model>
                         <define-field name="parameter-choice" as-type="markup-line" max-occurs="unbounded">
@@ -253,12 +259,12 @@
                         <p>A set of parameter value choices, that may be picked from to set the parameter value.</p>
                 </remarks>
         </define-assembly>
-        <define-flag name="depends-on" as-type="NCName">
+        <define-flag name="depends-on" as-type="token">
                 <!-- TODO: Work out cross-reference constraints -->
                 <formal-name>Depends on</formal-name>
                 <description>Another parameter invoking this one</description>
         </define-flag>
-        <define-flag name="control-id" as-type="NCName">
+        <define-flag name="control-id" as-type="token">
                 <formal-name>Control Identifier Reference</formal-name>
                 <description>A reference to a control with a corresponding <code>id</code> value.</description>
         </define-flag>

--- a/src/metaschema/oscal_control-common_metaschema.xml
+++ b/src/metaschema/oscal_control-common_metaschema.xml
@@ -8,12 +8,11 @@
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd" abstract="yes">
         <schema-name>OSCAL Control Catalog Format -- Common Models</schema-name>
-        <schema-version>1.0.0-rc2</schema-version>
+        <schema-version>1.0.0</schema-version>
         <short-name>oscal-catalog-common</short-name>
         <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+        <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
         <import href="oscal_metadata_metaschema.xml"/>
-
-
         <!-- ######################################## -->
         <!-- # Part Assembly and related constructs # -->
         <!-- ######################################## -->

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -14,9 +14,10 @@
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd" abstract="yes">
       <schema-name>OSCAL Implementation Common Information</schema-name>
-      <schema-version>1.0.0-rc2</schema-version>
+      <schema-version>1.0.0</schema-version>
       <short-name>oscal-implementation-common</short-name>
       <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+      <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
 
       <import href="oscal_metadata_metaschema.xml"/>
       <import href="oscal_control-common_metaschema.xml"/>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -58,7 +58,7 @@
                   <define-assembly name="status" min-occurs="1">
                         <formal-name>Status</formal-name>
                         <description>Describes the operational status of the system component.</description>
-                        <define-flag name="state" as-type="NCName" required="yes">
+                        <define-flag name="state" as-type="token" required="yes">
                               <formal-name>State</formal-name>
                               <description>The operational status.</description>
                               <constraint>
@@ -286,7 +286,7 @@
                         <p>Should be a number within a permitted range</p>
                   </remarks>
             </define-flag>
-            <define-flag name="transport" as-type="NCName">
+            <define-flag name="transport" as-type="token">
                   <formal-name>Transport</formal-name>
                   <description>Indicates the transport type.</description>
                   <constraint>
@@ -311,7 +311,7 @@
       <define-assembly name="implementation-status">
             <formal-name>Implementation Status</formal-name>
             <description>Indicates the degree to which the a given control is implemented.</description>
-            <define-flag name="state" as-type="NCName" required="yes">
+            <define-flag name="state" as-type="token" required="yes">
                   <formal-name>Implementation State</formal-name>
                   <description>Identifies the implementation status of the control or control objective.</description>
                   <constraint>
@@ -629,7 +629,7 @@
       </model>
    </define-assembly>
 -->
-      <define-flag name="statement-id" as-type="NCName">
+      <define-flag name="statement-id" as-type="token">
             <formal-name>Control Statement Reference</formal-name>
             <description>A reference to a control statement by its identifier</description>
       </define-flag>
@@ -668,7 +668,7 @@
       </define-field>
 
       <!-- ===== FLAGS ===== -->
-      <define-flag name="param-id" as-type="NCName">
+      <define-flag name="param-id" as-type="token">
             <!-- This is an id because the idenfier is assigned and managed by humans. -->
             <formal-name>Parameter ID</formal-name>
             <description>A reference to a parameter within a control, who's catalog has been imported into the current implementation context.</description>

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -5,9 +5,10 @@
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd" abstract="yes">
     <schema-name>OSCAL Document Metadata Description</schema-name>
-    <schema-version>1.0.0-rc2</schema-version>
+    <schema-version>1.0.0</schema-version>
     <short-name>oscal-metadata</short-name>
     <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
 
     <!-- ############################################### -->
     <!-- # Metadata Assembly and supporting constructs # -->

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -346,7 +346,7 @@
     <define-assembly name="role">
         <formal-name>Role</formal-name>
         <description>Defines a function assumed or expected to be assumed by a party in a specific situation.</description>
-        <define-flag name="id" as-type="NCName" required="yes">
+        <define-flag name="id" as-type="token" required="yes">
             <!-- This is an id because the idenfier is assigned and managed by humans. -->
             <formal-name>Role Identifier</formal-name>
             <description>A unique identifier for a specific role instance. This identifier's uniqueness is document scoped and is intended to be consistent for the same role across minor revisions of the document.</description>
@@ -381,7 +381,7 @@
         </remarks>
     </define-assembly>
 
-    <define-field name="role-id" as-type="NCName">
+    <define-field name="role-id" as-type="token">
         <formal-name>Role Identifier Reference</formal-name>
         <description>A reference to the roles served by the user.</description>
         <constraint>
@@ -585,7 +585,7 @@
         <formal-name>Property</formal-name>
         <description>An attribute, characteristic, or quality of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values.</description>
         <use-name>prop</use-name>
-        <define-flag name="name" as-type="NCName" required="yes">
+        <define-flag name="name" as-type="token" required="yes">
             <formal-name>Property Name</formal-name>
             <description>A textual label that uniquely identifies a specific attribute, characteristic, or quality of the property's containing object.</description>
             <constraint>
@@ -613,7 +613,7 @@
             <formal-name>Property Value</formal-name>
             <description>Indicates the value of the attribute, characteristic, or quality.</description>
         </define-flag>
-        <define-flag name="class" as-type="NCName">
+        <define-flag name="class" as-type="token">
             <formal-name>Property Class</formal-name>
             <description>A textual label that provides a sub-type or characterization of the property's <code>name</code>. This can be used to further distinguish or discriminate between the semantics of multiple properties of the same object with the same <code>name</code> and <code>ns</code>.
             </description>
@@ -644,7 +644,7 @@
                 <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URI pointing to the location of the referenced resource. A relative URI will be resolved relative to the location of the document containing the link.</p>
             </remarks>
         </define-flag>
-        <define-flag name="rel" as-type="NCName">
+        <define-flag name="rel" as-type="token">
             <formal-name>Relation</formal-name>
             <description>Describes the type of relationship provided by the link. This can be an indicator of the link's purpose.</description>
             <constraint>
@@ -704,7 +704,7 @@
     <define-assembly name="responsible-party">
         <formal-name>Responsible Party</formal-name>
         <description>A reference to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object.</description>
-        <define-flag required="yes" name="role-id" as-type="NCName">
+        <define-flag required="yes" name="role-id" as-type="token">
             <formal-name>Responsible Role</formal-name>
             <description>The role that the party is responsible for.</description>
         </define-flag>
@@ -736,7 +736,7 @@
     <define-assembly name="responsible-role">
         <formal-name>Responsible Role</formal-name>
         <description>A reference to one or more roles with responsibility for performing a function relative to the containing object.</description>
-        <define-flag name="role-id" as-type="NCName" required="yes">
+        <define-flag name="role-id" as-type="token" required="yes">
             <formal-name>Responsible Role ID</formal-name>
             <description>The role that is responsible for the business function.</description>
         </define-flag>
@@ -902,7 +902,7 @@
         <description>A single line of an address.</description>
     </define-field>
 
-    <define-flag name="location-type" as-type="NCName" scope="local">
+    <define-flag name="location-type" as-type="token" scope="local">
         <formal-name>Address Type</formal-name>
         <description>Indicates the type of address.</description>
         <constraint>

--- a/src/metaschema/oscal_poam_metaschema.xml
+++ b/src/metaschema/oscal_poam_metaschema.xml
@@ -3,9 +3,10 @@
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
     <schema-name>OSCAL Plan of Action and Milestones (POA&amp;M) Model</schema-name>
-    <schema-version>1.0.0-rc2</schema-version>
+    <schema-version>1.0.0</schema-version>
     <short-name>oscal-poam</short-name>
     <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
     <remarks>
         <p>The OSCAL Plan of Action and Milestones (POA&amp;M) format is used to describe the information typically provided by an assessor during the preparation for an assessment.</p>
         <p>The root of the OSCAL Plan of Action and Milestones (POA&amp;M) format is <code>plan-action-milestones</code>.

--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -6,9 +6,10 @@
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
       <schema-name>OSCAL Profile Model</schema-name>
-      <schema-version>1.0.0-rc2</schema-version>
+      <schema-version>1.0.0</schema-version>
       <short-name>oscal-profile</short-name>
       <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+      <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
       <remarks>
             <p>A profile designates a selection and configuration of controls from one or more catalogs, along with a series of operations over them. The topmost element in the OSCAL profile XML schema is <code>profile</code>.</p>
       </remarks>

--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -143,12 +143,12 @@
       <define-assembly name="group">
             <formal-name>Control group</formal-name>
             <description>A group of (selected) controls or of groups of controls</description>
-            <define-flag name="id" as-type="NCName">
+            <define-flag name="id" as-type="token">
                   <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
                   <formal-name>Group Identifier</formal-name>
                   <description>A unique identifier for a specific group instance that can be used to reference the group within this and in other OSCAL documents. This identifier's uniqueness is document scoped and is intended to be consistent for the same group across minor revisions of the document.</description>
             </define-flag>
-            <define-flag name="class" as-type="NCName">
+            <define-flag name="class" as-type="token">
                   <formal-name>Group Class</formal-name>
                   <description>A textual label that provides a sub-type or characterization of the group.</description>
                   <remarks>
@@ -194,12 +194,12 @@
                         <formal-name>Parameter Setting</formal-name>
                         <description>A parameter setting, to be propagated to points of insertion</description>
                         <group-as name="set-parameters" in-json="ARRAY"/>
-                        <define-flag required="yes" name="param-id" as-type="NCName">
+                        <define-flag required="yes" name="param-id" as-type="token">
                               <!-- This is an id because the idenfier is assigned and managed by humans. -->
                               <formal-name>Parameter ID</formal-name>
                               <description>Indicates the value of the 'id' flag on a target parameter; i.e. which parameter to set</description>
                         </define-flag>
-                        <define-flag name="class" as-type="NCName">
+                        <define-flag name="class" as-type="token">
                               <formal-name>Parameter Class</formal-name>
                               <description>A textual label that provides a characterization of the parameter.</description>
                               <remarks>
@@ -263,7 +263,7 @@
       <define-assembly name="insert-controls">
             <formal-name>Select controls</formal-name>
             <description>Specifies which controls to use in the containing context.</description>
-            <define-flag as-type="NCName" name="order">
+            <define-flag as-type="token" name="order">
                   <formal-name>Order</formal-name>
                   <description>A designation of how a selection of controls in a profile is to be ordered.</description>
                   <constraint>
@@ -308,7 +308,7 @@
             <description>Call a control by its ID</description>
             <flag ref="with-child-controls"/>
             <model>
-                  <define-field name="with-id" as-type="NCName" max-occurs="unbounded">
+                  <define-field name="with-id" as-type="token" max-occurs="unbounded">
                         <formal-name>Match Controls by Identifier</formal-name>
                         <description></description>
                         <group-as name="with-ids" in-json="ARRAY"/>
@@ -345,23 +345,23 @@
       <define-assembly name="remove">
             <formal-name>Removal</formal-name>
             <description>Specifies objects to be removed from a control based on specific aspects of the object that must all match.</description>
-            <define-flag name="by-name" as-type="NCName">
+            <define-flag name="by-name" as-type="token">
                   <formal-name>Reference by (assigned) name</formal-name>
                   <description>Identify items to remove by matching their assigned name</description>
             </define-flag>
-            <define-flag name="by-class" as-type="NCName">
+            <define-flag name="by-class" as-type="token">
                   <formal-name>Reference by class</formal-name>
                   <description>Identify items to remove by matching their <code>class</code>.</description>
             </define-flag>
-            <define-flag name="by-id" as-type="NCName">
+            <define-flag name="by-id" as-type="token">
                   <formal-name>Reference by ID</formal-name>
                   <description>Identify items to remove indicated by their <code>id</code>.</description>
             </define-flag>
-            <define-flag name="by-item-name" as-type="NCName">
+            <define-flag name="by-item-name" as-type="token">
                   <formal-name>Item Name Reference</formal-name>
                   <description>Identify items to remove by the name of the item's information element name, e.g. <code>title</code> or <code>prop</code></description>
             </define-flag>
-            <define-flag name="by-ns" as-type="NCName">
+            <define-flag name="by-ns" as-type="token">
                   <formal-name>Item Namespace Reference</formal-name>
                   <description>Identify items to remove by the item's <code>ns</code>, which is the namespace associated with a <code>part</code>, or <code>prop</code>.</description>
             </define-flag>
@@ -373,7 +373,7 @@
       <define-assembly name="add">
             <formal-name>Addition</formal-name>
             <description>Specifies contents to be added into controls, in resolution</description>
-            <define-flag name="position" as-type="NCName">
+            <define-flag name="position" as-type="token">
                   <formal-name>Position</formal-name>
                   <description>Where to add the new content with respect to the targeted element (beside it or inside it)</description>
                   <constraint>
@@ -385,7 +385,7 @@
                         </allowed-values>
                   </constraint>
             </define-flag>
-            <define-flag name="by-id" as-type="NCName">
+            <define-flag name="by-id" as-type="token">
                   <formal-name>Reference by ID</formal-name>
                   <description>Target location of the addition.</description>
             </define-flag>
@@ -419,7 +419,7 @@
                   <p><code>id-ref</code>, when given, should indicate, by its ID, an element inside the control to serve as the anchor point for the addition. In this case, <code>position</code> value may be any of the permitted values.</p>
             </remarks>
       </define-assembly>
-      <define-flag as-type="NCName" name="with-child-controls">
+      <define-flag as-type="token" name="with-child-controls">
             <formal-name>Include contained controls with control</formal-name>
             <description>When a control is included, whether its child (dependent) controls are also included.</description>
             <constraint>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -13,13 +13,13 @@
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
   <schema-name>OSCAL System Security Plan (SSP) Model</schema-name>
-  <schema-version>1.0.0-rc2</schema-version>
+  <schema-version>1.0.0</schema-version>
   <short-name>oscal-ssp</short-name>
   <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+  <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
   <remarks>
     <p>The OSCAL Control SSP format can be used to describe the information typically specified in a system security plan, such as those defined in NIST SP 800-18.</p>
-    <p>The root of the OSCAL System Security Plan (SSP) format is <code>system-security-plan</code>.
-    </p>
+    <p>The root of the OSCAL System Security Plan (SSP) format is <code>system-security-plan</code>.</p>
   </remarks>
 
   <import href="oscal_metadata_metaschema.xml"/>


### PR DESCRIPTION
# Committer Notes

Updates to OSCAL Metaschema sources in view of Metaschema processing enhancements addressing #805 and #911.

- New data type: `token` prohibits whitespace and enforces conformity with an XML-NCName workalike (also in JSON)
- Strings no longer permit leading or trailing whitespace

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
