### PR TITLE
Add actions assembly to encode an action (i.e. approval) and its role, party, and approval date.

### DIFF
--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -770,14 +770,6 @@
             <formal-name>Action Universally Unique Identifier</formal-name>
             <description>A unique identifier that can be used to reference this defined action elsewhere in an OSCAL document. A UUID should be consistently used for a given location across revisions of the document.</description>
         </define-flag>
-        <define-flag name="role-id" as-type="token" required="yes">
-            <formal-name>Action Responsible Role Identifier</formal-name>
-            <description>Identifier of the approving role in the responsible party.</description>
-        </define-flag>
-        <define-flag name="party-uuid" as-type="token" required="yes">
-            <formal-name>Action Party Universally Unique Identifier</formal-name>
-            <description>The universally unique identifier of the party responsible for the action.</description>
-        </define-flag>
         <define-flag name="date" as-type="dateTime-with-timezone">
             <formal-name>Action Occurrence Date</formal-name>
             <description>The date and time when the action occurred.</description>
@@ -793,11 +785,6 @@
                 <p>Provides a means to segment the value space for the <code>type</code>, so that different organizations and individuals can assert control over the allowed <code>action</code>'s <code>type</code>. This allows the semantics associated with a given <code>type</code> to be defined on an organization-by-organization basis.</p>
                 <p>An organization MUST use a URI that they have control over. e.g., a domain registered to the organization in a URI, a registered uniform resource names (URN) namespace.</p>
             </remarks>
-            <constraint>
-               <allowed-values allow-other="yes">
-                  <enum value="http://csrc.nist.gov/ns/oscal">This value identifies action types defined in the NIST OSCAL namespace.</enum>
-               </allowed-values>
-            </constraint>
          </define-flag>
         <model>
             <assembly ref="property" max-occurs="unbounded">
@@ -806,15 +793,25 @@
             <assembly ref="link" max-occurs="unbounded">
                 <group-as name="links" in-json="ARRAY"/>
             </assembly>
+            <assembly ref="responsible-party" max-occurs="unbounded">
+                <group-as name="responsible-parties" in-json="ARRAY"/>
+            </assembly>
             <field ref="remarks" in-xml="WITH_WRAPPER"/>
         </model>
         <constraint>
-            <index-has-key name="index-metadata-role-id" target=".">
+            <index-has-key name="index-metadata-role-id" target="responsible-party">
                 <key-field target="@role-id"/>
             </index-has-key>
-            <index-has-key name="index-metadata-party-uuid" target=".">
-                <key-field target="@party-uuid"/>
+            <index-has-key name="index-metadata-party-uuid" target="responsible-party">
+                <key-field target="party-uuid"/>
             </index-has-key>
+            <allowed-values target="./system/@value" allow-other="yes">
+                <enum value="http://csrc.nist.gov/ns/oscal">This value identifies action types defined in the NIST OSCAL namespace.</enum>
+             </allowed-values>
+             <allowed-values target="./type[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@value">
+                <enum value="approval">An approval of a document instance's content.</enum>
+                <enum value="request-changes">A request from the responisble party or parties to change the content.</enum>
+            </allowed-values>
         </constraint>
     </define-assembly>
  

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -52,6 +52,9 @@
             <assembly ref="responsible-party" max-occurs="unbounded">
                 <group-as name="responsible-parties" in-json="ARRAY"/>
             </assembly>
+            <assembly ref="action" max-occurs="unbounded">
+                <group-as name="actions" in-json="ARRAY"/>
+            </assembly>
             <field ref="remarks" in-xml="WITH_WRAPPER"/>
         </model>
         <constraint>
@@ -759,6 +762,62 @@
             </index-has-key>
         </constraint>
     </define-assembly>
+ 
+    <define-assembly name="action">
+        <formal-name>Action</formal-name>
+        <description>An action applied by a role within a given party to the content.</description>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Action Universally Unique Identifier</formal-name>
+            <description>A unique identifier that can be used to reference this defined action elsewhere in an OSCAL document. A UUID should be consistently used for a given location across revisions of the document.</description>
+        </define-flag>
+        <define-flag name="role-id" as-type="token" required="yes">
+            <formal-name>Action Responsible Role Identifier</formal-name>
+            <description>Identifier of the approving role in the responsible party.</description>
+        </define-flag>
+        <define-flag name="party-uuid" as-type="token" required="yes">
+            <formal-name>Action Party Universally Unique Identifier</formal-name>
+            <description>The universally unique identifier of the party responsible for the action.</description>
+        </define-flag>
+        <define-flag name="date" as-type="dateTime-with-timezone">
+            <formal-name>Action Occurrence Date</formal-name>
+            <description>The date and time when the action occurred.</description>
+        </define-flag>
+        <define-flag name="type" as-type="token" required="yes">
+            <formal-name>Action Type</formal-name>
+            <description>The type of action documented by the assembly, such as an approval.</description>
+        </define-flag>
+        <define-flag name="system" as-type="uri" required="yes">
+            <formal-name>Action Type System</formal-name>
+            <description>Specifies the action type system used.</description>
+            <remarks>
+                <p>Provides a means to segment the value space for the <code>type</code>, so that different organizations and individuals can assert control over the allowed <code>action</code>'s <code>type</code>. This allows the semantics associated with a given <code>type</code> to be defined on an organization-by-organization basis.</p>
+                <p>An organization MUST use a URI that they have control over. e.g., a domain registered to the organization in a URI, a registered uniform resource names (URN) namespace.</p>
+            </remarks>
+            <constraint>
+               <allowed-values allow-other="yes">
+                  <enum value="http://csrc.nist.gov/ns/oscal">This value identifies action types defined in the NIST OSCAL namespace.</enum>
+               </allowed-values>
+            </constraint>
+         </define-flag>
+        <model>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <index-has-key name="index-metadata-role-id" target=".">
+                <key-field target="@role-id"/>
+            </index-has-key>
+            <index-has-key name="index-metadata-party-uuid" target=".">
+                <key-field target="@party-uuid"/>
+            </index-has-key>
+        </constraint>
+    </define-assembly>
+ 
     <define-assembly name="responsible-role">
         <formal-name>Responsible Role</formal-name>
         <description>A reference to one or more roles with responsibility for performing a function relative to the containing object.</description>


### PR DESCRIPTION
# Committer Notes

A follow-up to usnistgov/OSCAL#1033, a recommended implementation for an `actions` assembly to allow developers using OSCAL to encode approval data for given staff certain `role`s for a `responsible-party` at a certain date and time.

This PR supercedes the obsolete PR usnistgov/OSCAL#1038.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)? (deferred to https://github.com/usnistgov/oscal-content/issues/130)
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
