### PR TITLE
Mapping whitespace in values of select/@how-many to hyphens '-'

### DIFF
--- a/src/release/content-upgrade/oscal-rc2-v1-0-0-update.xsl
+++ b/src/release/content-upgrade/oscal-rc2-v1-0-0-update.xsl
@@ -35,6 +35,13 @@
         <last-modified>{ current-dateTime() }</last-modified>
     </xsl:template>
 
+
+<!-- Usage change: we no longer permit spaces in values of select/@how-many -->
+    <xsl:template match="select/@how-many" expand-text="true">
+        <!-- trims and replaces remaining spaces with hyphens -->
+        <xsl:attribute name="how-many" select="normalize-space() ! replace(.,' ','-')"/>
+    </xsl:template>
+
     <!-- METASCHEMA MODULE oscal_catalog_metaschema.xml-->
     <!-- Catalog format changes only 'NCName' values to 'token'  -->
     


### PR DESCRIPTION
# Committer Notes

New template in RC2-v1.0.0 conversion XSLT to rewrite values of `select/@how-many` without whitespace (for schema validity).

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
