### PR TITLE
Requirement Tagging - Profile Resolution Specification

### DIFF
--- a/docs/content/concepts/_index.md
+++ b/docs/content/concepts/_index.md
@@ -19,6 +19,6 @@ This section of the OSCAL website presents:
 - Key [terminology](terminology/) used in OSCAL;
 - An overview of the OSCAL [layers and models](layer/), to include who and what processes they apply to;
 - An oververview of [identifier use](identifier-use) in OSCAL models;
-- A [processing specification](processing/) for handling some types of OSCAL content;
+- A [Profile Resolution Specification](processing/) for handling the transformation of OSCAL Profiles into OSCAL Catalogs;
 - Illustrative [examples](examples/) of how to represent control implementation and risk management data in OSCAL XML, JSON, and YAML formats; and
 - A discussion of how OSCAL [relates](relations-to-other/) to and draws inspiration from other documentary standards.

--- a/docs/content/concepts/processing/_index.md
+++ b/docs/content/concepts/processing/_index.md
@@ -1,13 +1,18 @@
 ---
-title: Processing Specification
+title: Processing Specifications
 weight: 50
 description: Standardized processes to be applied to OSCAL data
 aliases:
   - /documentation/specification/
   - /documentation/processing/
+suppresstopiclist: true
 ---
 
 OSCAL data is intended to be processed in many ways for many different purposes. The specifications here describe normative processes, in the sense that all OSCAL processors that perform these operations should produce the same outputs from the same inputs under the same configuration. However, users and developers should find many ways to take advantage of data encoded in OSCAL, even beyond what is considered here.
 
+**Please note that these specifications are currently a work in progress and are subject to change.** If you have any feedback or comments, please create an issue at the [NIST OSCAL Github Repository](https://github.com/usnistgov/OSCAL)
 
-**Please note that this specification is currently a work in progress and is subject to change.** If you have any feedback or comments, please create an issue at the [NIST OSCAL Github Repository](https://github.com/usnistgov/OSCAL)
+
+# Profile Resolution Specification
+
+The [Profile Resolution Specification](profile-resolution/) provides the standardized process for transforming an OSCAL Profile into an OSCAL Catalog. This specification is current a work in progress and is subject to change.

--- a/docs/content/concepts/processing/_index.md
+++ b/docs/content/concepts/processing/_index.md
@@ -8,3 +8,6 @@ aliases:
 ---
 
 OSCAL data is intended to be processed in many ways for many different purposes. The specifications here describe normative processes, in the sense that all OSCAL processors that perform these operations should produce the same outputs from the same inputs under the same configuration. However, users and developers should find many ways to take advantage of data encoded in OSCAL, even beyond what is considered here.
+
+
+**Please note that this specification is currently a work in progress and is subject to change.** If you have any feedback or comments, please create an issue at the [NIST OSCAL Github Repository](https://github.com/usnistgov/OSCAL)

--- a/src/specifications/profile-resolution/profile-resolution-specml.xml
+++ b/src/specifications/profile-resolution/profile-resolution-specml.xml
@@ -5,7 +5,7 @@
   <head>OSCAL Profile Resolution</head>
   <section id="draft">
     <head>Notice of Draft Status</head>
-    <p>Please note that this specification is currently a work in progress and is subject to change. If you have any feedback or comments, please create an issue at the NIST OSCAL Github Repository: <a href="https://github.com/usnistgov/OSCAL"/>. </p>
+    <p>Please note that this specification is currently a work in progress and is subject to change. If you have any feedback or comments, please create an issue at the NIST OSCAL Github Repository: <a href="https://github.com/usnistgov/OSCAL">github.com/usnistgov/OSCAL</a>.</p>
   </section>
   <section id="abstract">
     <head>Abstract</head>
@@ -262,7 +262,7 @@ profile:
       <xref rid="select-phase" />.
     </p>
     <p>The following section contains requirements for processing the
-      <src>import</src>child of a source
+      <src>import</src> child of a source
       <src>profile</src>
     </p>
     <section id="importhrefs">
@@ -286,9 +286,9 @@ profile:
       </section>
       <section id="internalref">
         <head>Internal References</head>
-        <p>URI Fragments in OSCAL represent internal references to other OSCAL objects in the same document. These references follow the pattern of &quot;#{{objectID}}&quot;. For example, the URI Fragment &quot;#param1&quot; is referencing the Parameter with unique ID &quot;param1&quot;.</p>
+        <p>URI Fragments in OSCAL represent internal references to other OSCAL objects in the same document. These references follow the pattern of <code>#{{objectID}}</code>. For example, the URI Fragment <code>#param1</code> is referencing the Parameter with unique ID <code>param1</code>.</p>
         <p><req level="must" id="req-internal">In the context of the Import Phase, internal references will only appear as a reference to a profile or catalog that is in the <src>resources</src> section of the source. When tools encounter such a reference, they MUST locate the object in <src>resources</src> with the matching ID value, and resolve the import using the
-          <src>rlink</src>URI and the above resolution requirements.
+          <src>rlink</src> URI and the above resolution requirements.
         </req></p>
         <p><req level="must" id="req-internal-error">If the object fetched cannot be found or is not a valid OSCAL object, the tool MUST cease processing and provide an error.</req></p>
         <tagging whose="source_profile">
@@ -317,11 +317,11 @@ profile:
         <p><req level="must" id="req-circular-resolve">If the resource acquired is an OSCAL Profile, the tool MUST apply this specification to resolve it, then continue processing having imported the resulting catalog.</req></p>
         <p><req level="should" id="req-circular-catalog">When a profile imports a profile, the subordinate profile SHOULD be resolved first into a catalog using this specification, before it is imported. </req> This presents the possibility of circular imports, when a profile is directed to import itself either directly or indirectly.</p>
         <p>A
-          <term>circular import</term>occurs when a profile imports an already imported profile, which was called at an earlier place in the import hierarchy. For example, if profile A imports profile B, and profile B imports profile A, the second import is circular. (An import at the top can only be circular if a profile tries to import itself.) If A imports B, B imports C and C imports A, C’s import is circular.
+          <term>circular import</term> occurs when a profile imports an already imported profile, which was called at an earlier place in the import hierarchy. For example, if profile A imports profile B, and profile B imports profile A, the second import is circular. (An import at the top can only be circular if a profile tries to import itself.) If A imports B, B imports C and C imports A, C’s import is circular.
         </p>
         <p>Note that an import can only be circular within the context of processing a particular profile. In the last example, C’s import would not be circular if invoked in the context of resolving B by itself.</p>
         <p><req level="must" id="req-circular-error">If a processor encounters a
-          <term>circular import</term>as described above (self-imports are inherently circular), the processor MUST cease processing and generate an error.
+          <term>circular import</term> as described above (self-imports are inherently circular), the processor MUST cease processing and generate an error.
         </req></p>
         <mapping>
           <p>A profile identified as
@@ -403,15 +403,15 @@ intermediate:
       <section id="mapping">
         <head>Mapping Controls</head>
         <p>The optional
-          <src>mapping</src>child of a given
-          <src>import</src>provides a simple ID remapping for objects included from that specific import. This provides the means for profile authors to proactively avoid clashing IDs of controls and other objects.
+          <src>mapping</src> child of a given
+          <src>import</src> provides a simple ID remapping for objects included from that specific import. This provides the means for profile authors to proactively avoid clashing IDs of controls and other objects.
         </p>
         <p>The Mapping section consists of 5 optional subsections, each covering a particular type of object. Each subsection is a list of ID mappings to be applied for objects that are the parent object type.</p>
         <p>When encountering a given mapping instruction, processors:</p>
         <ul>
           <li>
             <p>MUST change the distinctive ID of that object to be equal to the value of the
-              <src>to</src>object.
+              <src>to</src> object.
             </p>
           </li>
           <li>
@@ -420,7 +420,7 @@ intermediate:
         </ul>
         <p>Since mapping is a self contained process inside each import, the rest of this specification will continue to reference IDs with the assumption that mapping has already been applied if it was present. Since mapping is most commonly used to avoid clashing IDs, processors should take care to not handle duplicate IDs until after mapping is complete.</p>
         <p>Below is a simple example of mapping. The second
-          <src>import</src>is included controls from a different catalog whose ID values happen to collide. Knowing this, the profile author has remapped those IDs to new values.
+          <src>import</src> included controls from a different catalog whose ID values happen to collide. Knowing this, the profile author has remapped those IDs to new values.
         </p>
         <tagging whose="source_profile">
           <![CDATA[
@@ -470,17 +470,17 @@ intermediate:
       <section id="include-all">
         <head>include-all</head>
         <p><req level="must" id="req-include-all">When an import provides the
-          <src>include-all</src>directive, ALL controls and groups in the referenced document (including nested controls) MUST be included.
+          <src>include-all</src> directive, ALL controls and groups in the referenced document (including nested controls) MUST be included.
         </req></p>
         <tagging whose="source_profile">include-all: ~</tagging>
       </section>
       <section id="include-by-id">
         <head>include-controls plus with-id</head>
         <p><req level="must" id="req-include-by-id">When an import provides the
-          <src>include-controls</src>directive, with a
-          <src>with-id</src>child, all controls in the referenced document whose
-          <code>id</code>match one of the listed
-          <code>id</code>values MUST be included.
+          <src>include-controls</src> directive, with a
+          <src>with-id</src> child, all controls in the referenced document whose
+          <code>id</code> match one of the listed
+          <code>id</code> values MUST be included.
         </req></p>
         <tagging whose="source_profile">
           <![CDATA[
@@ -494,13 +494,13 @@ include-controls:
         <head>include-controls plus matching</head>
         <p>Controls may also be included using match patterns against their IDs. This is useful because related controls (either in a hierarchy, or together in a group) frequently have related IDs as well.</p>
         <p><req level="must" id="req-include-by-match">When an import provides the
-          <src>include-controls</src>directive, with a
-          <src>matching</src>child, all controls in the referenced document whose
-          <code>id</code>matches one of the listed
-          <code>pattern</code>values (Glob matching) MUST be included.
+          <src>include-controls</src> directive, with a
+          <src>matching</src> child, all controls in the referenced document whose
+          <code>id</code> matches one of the listed
+          <code>pattern</code> values (Glob matching) MUST be included.
         </req></p>
         <p><req level="must" id="req-include-by-match-empty">If a
-          <code>matching</code>object is provided with no
+          <code>matching</code> object is provided with no
           <code>pattern</code>, it MUST be treated as matching nothing. While not providing a pattern is technically valid, resolution tool implementers should be aware that it is generally undesirable, and warnings or notices to the user may be appropriate.
         </req></p>
         <tagging whose="source_profile">
@@ -515,22 +515,22 @@ include-controls:
         <p>In OSCAL, controls may contain child controls. For instance, in SP 800-53 many controls are supplemented with control enhancements; in OSCAL these are represented as child controls within parent controls. So parent AC-2 (in a given catalog) has children AC-2(1) through AC-2(13), for example.</p>
         <p>By default, inclusion of a control also causes any of that control&apos;s ancestors (or parents) to also be included. By default, inclusion of a control DOES NOT cause the inclusion of any descendants (or children) of that control to be included. This applies to both controls and groups.</p>
         <p>This default behavior can be modified by the following two optional children of the
-          <src>include-controls</src>object.
+          <src>include-controls</src> object.
         </p>
         <section id="include-child-controls">
           <head>with-child-controls</head>
-          <p>Child controls are, for the most part, treated the same as top level controls: they can be explicitly included using the selection directives above. As a shortcut to manually including all of the desired descendant controls of a given control, OSCAL provides the &quot;with-child-controls&quot; option. &quot;with-child-controls&quot; appears as a child object under a given inclusion directive, and defines additional behavior that is to be executed alongside the parent inclusion.</p>
+          <p>Child controls are, for the most part, treated the same as top level controls: they can be explicitly included using the selection directives above. As a shortcut to manually including all of the desired descendant controls of a given control, OSCAL provides the <code>with-child-controls</code> option. <code>with-child-controls</code> appears as a child object under a given inclusion directive, and defines additional behavior that is to be executed alongside the parent inclusion.</p>
           <p><req level="must" id="req-with-child-controls-yes">A
-            <src>with-child-controls: yes</src>directive on an
-            <src>include-controls</src>indicates that
-            <em>all descendant controls</em>of the included control MUST also be included.
+            <src>with-child-controls: yes</src> directive on an
+            <src>include-controls</src> indicates that
+            <em>all descendant controls</em> of the included control MUST also be included.
           </req></p>
           <p><req level="must" id="req-with-child-controls-no">A
-            <src>with-child-controls: no</src>directive on an
-            <src>include-controls</src>indicates that ONLY the matching control is included, any descendant children MUST NOT be included.
+            <src>with-child-controls: no</src> directive on an
+            <src>include-controls</src> indicates that ONLY the matching control is included, any descendant children MUST NOT be included.
           </req></p>
           <p><req level="must" id="req-with-child-controls-none">If no
-            <src>with-child-controls</src>is provided, the processor MUST consider the directive as being equivalent to one having
+            <src>with-child-controls</src> is provided, the processor MUST consider the directive as being equivalent to one having
             <src>with-child-controls:no</src>.
           </req></p>
         </section>
@@ -538,20 +538,20 @@ include-controls:
           <head>with-parent-controls</head>
           <p>Although similar to the above
             <src>with-child-controls</src>, the optional
-            <src>with-parent-controls</src>applies to parents of the included control, and has the opposite default behavior. In order to maintain the structure of the source catalog, profile resolution includes all parents of an included control by default. If a profile author wants to change this structure, they could use an exclude directive that lists all of the undesired parents. As a shortcut for this,
-            <src>with-parent-controls</src>provides the following functionality:
+            <src>with-parent-controls</src> applies to parents of the included control, and has the opposite default behavior. In order to maintain the structure of the source catalog, profile resolution includes all parents of an included control by default. If a profile author wants to change this structure, they should use an exclude directive that lists all of the undesired parents. As a shortcut for this,
+            <src>with-parent-controls</src> provides the following functionality:
           </p>
           <p><req level="must" id="req-with-parent-controls-yes">A
-            <src>with-parent-controls: yes</src>directive on an
-            <src>include-controls</src>indicates that
-            <em>all parent controls</em>of the included control MUST also be included.
+            <src>with-parent-controls: yes</src> directive on an
+            <src>include-controls</src> indicates that
+            <em>all parent controls</em> of the included control MUST also be included.
           </req></p>
           <p><req level="must" id="req-with-parent-controls-no">A
-            <src>with-parent-controls: no</src>directive on an
-            <src>include-controls</src>indicates that ONLY the matching control is included, any parents MUST NOT be included.
+            <src>with-parent-controls: no</src> directive on an
+            <src>include-controls</src> indicates that ONLY the matching control is included, any parent MUST NOT be included.
           </req></p>
           <p><req level="must" id="req-with-parent-controls-none">If no
-            <src>with-parent-controls</src>is provided, the processor MUST consider the directive as being equivalent to one having
+            <src>with-parent-controls</src> is provided, the processor MUST consider the directive as being equivalent to one having
             <src>with-parent-controls:yes</src>.
           </req></p>
         </section>
@@ -560,22 +560,22 @@ include-controls:
         <head>exclude-controls</head>
         <p>Exclusions work the same way as inclusions, except with the opposite effect - the indicated control(s) do not appear in the target catalog.</p>
         <p><req level="must" id="req-exclude">Any control designated to be both included and excluded, MUST be excluded. This holds irrespective of the specificity of the selection for inclusion or exclusion.</req> For example, if AC-1 is included by id
-          <code>ac-1</code>and excluded by matching
+          <code>ac-1</code> and excluded by matching
           <code>ac.*</code>, it is excluded.
         </p>
         <p><req level="must" id="req-exclude-additional">When
-          <src>exclude-controls</src>has at least one
-          <src>with-ids</src>or
-          <src>matching</src>directive, the processor MUST follow the same rules as defined in the relevant sections above for these directives, but exclude instead of include any controls. All optional features (with-child-controls, etc.) also apply to exclusion directives.
+          <src>exclude-controls</src> has at least one
+          <src>with-ids</src> or
+          <src>matching</src> directive, the processor MUST follow the same rules as defined in the relevant sections above for these directives, but exclude instead of include any controls. All optional features (<src>with-child-controls</src>, etc.) also apply to exclusion directives.
         </req></p>
       </section>
       <section id="redundant-calls">
         <head>Redundant Inclusions and Exclusions</head>
         <p><req level="must" id="req-redundant">A given
-          <src>import</src>may have any number of inclusion statements and any number of exclusion statements. Their effect is cumulative; any control that is included (or excluded) more than once MUST be considered to be included (or excluded) only once. In other words, a given control being included or excluded more than once has no effect. Exclusion still takes priority over inclusion (see above).
+          <src>import</src> may have any number of inclusion statements and any number of exclusion statements. Their effect is cumulative; any control that is included (or excluded) more than once MUST be considered to be included (or excluded) only once. In other words, a given control being included or excluded more than once has no effect. Exclusion still takes priority over inclusion (see above).
         </req></p>
         <p>Note that this requirement only applies to controls included within the context of a single import. Controls with duplicate IDs included under a different
-          <src>import</src>are not discarded. Also note that this redundancy pruning happens after any relevant mappings have been applied.
+          <src>import</src> are not discarded. Also note that this redundancy pruning happens after any relevant mappings have been applied.
         </p>
       </section>
       <section id="import-param">
@@ -584,15 +584,15 @@ include-controls:
           <src>param</src>that is not directly under a control is referred to as a
           <q>loose</q>param.
         </p>
-        <p><req level="must" id="req-loose-param">All loose params from both imported documents and the profile source MUST be included. These params will be kept in the final output if document contains any references to them, and discarded otherwise. See
+        <p><req level="must" id="req-loose-param">All loose params from both imported documents and the profile source MUST be included. These params will be kept in the final output if the document contains any references to them, and discarded otherwise. See
           <xref rid="cleanup" />.</req> Since new references can be created during the
-          <src>modify</src>phase, tools should be careful not to prune params without fully understanding the final state of the output document.
+          <src>modify</src> phase, tools should be careful not to prune params without fully understanding the final state of the output document.
         </p>
       </section>
       <section id="import-group"> <!-- TODO: Add requirements here? Take another look at this. -->
         <head>Handling Groups</head>
         <p>Some source catalogs use
-          <src>group</src>objects to place controls into arbitrary groupings. Tools will need to be aware of these groups when executing the "merge" phase below, as they will duplicated into the output under the "as-is" mode and can be referenced in "custom" mode. The naïve intermediate approach would keep all groups until all other phases are complete, but implementations may find it more performant to look ahead and prune unused groups early.
+          <src>group</src> objects to place controls into arbitrary groupings. Tools will need to be aware of these groups when executing the "merge" phase below, as they will duplicated into the output under the "as-is" mode and can be referenced in "custom" mode. The naïve intermediate approach would keep all groups until all other phases are complete, but implementations may find it more performant to look ahead and prune unused groups early.
         </p>
       </section>
       <section id="import-pitfalls">
@@ -609,8 +609,8 @@ include-controls:
     <section id="import-wrap-up">
       <head>Wrapping up the Import Phase</head>
       <p>At this point all requirements for content importing and control inclusion have been covered. If using the intermediate approach, the processor should have an intermediate that contains: a set of included controls and all of their child informational (non-control, non-group) objects, any relevant
-        <src>group</src>objects and their informational content, and a set of included &quot;loose params&quot;
-        <xref rid="import-param" />(zero to many). The general structure of the intermediate would match that of the imported catalogs (i.e. Nested controls remain nested, grouped controls remain grouped).
+        <src>group</src> objects and their informational content, and a set of included &quot;loose params&quot;
+        <xref rid="import-param" /> (zero to many). The general structure of the intermediate would match that of the imported catalogs (i.e. nested controls remain nested, grouped controls remain grouped).
       </p>
     </section>
   </section>
@@ -618,11 +618,11 @@ include-controls:
     <head>Merge Phase</head>
     <p>Profiles may contain a
       <src>merge</src>section, where directives are given to instruct the processor how to combine the set of included objects collected during the Import Phase.
-      <code>merge</code>has two parts: a &quot;combine&quot; directive, and a &quot;structuring&quot; directive.
+      <src>merge</src>has two parts: a &quot;combine&quot; directive, and a &quot;structuring&quot; directive.
     </p>
     <p><req level="recommended" id="req-merge-order">It is RECOMMENDED that tools apply the &quot;combine&quot; directive to the intermediate generated by the Import phase first, then apply the &quot;structuring&quot; directive.</req></p>
     <p>The following section contains requirements for processing the
-      <src>merge</src>child of a source profile.
+      <src>merge</src> child of a source profile.
     </p>
     <section id="merge-combine">
       <head>The &quot;combine&quot; Directive</head>
@@ -647,12 +647,12 @@ include-controls:
       <p>In order to apply the combination method, IDs of each control explicitly included are compared against one another. As IDs are unique across entire OSCAL documents, different imports or any groupings have no bearing on collision. Processing requirements for each method are described below.</p>
       <section id="no-merge-explicit">
         <head>No Combine Directive</head>
-        <p><req level="must" id="req-merge-none">If no
-          <src>merge</src>directive is given in the profile, or if a
-          <src>merge</src>is given without a
+        <p><req level="must" id="req-merge-none"> If no
+          <src>merge</src> directive is given in the profile, or if a
+          <src>merge</src> is given without a
           <src>combine</src>, merge conflicts MUST be treated as if
-          <src>method: keep</src>was given. </req> For example, a profile with no
-          <src>merge</src>directive:
+          <src>method: keep</src> was given. </req> For example, a profile with no
+          <src>merge</src> directive:
         </p>
         <tagging whose="source_profile">
           <![CDATA[
@@ -680,7 +680,7 @@ profile:
         </head>
         <p><req level="must" id="req-merge-keep">When a merge is indicated by
           <src>method:keep</src>, or when no merge directive is given, the
-          <q>keep</q>combination rule is used. Any controls with the same distinctive ID
+          <q>keep</q>combination rule is used. Any control with the same distinctive ID
           <xref rid="id" />MUST NOT not merged. (They are kept.)
         </req></p>
         <tagging whose="source_profile">
@@ -720,8 +720,8 @@ intermediate:
           - ac-2 ]]>
         </tagging>
         <p>In this case, downstream errors should be expected: the two
-          <code>ac-1</code>controls clash with each other, as do the two
-          <code>ac-2</code>controls.
+          <code>ac-1</code> controls clash with each other, as do the two
+          <code>ac-2</code> controls.
         </p>
         <p><req level="should" id="req-merge-keep-warning">Processors SHOULD provide a warning under the merge:keep directive when duplicate controls are detected.</req> <req level="may" id="req-merge-keep-error">The processor MAY throw an error and cease processing (short-circuiting a certain future error) when duplicate controls are detected under the merge:keep directive.</req></p>
       </section>
@@ -736,8 +736,8 @@ intermediate:
       method: use-first ]]>
         </tagging>
         <p><req level="must" id="req-merge-use-first">When the
-          <q>use-first</q>combination rule is applied, and controls that share a distinctive ID are found, the first control encountered MUST be kept, the rest MUST be discarded.
-          <q>First</q>MUST be determined by a top-down, depth-first traversal of the source profile&apos;s import hierarchy.
+          &quot;use-first&quot;combination rule is applied, and controls that share a distinctive ID are found, the first control encountered MUST be kept, the rest MUST be discarded.
+          &quot;First&quot; MUST be determined by a top-down, depth-first traversal of the source profile&apos;s import hierarchy.
         </req></p>
         <mapping>
           <tagging whose="source_profile">
@@ -781,7 +781,7 @@ intermediate:
       <head>The &quot;structuring&quot; Directive</head>
       <p>This section describes how a profile may dictate the structure of the target
         <tgt>catalog</tgt>, apart from its
-        <tgt>metadata</tgt>or
+        <tgt>metadata</tgt> or
         <tgt>back-matter</tgt>. <req level="must" id="req-stucture">Optionally, one of three &quot;structuring&quot; directives can be included as a child of
         <src>merge</src>:
         <src>flat</src>,
@@ -791,10 +791,10 @@ intermediate:
       <section id="structure-none">
         <head>No Structuring Directive</head>
         <p><req level="must" id="req-structure-none">If no
-          <src>merge</src>directive is given in the profile, or if a
-          <src>merge</src>is given without a structuring directive, structuring the output MUST be treated as if the structuring directive
-          <src>flat</src>was given. For example, a profile with no
-          <src>merge</src>directive:
+          <src>merge</src> directive is given in the profile, or if a
+          <src>merge</src> is given without a structuring directive, structuring the output MUST be treated as if the structuring directive
+          <src>flat</src> was given. For example, a profile with no
+          <src>merge</src> directive:
         </req></p>
         <tagging whose="source_profile">
           <![CDATA[
@@ -869,10 +869,10 @@ intermediate:
           <q>as-is</q>
         </head>
         <p>An
-          <src>as-is</src>directive is used to reproduce the structure of the source documents in the target catalog.
+          <src>as-is</src> directive is used to reproduce the structure of the source documents in the target catalog.
         </p>
         <p><req level="must" id="id-structure-as-is-list">Processors MUST handle the
-          <src>as-is</src>directive by adhering to the following requirements:</req> <!-- TODO, ISSUE, REQ TAGGING OF LISTS -->
+          <src>as-is</src> directive by adhering to the following requirements:</req> <!-- TODO, ISSUE, REQ TAGGING OF LISTS -->
         </p>
         <ul>
           <li>
@@ -934,36 +934,36 @@ intermediate:
           <head>Creating Custom Groups</head>
           <p><req level="must" id="req-custom-group">A
             <src>group</src>object given under
-            <src>custom</src>MUST result in a
-            <tgt>group</tgt>with the exact same content (excluding
+            <src>custom</src> MUST result in a
+            <tgt>group</tgt> with the exact same content (excluding
             <src>insert-controls</src>) in the target catalog.
           </req></p>
           <p><req level="must" id="req-custom-group-contents">If the ID of the group matches the ID of a group that has been included during the import phase, all contents inside the group, including
             <src>title</src>,
             <src>param</src>,
-            <src>prop</src>and
-            <src>part</src>objects MUST be copied into the target, appearing in the same order as in the source.
+            <src>prop</src> and
+            <src>part</src> objects MUST be copied into the target, appearing in the same order as in the source.
           </req></p>
           <p>Note that groups defined in
-            <src>custom</src>may vary from fully featured to minimally instantiated. This includes arbitrary nesting of such groups inside of one another. No groups other than those explicitly declared should appear in the output catalog.
+            <src>custom</src> may vary from fully featured to minimally instantiated. This includes arbitrary nesting of such groups inside of one another. No groups other than those explicitly declared should appear in the output catalog.
           </p>
         </section>
         <section id="custom-selection">
           <head>Inserting Controls</head>
           <p>The
-            <src>insert-controls</src>directive may appear anywhere under
+            <src>insert-controls</src> directive may appear anywhere under
             <src>custom</src>, whether as a direct child or inside any of the defined groups. Inside insert-controls,
-            <src>include-controls</src>and
-            <src>include-all</src>from the Import Phase
+            <src>include-controls</src> and
+            <src>include-all</src> from the Import Phase
             <xref rid="import" />are used with the same basic behavior to configure which controls are selected and inserted at the current location.
           </p>
           <p>In order to provide clarity, controls that match the various conditions of these inclusion directives inside the
-            <src>custom</src>object will be referred to as &quot;selected&quot; instead of &quot;included&quot;. Only directly selected controls will appear in the target catalog.
+            <src>custom</src> object will be referred to as &quot;selected&quot; instead of &quot;included&quot;. Only directly selected controls will appear in the target catalog.
           </p>
           <p><req level="must" id="req-custom-select">When processing the control selection of a <src>custom</src> element, the behavior defined in this section MUST be followed to generate the output.</req></p>
           <p>A
-            <src>insert-controls</src>with an
-            <src>include-controls</src>child results in the following behavior:
+            <src>insert-controls</src> with an
+            <src>include-controls</src> child results in the following behavior:
           </p>
           <ul>
             <li>
@@ -982,12 +982,12 @@ intermediate:
             </li>
           </ul>
           <p>An
-            <src>insert-controls</src>with an
-            <src>include-all</src>child results in all included controls being selected and inserted. They are given in the same order as they appear in the input control selection(s).
+            <src>insert-controls</src> with an
+            <src>include-all</src> child results in all included controls being selected and inserted. They are given in the same order as they appeared in the input control selection(s).
           </p>
           <p>
-            <src>insert-controls</src>can also indicate the order that the selected controls are to be emitted in the result catalog using an
-            <src>order</src>child. Three values MUST be supported and handled as specified below:
+            <src>insert-controls</src> can also indicate the order that the selected controls are to be emitted in the result catalog using an
+            <src>order</src> child. Three values MUST be supported and handled as specified below:
           </p>
           <ul>
             <li>
@@ -1006,7 +1006,7 @@ intermediate:
               </p>
             </li>
           </ul>
-          <p><req level="must" id="req-custom-select-ignore">In the case that a control selection matches none of the included controls, it MUST be ignored.</req> <req level="should" id="req-custom-select-warning">In the case that a control selection matches none of the included controls, a warning SHOULD be provided.</req> If a control that was included by the Import Phase is never selected, no error occurs, that control simply does not appear in the output catalog.</p>
+          <p><req level="must" id="req-custom-select-ignore">In the case that a control selection matches none of the included controls, it MUST be ignored.</req> <req level="should" id="req-custom-select-warning">In the case that a control selection matches none of the included controls, a warning SHOULD be provided.</req> If a control that was included by the Import Phase is never selected, no error occurs. That control simply does not appear in the output catalog.</p>
         </section>
       </section>
     </section>
@@ -1020,16 +1020,16 @@ intermediate:
   </section>
   <section id="modify-phase">
     <head>Modify Phase</head>
-    <p>There are two ways profiles may further modify the results of profile resolution: setting parameters, and altering controls. These activities are defined as two child objects inside the third step of profile resolution, the Modify Phase.</p>
+    <p>There are two ways profiles may further modify the results of profile resolution: setting parameters and altering controls. These activities are defined as two child objects inside the third step of profile resolution, the Modify Phase.</p>
     <p>The following section contains requirements for processing the
-      <src>modify</src>child of a source profile.
+      <src>modify</src> child of a source profile.
     </p>
     <section id="param-setting">
       <head>Setting Parameters</head>
       <p>Modification of parameter settings is indicated using the
-        <src>set-parameter</src>object under
+        <src>set-parameter</src> object under
         <src>modify</src>. For this section, a given
-        <src>set-parameter</src>object will be referred to as the
+        <src>set-parameter</src> object will be referred to as the
         source.
       </p>
       <p>Profile Resolution Tools MUST adhere to the following requirements for processing &quot;set-parameter&quot;:</p>
@@ -1041,12 +1041,12 @@ intermediate:
           <p><req level="must" id="req-modify-set-param-objects1">For the following objects inside the source: class, depends-on, label, usage, values, select; the object MUST be copied into the target from the source, first removing any existing objects with the same name.</req></p>
         </li>
         <li>
-          <p><req level="must" id="req-modify-set-param-objects2">For the following objects inside the source: props, links, constraints, guidelines; the contents of the object MUST be added to the contents of the target object of the same name. If no such object exists in the target, it is created.</req></p>
+          <p><req level="must" id="req-modify-set-param-objects2">For the following objects inside the source: props, <src>links</src>, <src>constraints</src>, <src>guidelines</src>; the contents of the object MUST be added to the contents of the target object of the same name. If no such object exists in the target, it is created.</req></p>
         </li>
-        <li> <p><req level="must" id="req-modify-set-param-objects3">For the following objects inside the source: prop, link; the object MUST be copied into the target from the source, first removing any existing objects with the same distinctive ID. (<xref rid="id"></xref>).</req></p></li>
+        <li> <p><req level="must" id="req-modify-set-param-objects3">For the following objects inside the source: <src>prop</src>, <src>link</src>; the object MUST be copied into the target from the source, first removing any existing objects with the same distinctive ID. (<xref rid="id"></xref>).</req></p></li>
         <li>
           <p><req level="must" id="req-modify-param-multi">If more than one
-            <src>set-parameter</src>directive is given for the same parameter, all MUST BE applied, in the sequence given in the profile.</req>
+            <src>set-parameter</src> directive is given for the same parameter, all MUST BE applied, in the sequence given in the profile.</req>
           </p>
         </li>
       </ul>
@@ -1064,30 +1064,30 @@ intermediate:
         <section id="add-to-control">
           <head>Implicit binding</head>
           <p><req level="must" id="req-modify-alter-add-implicit">An
-            <src>add</src>directive with no
+            <src>add</src> directive with no
             <src>by-id</src> child MUST be considered an implicit binding, and will apply to the control as a whole.</req>
           </p>
           <p><req level="must" id="req-modify-alter-add-implicit0contents">The contents of an implicitly bound add directive MUST be added to the control contents in the target, either after its
-            <tgt>title</tgt>when
-            <src>position</src>is
+            <tgt>title</tgt> when
+            <src>position</src> is
             <code>starting</code>, or at the end if its position is
-            <code>ending</code>, or if no valid poisition is given.</req>
+            <code>ending</code>, or if no valid position is given.</req>
           </p>
           <p><req level="must" id="req-modify-alter-add-implicit-position">When an add directive is implicitly bound, the
-            <src>position</src>values
-            <code>before</code>and
-            <code>after</code>MUST be treated like
-            <code>starting</code>and
+            <src>position</src> values
+            <code>before</code> and
+            <code>after</code> MUST be treated like
+            <code>starting</code> and
             <code>ending</code>, respectively.</req>
           </p>
           <p>Control contents in catalogs must appear in the order
-            <code>title, param, prop, link, part, control</code> per the OSCAL model documentation. <req level="must" id="req-modify-alter-add-implicit-order">After processing an implicitly bound add directive, the control contents MUST be sorted to appear in the required order: a new
-            <tgt>prop</tgt>appears after any
-            <src>prop</src>already in the control, when
-            <src>position</src>is
+            <code>title</code>, <code>param</code>, <code>prop</code>, <code>link</code>, <code>part</code>, <code>control</code> per the OSCAL model documentation. <req level="must" id="req-modify-alter-add-implicit-order">After processing an implicitly bound add directive, the control contents MUST be sorted to appear in the required order: a new
+            <tgt>prop</tgt> appears after any
+            <src>prop</src> already in the control, when
+            <src>position</src> is
             <code>ending</code>, or not given, or before any
-            <src>prop</src>in the control when
-            <src>position</src>is
+            <src>prop</src> in the control when
+            <src>position</src> is
             <code>starting</code>.</req>
           </p>
 
@@ -1189,17 +1189,17 @@ control:
         <section id="add-to-element">
           <head>Explicit binding</head>
           <p>An explicit binding on an addition permits inserting new contents anywhere in a control, not only at the top level. <req level="must" id="req-modify-alter-add-explicit">An
-            <src>add</src>directive with a
-            <src>by-id</src> child MUST be considered an explicit binding, and applies to only a single object inside the control.</req> <req level="must" id="req-modify-alter-add-explicit-id">When an add directive is explitly bound, the value of the
+            <src>add</src> directive with a
+            <src>by-id</src> child MUST be considered an explicit binding, and applies to only a single object inside the control.</req> <req level="must" id="req-modify-alter-add-explicit-id">When an add directive is explicitly bound, the value of the
             <src>by-id</src> child MUST correspond to the value of an
-              <src>id</src>on an object inside the control, and not the control itself.</req> <req level="must" id="req-modify-alter-add-explicit-id-ignore">If
-            <src>by-id</src>does not correspond to such a value, the
-                <src>add</src>directive MUST be considered inoperative and ignored.</req> <req level="may" id="req-modify-alter-add-explicit-id-warning">An inoperative add directive MAY result in a warning.</req>
+              <src>id</src> on an object inside the control, and not the control itself.</req> <req level="must" id="req-modify-alter-add-explicit-id-ignore">If
+            <src>by-id</src> does not correspond to such a value, the
+                <src>add</src> directive MUST be considered inoperative and ignored.</req> <req level="may" id="req-modify-alter-add-explicit-id-warning">An inoperative add directive MAY result in a warning.</req>
           </p>
           <p>The object with
-            <src>id</src>equal to the value of
-            <src>by-id</src>is considered the
-            <term>target</term>of the addition.
+            <src>id</src> equal to the value of
+            <src>by-id</src> is considered the
+            <term>target</term> of the addition.
           </p>
           <p><req level="must" id="req-modify-alter-add-explicit-inside">When
             <src>position</src> has a value of
@@ -1295,9 +1295,9 @@ control:
           <head>Modifying controls inside controls
           </head>
           <p>OSCAL supports controls inside controls in the form of
-            <src>control</src>objects inside
-            <src>control</src>objects. Because the semantics of the
-            <src>add</src> and remove directives target any (object) contents of controls, they can be used to target these child controls for modification as well as other contents. <req level="must" id="req-modify-alter-add-nested">Profile Resolution tools MUST be able to correctly handle add directives targetting nested controls. This includes directives that target a child control as well as directives that target a parent control and modify the child. </req> </p>
+            <src>control</src> objects inside
+            <src>control</src> objects. Because the semantics of the
+            <src>add</src> and remove directives target any (object) contents of controls, they can be used to target these child controls for modification as well as other contents. <req level="must" id="req-modify-alter-add-nested">Profile resolution tools MUST be able to correctly handle add directives targetting nested controls. This includes directives that target a child control as well as directives that target a parent control and modify the child. </req> </p>
         </section>
       </section>
       <section id="remove-directive">
@@ -1305,33 +1305,33 @@ control:
         <p>Contents inside controls can be removed from them in catalog targets. In combination with adding new contents, this feature can be used to edit controls as well as amend them.</p>
         <p>A
           <src>remove</src>directive inside an
-          <src>alter</src>directive identifies an object or set of objects inside a control to be removed. It does this using any of five child objects.
+          <src>alter</src> directive identifies an object or set of objects inside a control to be removed. It does this using any of five child objects.
         </p>
         <p><req level="must" id="req-modify-alter-remove-match"> An object inside the control MUST be removed from the output if and only if it meets all of the criteria given by the child objects of the remove directive.</req> When more than one child appears under the remove directive, an object would need to match all of them, otherwise it is not removed. </p>
         <ul>
           <li>
             <p>
-              <req level="must" id="req-modify-alter-remove-by-id">The remove directive criteria <src>by-id</src> MUST match an object if and only its value is identical to the <src>id</src> value of that object.</req> Because
-              <src>id</src>values are unique, this criteria will result in the remove directive removing only a single object.
+              <req level="must" id="req-modify-alter-remove-by-id">The remove directive criteria <src>by-id</src> MUST match an object if and only if its value is identical to the <src>id</src> value of that object.</req> Because
+              <src>id</src> values are unique, this criteria will result in the remove directive removing only a single object.
             </p>
           </li>
           <li>
             <p>
-              <req level="must" id="req-modify-alter-remove-name-ref">The remove directive criteria <src>name-ref</src> MUST match an object if and only its value is identical to the value of that object's <src>name</src> child.</req>
+              <req level="must" id="req-modify-alter-remove-name-ref">The remove directive criteria <src>name-ref</src> MUST match an object if and only if its value is identical to the value of that object's <src>name</src> child.</req>
             </p>
           </li>
           <li>
-            <p><req level="must" id="req-modify-alter-remove-ns-ref">The remove directive criteria <src>ns-ref</src> MUST match an object if and only its value is identical to the value of that object's <src>ns</src> child.</req></p>
+            <p><req level="must" id="req-modify-alter-remove-ns-ref">The remove directive criteria <src>ns-ref</src> MUST match an object if and only if its value is identical to the value of that object's <src>ns</src> child.</req></p>
           </li>
           <li>
-            <p><req level="must" id="req-modify-alter-remove-class-ref">The remove directive criteria <src>class-ref</src> MUST match an object if and only its value is identical to the value of that object's <src>class</src> child.</req></p>
+            <p><req level="must" id="req-modify-alter-remove-class-ref">The remove directive criteria <src>class-ref</src> MUST match an object if and only if its value is identical to the value of that object's <src>class</src> child.</req></p>
           </li>
           <li>
-            <p><req level="must" id="req-modify-alter-remove-item-name">The remove directive criteria <src>item-name</src> MUST match an object if and only its value is identical to the value of that object's serialized name.</req> For example,
-              <code>remove:item-name:prop</code>has the effect of removing all
+            <p><req level="must" id="req-modify-alter-remove-item-name">The remove directive criteria <src>item-name</src> MUST match an object if and only if its value is identical to the value of that object's serialized name.</req> For example,
+              <code>remove:item-name:prop</code> has the effect of removing all
               <src>prop</src>objects from inside the control.
             </p>
-            <p><req level="must" id="req-modify-alter-remove-item-name-array">In serialization formats that use arrays of objects in the OSCAL model, an object's name MUST be considered the singular form of its containing parent array. </req> For example, in the JSON format, remove:item-name:link would remove all of the objects inside of the <src>links</src> array. </p>
+            <p><req level="must" id="req-modify-alter-remove-item-name-array">In serialization formats that use arrays of objects in the OSCAL model, an object's name MUST be referenced as singular form of its containing parent array. </req> For example, in the JSON format, remove:item-name:link would remove all of the objects inside of the <src>links</src> array. </p>
           </li>
         </ul>
       </section>
@@ -1342,16 +1342,16 @@ control:
     <section id="target-back-matter">
       <head>Backmatter Resolution</head>
       <p>
-        <tgt>back-matter</tgt>in the result is produced by combining all objects within
-        <src>back-matter</src>in all source catalogs, with the
-        <src>back-matter</src>in the input profile.
+        <tgt>back-matter</tgt> in the result is produced by combining all objects within
+        <src>back-matter</src> in all source catalogs, with the
+        <src>back-matter</src> in the input profile.
       </p>
       <ul>
-        <li><p><req level="must" id="req-backmatter">The output's backmatter MUST be generated by copying in each <src>resource</src> object from the backmatters of the imported catalogs/profiles in top-to-bottom order, then by copying in each <src>resource</src> object from the backmatter of the source profile itself. These objects MUST be processed in the order they are given in their respective documents.</req></p></li>
+        <li><p><req level="must" id="req-backmatter">The output's backmatter MUST be generated by copying in each <src>resource</src> object from the backmatters of the imported catalogs/profiles in top-to-bottom order, then by copying in each <src>resource</src> object from the backmatter of the source profile itself. These objects MUST be processed in the order they are defined in each respective document.</req></p></li>
         <li>
           <p><req level="must" id="req-backmatter-dupe">If a given
-            <src>resource</src>has the same
-            <src>uuid</src>as a resource that has already been added, the previous resource MUST be removed, and the more recent one added, unless superceded by other requirements.</req>
+            <src>resource</src> has the same
+            <src>uuid</src> as a resource that has already been added, the previous resource MUST be removed, and the more recent one added, unless superseded by other requirements.</req>
           </p>
         </li>
         <li>
@@ -1359,7 +1359,7 @@ control:
         </li>
       </ul>
       <p><req level="may" id="req-backmatter-prune">Tools MAY check for pruning conditions
-        <xref rid="cleanup" />as resources are added as long as the final result is the same as if the pruning had taken place at the end of all resource addition.</req>
+        <xref rid="cleanup" /> as resources are added as long as the final result is the same as if the pruning had taken place at the end of all resource addition.</req>
       </p>
       <p>Placing the keep always prop on a resource in a catalog has the effect of ensuring it will always appear in the output produced by any profile importing that catalog, even if nothing links to the resource. This version of the resource will also be the one copied, unless a later-imported catalog or importing profile offers its own version marked to keep always.</p>
     </section>
@@ -1376,7 +1376,7 @@ control:
           <p><req level="must" id="req-meta-version">The value of metadata:version in the target MUST be set with a string that identifies the version of that document.</req> <req level="should" id="req-meta-version-track">The metadata:version SHOULD be used to track updates to this specific output document.</req></p>
         </li>
         <li>
-          <p><req level="must" id="req-meta-oscal-version">The value of metadata:oscal-version in the target MUST be set with a string that identifies the version of OSCAL used by this tool to resolve the profile (ex. 1.0.0). This value MUST be determined by compiling the oscal-versions from each imported document and the source profile, and taking the most recent minor version. If this version is more recent than what the resolution tool is using, then the value of the output oscal-version MUST be the version that the tool used internally.</req> <req level="must" id="req-meta-oscalversion-error">If any of the above OSCAL versions (imported document versions, source profile version, tool version) are of a different major version (the first digit differs), the tool SHOULD provide an error and cease processing.</req></p>
+          <p><req level="must" id="req-meta-oscal-version">The value of metadata:oscal-version in the target MUST be set with a string that identifies the version of OSCAL used by this tool to resolve the profile (ex. 1.0.0). This value MUST be determined by compiling the oscal-versions from each imported document and the source profile, and taking the most recent minor version. If this version is more recent than what the resolution tool is using, then the value of oscal-version MUST be the version that the tool used internally.</req> <req level="must" id="req-meta-oscalversion-error">If any of the above OSCAL versions (imported document versions, source profile version, tool version) are of a different major version (the first digit differs), the tool SHOULD provide an error and cease processing.</req></p>
         </li>
         <li>
           <p><req level="must" id="req-meta-last-modified">The value of metadata:last-modified in the target MUST be set with a valid timestamp representing the time the profile resolution completed.</req></p>
@@ -1413,7 +1413,7 @@ control:
           <p><req level="must" id="req-prune-modify">If an object was referenced in the <src>modify</src> section of the source profile, it MUST NOT be pruned. Any objects removed in that section are still removed.</req></p>
         </li>
         <li>
-          <p><req level="must" id="req-prune-ref">If the object appears in a reference anywhere in the final result catalog, except in other objects that also meet all other pruning criteria, it MUST NOT be removed. A reference to a given object exists if &quot;#{distinctiveID}&quot; appears anywhere, where {distinctiveID} is the distinctive ID of the object
+          <p><req level="must" id="req-prune-ref">If the object appears in a reference anywhere in the final result catalog, except in other objects that also meet all other pruning criteria, it MUST NOT be removed. A reference to a given object exists if <code>#{distinctiveID}</code> appears anywhere, where <code>{distinctiveID}</code> is the distinctive ID of the object
             <xref rid="id" />.</req>
           </p>
         </li>
@@ -1429,13 +1429,13 @@ control:
     <section id="id">
       <head>Distinct ID of Objects</head>
       <p>Whenever this specification refers to
-        <q>distinctiveness</q>, it is to be interpreted as is defined in this section with regards to the object in question.
+        &quot;distinctiveness&quot;, it is to be interpreted as is defined in this section with regards to the object in question.
       </p>
       <p><req level="must" id="req-id-id">For the objects control, param, and group, distinctiveness MUST be determined by the value of the
-        <q>id</q>child object.</req>
+        &quot;id&quot; child object.</req>
       </p>
       <p><req level="must" id="req-id-uuid">For the object resource, distinctiveness MUST be determined by the value of the
-        <q>uuid</q>
+        &quot;uuid&quot;
         <xref rid="target-back-matter" />.</req>
       </p>
     </section>
@@ -1454,22 +1454,22 @@ control:
       <section id="xmlrequirements">
         <head>Requirements and Guidance for XML Output</head>
         <p><req level="must" id="req-output-xml">The final Catalog output, if using XML, MUST be valid as defined by the XML model documentation for the OSCAL Catalog. See
-          <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/xml-definitions/">the complete XML reference</a>for model requirements.</req>
+          <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/xml-definitions/">the complete XML reference</a> for model requirements.</req>
         </p> <!-- TODO: Add Namespace --> <!-- TODO: Consult XML Wizards on namespacing and other XML requirements -->
       </section>
       <section id="jsonrequirements">
         <head>Requirements and Guidance for JSON Output</head>
         <p><req level="must" id="req-output-json">The final Catalog output, if using JSON, MUST be valid as defined by the JSON model documentation for the OSCAL Catalog. See the
-          <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/json-reference/">complete JSON reference</a>for model requirements. </req>
+          <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/json-reference/">complete JSON reference</a> for model requirements. </req>
         </p>
         <p>The JSON format, in general use, does not require the preservation of order of fields. As order matters in OSCAL, care should be taken to adhere to the canonical OSCAL order
-          <xref rid="order" />when outputting a catalog in JSON.
+          <xref rid="order" /> when outputting a catalog in JSON.
         </p> <!-- TODO: Add Namespace (BaseURI) -->
       </section>
       <section id="yamlrequirements">
         <head>Requirements and Guidance for YAML Output</head>
         <p><req level="must" id="req-output-yaml">The final Catalog output, if using YAML, MUST be valid as defined by the JSON model documentation for the OSCAL Catalog. </req> YAML is considered a simple variation on the JSON format. Beyond cosmetic differences there are no differences in the information structure between these formats. Therefore, the
-          <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/json-reference/">complete JSON reference</a>provides model requirements.
+          <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/json-reference/">complete JSON reference</a> provides model requirements.
         </p>
         <p>The YAML format, in general use, does not require the preservation of order of fields. As order matters in OSCAL, care should be taken to adhere to the canonical OSCAL order
           <xref rid="order" />when outputting a catalog in YAML.

--- a/src/specifications/profile-resolution/profile-resolution-specml.xml
+++ b/src/specifications/profile-resolution/profile-resolution-specml.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="specml.rnc" type="application/relax-ng-compact-syntax"?>
-<!--<?xml-stylesheet type="text/xsl" href="specml-html-xslt1.xsl"?>-->
-<?xml-stylesheet type="text/css" href="specml.css"?>
 <?xml-model href="spec-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="specml.rnc" type="application/relax-ng-compact-syntax"?>
 <SPECIFICATION xmlns="http://csrc.nist.gov/ns/oscal/specml">
   <head>OSCAL Profile Resolution</head>
+  <section id="draft">
+    <head>Notice of Draft Status</head>
+    <p>Please note that this specification is currently a work in progress and is subject to change. If you have any feedback or comments, please create an issue at the NIST OSCAL Github Repository: <a href="https://github.com/usnistgov/OSCAL"/>. </p>
+  </section>
   <section id="abstract">
     <head>Abstract</head>
     <p>This specification provides the minimal requirements for processing an OSCAL Profile to create a new OSCAL Catalog Document. This process of applying a profile to a catalog to create a new catalog is called
@@ -180,7 +182,7 @@
   <section id="phases">
     <head>Phases of Profile Processing</head>
     <p>An OSCAL Profile has three major sections, each which correspond to a phase of profile resolution. In order to complete the profile resolution process, each section must be fully parsed and a catalog output created.</p>
-    <p>It is strongly RECOMMENDED that implementations execute the following steps in the order that they are provided here. While it is possible to achieve compliance with a non-standard approach, the iterative nature of profile resolution lends itself to linear processing.</p>
+    <p><req level="recommended" id="req-phase-order">It is strongly RECOMMENDED that implementations execute the following steps in the order that they are provided here (import, merge, modify).</req> While it is possible to achieve compliance with a non-standard approach, the iterative nature of profile resolution lends itself to linear processing.</p>
     <p>The three steps are
       <term>import</term>;
       <term>merge</term>; and
@@ -260,35 +262,35 @@ profile:
       <xref rid="select-phase" />.
     </p>
     <p>The following section contains requirements for processing the
-      <source>import</source>child of a source
-      <source>profile</source>
+      <src>import</src>child of a source
+      <src>profile</src>
     </p>
     <section id="importhrefs">
       <head>Import href Requirements</head>
       <section id="resolving-uris">
         <head>Import URI Resolution</head>
-        <p>Tools MUST resolve URIs by following
+        <p><req level="must" id="req-uri-resolve">Tools MUST resolve URIs by following
           <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-5">Section 5 of RFC3986</a>, with the exception of URI Fragments (URIs that start with &quot;#&quot;). URI Fragments MUST instead be resolved as defined in
-          <xref rid="internalref" />.
+          <xref rid="internalref" />.</req>
         </p>
       </section>
       <section id="aquiring-resource">
         <head>Import Resource Acquisition</head>
-        <p>Tools MUST acquire resources at the resolved URI by following
+        <p><req level="must" id="req-uri-aquire">Tools MUST acquire resources at the resolved URI by following
           <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-5">Section 5 of RFC3986</a>, with the exception of URI Fragments (URIs that start with &quot;#&quot;). URI Fragments MUST instead be acquired as defined in
           <xref rid="internalref" />.
-        </p>
-        <p>For the purposes of resolving URIs using the above specification, the Base URI MUST be considered to be the absolute URI of the containing profile.</p>
-        <p>In the case that acquiring a resource fails, the tool MUST cease processing and provide an error. In order to ensure profile resolution results in the same catalog regardless of which tool resolves it, all imports must successfully resolve. While this may cause inconvenience if resources are frequently not available, it ensures interoperability.</p>
+        </req></p>
+        <p><req level="must" id="req-uri-base">For the purposes of resolving URIs using the above specification, the Base URI MUST be considered to be the absolute URI of the containing profile.</req></p>
+        <p><req level="must" id="req-uri-error">In the case that acquiring a resource fails, the tool MUST cease processing and provide an error. In order to ensure profile resolution results in the same catalog regardless of which tool resolves it, all imports must successfully resolve. While this may cause inconvenience if resources are frequently not available, it ensures interoperability.</req></p>
         <p>Note that receiving a cached version of an import, or resolving an import that is otherwise unavailable through some other (but automatic) means still satisfies the above requirement. This specification does not put requirements on the precise function of the import, as long as the correct document is retrieved.</p>
       </section>
       <section id="internalref">
         <head>Internal References</head>
         <p>URI Fragments in OSCAL represent internal references to other OSCAL objects in the same document. These references follow the pattern of &quot;#{{objectID}}&quot;. For example, the URI Fragment &quot;#param1&quot; is referencing the Parameter with unique ID &quot;param1&quot;.</p>
-        <p>In the context of the Import Phase, internal references will only appear as a reference to a profile or catalog that is in the <src>resources</src> section of the source. When tools encounter such a reference, they MUST locate the object in <src>resources</src> with the matching ID value, and resolve the import using the
-          <source>rlink</source>URI and the above resolution requirements.
-        </p>
-        <p>If the object fetched cannot be found or is not a valid OSCAL object, the tool MUST cease processing and provide an error.</p>
+        <p><req level="must" id="req-internal">In the context of the Import Phase, internal references will only appear as a reference to a profile or catalog that is in the <src>resources</src> section of the source. When tools encounter such a reference, they MUST locate the object in <src>resources</src> with the matching ID value, and resolve the import using the
+          <src>rlink</src>URI and the above resolution requirements.
+        </req></p>
+        <p><req level="must" id="req-internal-error">If the object fetched cannot be found or is not a valid OSCAL object, the tool MUST cease processing and provide an error.</req></p>
         <tagging whose="source_profile">
           <![CDATA[
 profile:
@@ -312,15 +314,15 @@ profile:
       </section>
       <section id="URI-circular">
         <head>Resolving Imports of Profiles</head>
-        <p>If the resource acquired is an OSCAL Profile, the tool MUST apply this specification to resolve it, then continue processing having imported the resulting catalog.</p>
-        <p>When a profile imports a profile, the subordinate profile SHOULD be resolved first into a catalog using this specification, before it is imported. This presents the possibility of circular imports, when a profile is directed to import itself either directly or indirectly.</p>
+        <p><req level="must" id="req-circular-resolve">If the resource acquired is an OSCAL Profile, the tool MUST apply this specification to resolve it, then continue processing having imported the resulting catalog.</req></p>
+        <p><req level="should" id="req-circular-catalog">When a profile imports a profile, the subordinate profile SHOULD be resolved first into a catalog using this specification, before it is imported. </req> This presents the possibility of circular imports, when a profile is directed to import itself either directly or indirectly.</p>
         <p>A
           <term>circular import</term>occurs when a profile imports an already imported profile, which was called at an earlier place in the import hierarchy. For example, if profile A imports profile B, and profile B imports profile A, the second import is circular. (An import at the top can only be circular if a profile tries to import itself.) If A imports B, B imports C and C imports A, C’s import is circular.
         </p>
         <p>Note that an import can only be circular within the context of processing a particular profile. In the last example, C’s import would not be circular if invoked in the context of resolving B by itself.</p>
-        <p>If a processor encounters a
+        <p><req level="must" id="req-circular-error">If a processor encounters a
           <term>circular import</term>as described above (self-imports are inherently circular), the processor MUST cease processing and generate an error.
-        </p>
+        </req></p>
         <mapping>
           <p>A profile identified as
             <code>home_profile.yaml</code>imports another one identified as
@@ -401,15 +403,15 @@ intermediate:
       <section id="mapping">
         <head>Mapping Controls</head>
         <p>The optional
-          <source>mapping</source>child of a given
-          <source>import</source>provides a simple ID remapping for objects included from that specific import. This provides the means for profile authors to proactively avoid clashing IDs of controls and other objects.
+          <src>mapping</src>child of a given
+          <src>import</src>provides a simple ID remapping for objects included from that specific import. This provides the means for profile authors to proactively avoid clashing IDs of controls and other objects.
         </p>
         <p>The Mapping section consists of 5 optional subsections, each covering a particular type of object. Each subsection is a list of ID mappings to be applied for objects that are the parent object type.</p>
         <p>When encountering a given mapping instruction, processors:</p>
         <ul>
           <li>
             <p>MUST change the distinctive ID of that object to be equal to the value of the
-              <source>to</source>object.
+              <src>to</src>object.
             </p>
           </li>
           <li>
@@ -418,7 +420,7 @@ intermediate:
         </ul>
         <p>Since mapping is a self contained process inside each import, the rest of this specification will continue to reference IDs with the assumption that mapping has already been applied if it was present. Since mapping is most commonly used to avoid clashing IDs, processors should take care to not handle duplicate IDs until after mapping is complete.</p>
         <p>Below is a simple example of mapping. The second
-          <source>import</source>is included controls from a different catalog whose ID values happen to collide. Knowing this, the profile author has remapped those IDs to new values.
+          <src>import</src>is included controls from a different catalog whose ID values happen to collide. Knowing this, the profile author has remapped those IDs to new values.
         </p>
         <tagging whose="source_profile">
           <![CDATA[
@@ -467,19 +469,19 @@ intermediate:
         may make changes to an included control or group that could cause it to appear differently, or not at all, in the output. Using the intermediate implementation approach, any control(s) that are included would be extracted from the referenced catalogs, any applicable mappings would be applied, then the controls(s) would be stored.</p>
       <section id="include-all">
         <head>include-all</head>
-        <p>When an import provides the
-          <src>include-all</src>directive, ALL controls and groups in the referenced document (including nested controls) MUST be included:
-        </p>
+        <p><req level="must" id="req-include-all">When an import provides the
+          <src>include-all</src>directive, ALL controls and groups in the referenced document (including nested controls) MUST be included.
+        </req></p>
         <tagging whose="source_profile">include-all: ~</tagging>
       </section>
       <section id="include-by-id">
         <head>include-controls plus with-id</head>
-        <p>When an import provides the
+        <p><req level="must" id="req-include-by-id">When an import provides the
           <src>include-controls</src>directive, with a
           <src>with-id</src>child, all controls in the referenced document whose
           <code>id</code>match one of the listed
-          <code>id</code>values MUST be included:
-        </p>
+          <code>id</code>values MUST be included.
+        </req></p>
         <tagging whose="source_profile">
           <![CDATA[
 include-controls:
@@ -491,16 +493,16 @@ include-controls:
       <section id="include-by-match">
         <head>include-controls plus matching</head>
         <p>Controls may also be included using match patterns against their IDs. This is useful because related controls (either in a hierarchy, or together in a group) frequently have related IDs as well.</p>
-        <p>When an import provides the
+        <p><req level="must" id="req-include-by-match">When an import provides the
           <src>include-controls</src>directive, with a
           <src>matching</src>child, all controls in the referenced document whose
           <code>id</code>matches one of the listed
-          <code>pattern</code>values (Glob matching) MUST be included:
-        </p>
-        <p>If a
+          <code>pattern</code>values (Glob matching) MUST be included.
+        </req></p>
+        <p><req level="must" id="req-include-by-match-empty">If a
           <code>matching</code>object is provided with no
           <code>pattern</code>, it MUST be treated as matching nothing. While not providing a pattern is technically valid, resolution tool implementers should be aware that it is generally undesirable, and warnings or notices to the user may be appropriate.
-        </p>
+        </req></p>
         <tagging whose="source_profile">
           <![CDATA[
 include-controls:
@@ -513,67 +515,67 @@ include-controls:
         <p>In OSCAL, controls may contain child controls. For instance, in SP 800-53 many controls are supplemented with control enhancements; in OSCAL these are represented as child controls within parent controls. So parent AC-2 (in a given catalog) has children AC-2(1) through AC-2(13), for example.</p>
         <p>By default, inclusion of a control also causes any of that control&apos;s ancestors (or parents) to also be included. By default, inclusion of a control DOES NOT cause the inclusion of any descendants (or children) of that control to be included. This applies to both controls and groups.</p>
         <p>This default behavior can be modified by the following two optional children of the
-          <source>include-controls</source>object.
+          <src>include-controls</src>object.
         </p>
         <section id="include-child-controls">
           <head>with-child-controls</head>
           <p>Child controls are, for the most part, treated the same as top level controls: they can be explicitly included using the selection directives above. As a shortcut to manually including all of the desired descendant controls of a given control, OSCAL provides the &quot;with-child-controls&quot; option. &quot;with-child-controls&quot; appears as a child object under a given inclusion directive, and defines additional behavior that is to be executed alongside the parent inclusion.</p>
-          <p>A
+          <p><req level="must" id="req-with-child-controls-yes">A
             <src>with-child-controls: yes</src>directive on an
             <src>include-controls</src>indicates that
             <em>all descendant controls</em>of the included control MUST also be included.
-          </p>
-          <p>A
+          </req></p>
+          <p><req level="must" id="req-with-child-controls-no">A
             <src>with-child-controls: no</src>directive on an
-            <src>include-controls</src>indicates that ONLY the matching control is included, any descendant children are not included.
-          </p>
-          <p>If no
+            <src>include-controls</src>indicates that ONLY the matching control is included, any descendant children MUST NOT be included.
+          </req></p>
+          <p><req level="must" id="req-with-child-controls-none">If no
             <src>with-child-controls</src>is provided, the processor MUST consider the directive as being equivalent to one having
             <src>with-child-controls:no</src>.
-          </p>
+          </req></p>
         </section>
         <section id="include-parent-controls">
           <head>with-parent-controls</head>
           <p>Although similar to the above
-            <source>with-child-controls</source>, the optional
-            <source>with-parent-controls</source>applies to parents of the included control, and has the opposite default behavior. In order to maintain the structure of the source catalog, profile resolution includes all parents of an included control by default. If a profile author wants to change this structure, they could use an exclude directive that lists all of the undesired parents. As a shortcut for this,
-            <source>with-parent-controls</source>provides the following functionality:
+            <src>with-child-controls</src>, the optional
+            <src>with-parent-controls</src>applies to parents of the included control, and has the opposite default behavior. In order to maintain the structure of the source catalog, profile resolution includes all parents of an included control by default. If a profile author wants to change this structure, they could use an exclude directive that lists all of the undesired parents. As a shortcut for this,
+            <src>with-parent-controls</src>provides the following functionality:
           </p>
-          <p>A
+          <p><req level="must" id="req-with-parent-controls-yes">A
             <src>with-parent-controls: yes</src>directive on an
             <src>include-controls</src>indicates that
             <em>all parent controls</em>of the included control MUST also be included.
-          </p>
-          <p>A
+          </req></p>
+          <p><req level="must" id="req-with-parent-controls-no">A
             <src>with-parent-controls: no</src>directive on an
-            <src>include-controls</src>indicates that ONLY the matching control is included, any parents are not included.
-          </p>
-          <p>If no
+            <src>include-controls</src>indicates that ONLY the matching control is included, any parents MUST NOT be included.
+          </req></p>
+          <p><req level="must" id="req-with-parent-controls-none">If no
             <src>with-parent-controls</src>is provided, the processor MUST consider the directive as being equivalent to one having
             <src>with-parent-controls:yes</src>.
-          </p>
+          </req></p>
         </section>
       </section>
       <section id="exclude-directive">
         <head>exclude-controls</head>
         <p>Exclusions work the same way as inclusions, except with the opposite effect - the indicated control(s) do not appear in the target catalog.</p>
-        <p>Any control designated to be both included and excluded, MUST be excluded. This holds irrespective of the specificity of the selection for inclusion or exclusion. For example, if AC-1 is included by id
+        <p><req level="must" id="req-exclude">Any control designated to be both included and excluded, MUST be excluded. This holds irrespective of the specificity of the selection for inclusion or exclusion.</req> For example, if AC-1 is included by id
           <code>ac-1</code>and excluded by matching
           <code>ac.*</code>, it is excluded.
         </p>
-        <p>When
+        <p><req level="must" id="req-exclude-additional">When
           <src>exclude-controls</src>has at least one
           <src>with-ids</src>or
           <src>matching</src>directive, the processor MUST follow the same rules as defined in the relevant sections above for these directives, but exclude instead of include any controls. All optional features (with-child-controls, etc.) also apply to exclusion directives.
-        </p>
+        </req></p>
       </section>
       <section id="redundant-calls">
         <head>Redundant Inclusions and Exclusions</head>
-        <p>A given
+        <p><req level="must" id="req-redundant">A given
           <src>import</src>may have any number of inclusion statements and any number of exclusion statements. Their effect is cumulative; any control that is included (or excluded) more than once MUST be considered to be included (or excluded) only once. In other words, a given control being included or excluded more than once has no effect. Exclusion still takes priority over inclusion (see above).
-        </p>
+        </req></p>
         <p>Note that this requirement only applies to controls included within the context of a single import. Controls with duplicate IDs included under a different
-          <source>import</source>are not discarded. Also note that this redundancy pruning happens after any relevant mappings have been applied.
+          <src>import</src>are not discarded. Also note that this redundancy pruning happens after any relevant mappings have been applied.
         </p>
       </section>
       <section id="import-param">
@@ -582,24 +584,24 @@ include-controls:
           <src>param</src>that is not directly under a control is referred to as a
           <q>loose</q>param.
         </p>
-        <p>All loose params from both imported documents and the profile source MUST be included. These params will be kept in the final output if document contains any references to them, and discarded otherwise. See
-          <xref rid="cleanup" />. Since new references can be created during the
-          <source>modify</source>phase, tools should be careful not to prune params without fully understanding the final state of the output document.
+        <p><req level="must" id="req-loose-param">All loose params from both imported documents and the profile source MUST be included. These params will be kept in the final output if document contains any references to them, and discarded otherwise. See
+          <xref rid="cleanup" />.</req> Since new references can be created during the
+          <src>modify</src>phase, tools should be careful not to prune params without fully understanding the final state of the output document.
         </p>
       </section>
-      <section id="import-group">
+      <section id="import-group"> <!-- TODO: Add requirements here? Take another look at this. -->
         <head>Handling Groups</head>
         <p>Some source catalogs use
-          <source>group</source>objects to place controls into arbitrary groupings. Tools will need to be aware of these groups when executing the "merge" phase below, as they will duplicated into the output under the "as-is" mode and can be referenced in "custom" mode. The naïve intermediate approach would keep all groups until all other phases are complete, but implementations may find it more performant to look ahead and prune unused groups early.
+          <src>group</src>objects to place controls into arbitrary groupings. Tools will need to be aware of these groups when executing the "merge" phase below, as they will duplicated into the output under the "as-is" mode and can be referenced in "custom" mode. The naïve intermediate approach would keep all groups until all other phases are complete, but implementations may find it more performant to look ahead and prune unused groups early.
         </p>
       </section>
       <section id="import-pitfalls">
         <head>Avoiding Implementation Pitfalls</head>
         <p>In order to ensure that implementers have as much flexibility as possible, requirements in this section have purposefully been kept minimal. Below are some common issues for implementers to be aware of:  </p>
         <ul> <!-- TODO: Add more of these pitfall tips? -->
-          <li>The ordering and hierarchical organization of included controls as they were present in the original catalog may be used later in the resolution process. 
+          <li><p>The ordering and hierarchical organization of included controls as they were present in the original catalog may be used later in the resolution process. 
             Specifically, if the profile is using the "as-is" structuring directive, the ordering and organziation of the output should match the source catalog as closely as possible. 
-            Implementations may want to track this information, or look ahead to see what structuring mode is being used. Note that "as-is" also requires implementations to replicate any use of the <src>group</src> element.
+            Implementations may want to track this information, or look ahead to see what structuring mode is being used. Note that "as-is" also requires implementations to replicate any use of the <src>group</src> element.</p>
           </li>
         </ul>
       </section>
@@ -607,7 +609,7 @@ include-controls:
     <section id="import-wrap-up">
       <head>Wrapping up the Import Phase</head>
       <p>At this point all requirements for content importing and control inclusion have been covered. If using the intermediate approach, the processor should have an intermediate that contains: a set of included controls and all of their child informational (non-control, non-group) objects, any relevant
-        <source>group</source>objects and their informational content, and a set of included &quot;loose params&quot;
+        <src>group</src>objects and their informational content, and a set of included &quot;loose params&quot;
         <xref rid="import-param" />(zero to many). The general structure of the intermediate would match that of the imported catalogs (i.e. Nested controls remain nested, grouped controls remain grouped).
       </p>
     </section>
@@ -618,9 +620,9 @@ include-controls:
       <src>merge</src>section, where directives are given to instruct the processor how to combine the set of included objects collected during the Import Phase.
       <code>merge</code>has two parts: a &quot;combine&quot; directive, and a &quot;structuring&quot; directive.
     </p>
-    <p>It is RECOMMENDED that tools apply the &quot;combine&quot; directive to the intermediate generated by the Import phase first, then apply the &quot;structuring&quot; directive.</p>
+    <p><req level="recommended" id="req-merge-order">It is RECOMMENDED that tools apply the &quot;combine&quot; directive to the intermediate generated by the Import phase first, then apply the &quot;structuring&quot; directive.</req></p>
     <p>The following section contains requirements for processing the
-      <source>merge</source>child of a source profile.
+      <src>merge</src>child of a source profile.
     </p>
     <section id="merge-combine">
       <head>The &quot;combine&quot; Directive</head>
@@ -641,15 +643,15 @@ include-controls:
           <p>keep: Keep - controls with the same ID are kept, retaining the clash</p>
         </li>
       </ul>
-      <p>Note that "merge: combine" is deprecated, and MUST be considered undefined behavior when encountered.</p>
+      <p><req level="must" id="req-merge-combine">Note that "merge: combine" is deprecated, and MUST be considered undefined behavior when encountered.</req></p>
       <p>In order to apply the combination method, IDs of each control explicitly included are compared against one another. As IDs are unique across entire OSCAL documents, different imports or any groupings have no bearing on collision. Processing requirements for each method are described below.</p>
       <section id="no-merge-explicit">
         <head>No Combine Directive</head>
-        <p>If no
+        <p><req level="must" id="req-merge-none">If no
           <src>merge</src>directive is given in the profile, or if a
           <src>merge</src>is given without a
           <src>combine</src>, merge conflicts MUST be treated as if
-          <src>method: keep</src>was given. For example, a profile with no
+          <src>method: keep</src>was given. </req> For example, a profile with no
           <src>merge</src>directive:
         </p>
         <tagging whose="source_profile">
@@ -676,11 +678,11 @@ profile:
         <head>
           <q>method:keep</q>
         </head>
-        <p>When a merge is indicated by
-          <src>method:keep</src>, or not given, the
+        <p><req level="must" id="req-merge-keep">When a merge is indicated by
+          <src>method:keep</src>, or when no merge directive is given, the
           <q>keep</q>combination rule is used. Any controls with the same distinctive ID
           <xref rid="id" />MUST NOT not merged. (They are kept.)
-        </p>
+        </req></p>
         <tagging whose="source_profile">
           <![CDATA[
   merge:
@@ -721,7 +723,7 @@ intermediate:
           <code>ac-1</code>controls clash with each other, as do the two
           <code>ac-2</code>controls.
         </p>
-        <p>Processors SHOULD provide a warning under this directive when duplicate controls are detected. The processor MAY throw an error and cease processing (short-circuiting a certain future error).</p>
+        <p><req level="should" id="req-merge-keep-warning">Processors SHOULD provide a warning under the merge:keep directive when duplicate controls are detected.</req> <req level="may" id="req-merge-keep-error">The processor MAY throw an error and cease processing (short-circuiting a certain future error) when duplicate controls are detected under the merge:keep directive.</req></p>
       </section>
       <section id="use-first-combination-rule">
         <head>
@@ -733,10 +735,10 @@ intermediate:
     combine:
       method: use-first ]]>
         </tagging>
-        <p>When the
+        <p><req level="must" id="req-merge-use-first">When the
           <q>use-first</q>combination rule is applied, and controls that share a distinctive ID are found, the first control encountered MUST be kept, the rest MUST be discarded.
           <q>First</q>MUST be determined by a top-down, depth-first traversal of the source profile&apos;s import hierarchy.
-        </p>
+        </req></p>
         <mapping>
           <tagging whose="source_profile">
             <![CDATA[
@@ -770,7 +772,7 @@ intermediate:
       </section>
       <section id="merge-combination-rule">
         <head>
-          <source>method:merge</source>
+          <src>method:merge</src>
         </head>
         <p>Deprecated, unspecified behavior.</p>
       </section>
@@ -780,20 +782,20 @@ intermediate:
       <p>This section describes how a profile may dictate the structure of the target
         <tgt>catalog</tgt>, apart from its
         <tgt>metadata</tgt>or
-        <tgt>back-matter</tgt>. Optionally, one of three &quot;structuring&quot; directives can be included as a child of
-        <source>merge</source>:
+        <tgt>back-matter</tgt>. <req level="must" id="req-stucture">Optionally, one of three &quot;structuring&quot; directives can be included as a child of
+        <src>merge</src>:
         <src>flat</src>,
         <src>as-is</src>and
-        <src>custom</src>. When one of these appears, it is the selected structuring directive. If more than one appears, processors MUST generate an error and cease processing. Processing requirements for each are given below:
+        <src>custom</src>. When one of these appears, it is the selected structuring directive. If more than one appears, processors MUST generate an error and cease processing.</req> Processing requirements for each are given below:
       </p>
       <section id="structure-none">
         <head>No Structuring Directive</head>
-        <p>If no
+        <p><req level="must" id="req-structure-none">If no
           <src>merge</src>directive is given in the profile, or if a
           <src>merge</src>is given without a structuring directive, structuring the output MUST be treated as if the structuring directive
           <src>flat</src>was given. For example, a profile with no
           <src>merge</src>directive:
-        </p>
+        </req></p>
         <tagging whose="source_profile">
           <![CDATA[
 profile:
@@ -816,16 +818,16 @@ profile:
       </section>
       <section id="merge-flat">
         <head>&quot;flat&quot;</head>
-        <p>Profiles with the &quot;flat&quot; merge directive are resolved as unstructured catalogs, with no groupings of controls.</p>
-        <p>Unstructured catalog output MUST be produced by adhering to the following requirements:</p>
+        <p><req level="must" id="req-merge-flat">Profiles with the &quot;flat&quot; merge directive MUST be resolved as unstructured catalogs, with no grouping or nesting of controls.</req></p>
+        <p><req level="must" id="req-merge-flat-list">Unstructured catalog output MUST be produced by adhering to the following requirements:</req></p> <!-- TODO, ISSUE, REQ TAGGING OF LISTS -->
         <ul>
           <li>
-            <p>All included controls are output to the target as a flat list directly under &quot;catalog&quot;.</p>
+            <p><req level="must" id="req-merge-flat-list-1">All included controls are output to the target as a flat list directly under &quot;catalog&quot;. </req></p>
           </li>
           <li>
-            <p>Any included &quot;loose params&quot; are output to the target as a flat list directly under &quot;catalog&quot;.</p>
+            <p><req level="must" id="req-merge-flat-list-2">Any included &quot;loose params&quot; are output to the target as a flat list directly under &quot;catalog&quot;.</req></p>
           </li>
-          <li>Any groups are discarded.</li>
+          <li><p><req level="must" id="req-merge-flat-list-3">Any groups are discarded.</req></p></li>
         </ul>
         <p>An example of flat structuring is provided below</p>
         <tagging whose="source_catalog">
@@ -869,16 +871,16 @@ intermediate:
         <p>An
           <src>as-is</src>directive is used to reproduce the structure of the source documents in the target catalog.
         </p>
-        <p>Processors MUST handle the
-          <src>as-is</src>directive by adhering to the following requirements:
+        <p><req level="must" id="id-structure-as-is-list">Processors MUST handle the
+          <src>as-is</src>directive by adhering to the following requirements:</req> <!-- TODO, ISSUE, REQ TAGGING OF LISTS -->
         </p>
         <ul>
           <li>
-            <p>All included controls are output to the target, keeping the structure of the groups and nested controls. Any group that holds an included control MUST appear in the output with all of its non-control children intact. 
-              If an included control has a parent control that was not included, that control's output location is "up-leveled", or made equal to the non-included parent. This applies recursively until the control is directly under either "catalog" or another included control.</p>
+            <p><req level="must" id="id-structure-as-is-list-1">All included controls are output to the target, keeping the structure of the groups and nested controls. Any group that holds an included control MUST appear in the output with all of its non-control children intact. 
+              If an included control has a parent control that was not included, that control's output location is "up-leveled", or made equal to the non-included parent. This applies recursively until the control is directly under either "catalog" or another included control.</req></p>
           </li>
           <li>
-            <p>Any included &quot;loose params&quot; are output to the target as a flat list directly under &quot;catalog&quot;.</p>
+            <p><req level="must" id="id-structure-as-is-list-2">Any included &quot;loose params&quot; are output to the target as a flat list directly under &quot;catalog&quot;.</req></p>
           </li>
         </ul>
         <p>Example:</p>
@@ -930,37 +932,38 @@ intermediate:
         </p>
         <section id="custom-groups">
           <head>Creating Custom Groups</head>
-          <p>A
+          <p><req level="must" id="req-custom-group">A
             <src>group</src>object given under
-            <source>custom</source>MUST result in a
+            <src>custom</src>MUST result in a
             <tgt>group</tgt>with the exact same content (excluding
-            <source>insert-controls</source>) in the target catalog.
-          </p>
-          <p>If the ID of the group matches the ID of a group that has been included during the import phase, all contents inside the group, including
+            <src>insert-controls</src>) in the target catalog.
+          </req></p>
+          <p><req level="must" id="req-custom-group-contents">If the ID of the group matches the ID of a group that has been included during the import phase, all contents inside the group, including
             <src>title</src>,
             <src>param</src>,
             <src>prop</src>and
             <src>part</src>objects MUST be copied into the target, appearing in the same order as in the source.
-          </p>
+          </req></p>
           <p>Note that groups defined in
-            <source>custom</source>may vary from fully featured to minimally instantiated. This includes arbitrary nesting of such groups inside of one another. No groups other than those explicitly declared should appear in the output catalog.
+            <src>custom</src>may vary from fully featured to minimally instantiated. This includes arbitrary nesting of such groups inside of one another. No groups other than those explicitly declared should appear in the output catalog.
           </p>
         </section>
         <section id="custom-selection">
           <head>Inserting Controls</head>
           <p>The
-            <source>insert-controls</source>directive may appear anywhere under
-            <source>custom</source>, whether as a direct child or inside any of the defined groups. Inside insert-controls,
-            <source>include-controls</source>and
-            <source>include-all</source>from the Import Phase
+            <src>insert-controls</src>directive may appear anywhere under
+            <src>custom</src>, whether as a direct child or inside any of the defined groups. Inside insert-controls,
+            <src>include-controls</src>and
+            <src>include-all</src>from the Import Phase
             <xref rid="import" />are used with the same basic behavior to configure which controls are selected and inserted at the current location.
           </p>
           <p>In order to provide clarity, controls that match the various conditions of these inclusion directives inside the
-            <source>custom</source>object will be referred to as &quot;selected&quot; instead of &quot;included&quot;. Only directly selected controls will appear in the target catalog.
+            <src>custom</src>object will be referred to as &quot;selected&quot; instead of &quot;included&quot;. Only directly selected controls will appear in the target catalog.
           </p>
+          <p><req level="must" id="req-custom-select">When processing the control selection of a <src>custom</src> element, the behavior defined in this section MUST be followed to generate the output.</req></p>
           <p>A
-            <source>insert-controls</source>with an
-            <source>include-controls</source>child results in the following behavior:
+            <src>insert-controls</src>with an
+            <src>include-controls</src>child results in the following behavior:
           </p>
           <ul>
             <li>
@@ -979,11 +982,11 @@ intermediate:
             </li>
           </ul>
           <p>An
-            <source>insert-controls</source>with an
-            <source>include-all</source>child results in all included controls being selected and inserted. They are given in the same order as they appear in the input control selection(s).
+            <src>insert-controls</src>with an
+            <src>include-all</src>child results in all included controls being selected and inserted. They are given in the same order as they appear in the input control selection(s).
           </p>
           <p>
-            <source>insert-controls</source>can also indicate the order that the selected controls are to be emitted in the result catalog using an
+            <src>insert-controls</src>can also indicate the order that the selected controls are to be emitted in the result catalog using an
             <src>order</src>child. Three values MUST be supported and handled as specified below:
           </p>
           <ul>
@@ -1003,7 +1006,7 @@ intermediate:
               </p>
             </li>
           </ul>
-          <p>In the case that a control selection matches none of the included controls, it MUST be ignored; a warning SHOULD be provided. If a control that was included by the Import Phase is never selected, no error occurs, that control simply does not appear in the output catalog.</p>
+          <p><req level="must" id="req-custom-select-ignore">In the case that a control selection matches none of the included controls, it MUST be ignored.</req> <req level="should" id="req-custom-select-warning">In the case that a control selection matches none of the included controls, a warning SHOULD be provided.</req> If a control that was included by the Import Phase is never selected, no error occurs, that control simply does not appear in the output catalog.</p>
         </section>
       </section>
     </section>
@@ -1019,32 +1022,31 @@ intermediate:
     <head>Modify Phase</head>
     <p>There are two ways profiles may further modify the results of profile resolution: setting parameters, and altering controls. These activities are defined as two child objects inside the third step of profile resolution, the Modify Phase.</p>
     <p>The following section contains requirements for processing the
-      <source>modify</source>child of a source profile.
+      <src>modify</src>child of a source profile.
     </p>
     <section id="param-setting">
       <head>Setting Parameters</head>
       <p>Modification of parameter settings is indicated using the
         <src>set-parameter</src>object under
-        <source>modify</source>. For this section, a given
-        <source>set-parameter</source>object will be referred to as the
-        <source>source</source>.
+        <src>modify</src>. For this section, a given
+        <src>set-parameter</src>object will be referred to as the
+        source.
       </p>
       <p>Profile Resolution Tools MUST adhere to the following requirements for processing &quot;set-parameter&quot;:</p>
       <ul>
         <li>
-          <p>First, the list of included params (among &quot;loose params&quot; and remaining included controls and groups) is searched for a param who has a &quot;id&quot; equal to this object&apos;s &quot;param-id&quot;. This is the &quot;target&quot;. If no such parameter is found, a warning SHOULD be issued, but processing MUST continue.</p>
+          <p>First, the list of included params (among &quot;loose params&quot; and remaining included controls and groups) is searched for a param who has an &quot;id&quot; equal to this object&apos;s &quot;param-id&quot;. This is the &quot;target&quot;. <req level="should" id="req-modify-set-param-warning">If no such parameter is found, a warning SHOULD be issued.</req> <req level="must" id="req-modify-set-param-id-ignore">If no such parameter is found, processing MUST still continue.</req></p>
         </li>
         <li>
-          <p>When encountering the following objects in the source: class, depends-on, label, usage, values, select; overwrites the object of the same name in the target. If no such object exists in the target, it is created.</p>
+          <p><req level="must" id="req-modify-set-param-objects1">For the following objects inside the source: class, depends-on, label, usage, values, select; the object MUST be copied into the target from the source, first removing any existing objects with the same name.</req></p>
         </li>
         <li>
-          <p>When encountering the following objects in the source: props, links, constraints, guidelines; adds the contents of the source object to the contents of the target object of the same name. If no such object exists in the target, it is created. For each individual child object of &quot;props&quot; and &quot;links&quot; in the source, if an individual child inside the target object has the same distinctive ID, it is instead overwritten by the source object
-            <xref rid="id" />
-          </p>
+          <p><req level="must" id="req-modify-set-param-objects2">For the following objects inside the source: props, links, constraints, guidelines; the contents of the object MUST be added to the contents of the target object of the same name. If no such object exists in the target, it is created.</req></p>
         </li>
+        <li> <p><req level="must" id="req-modify-set-param-objects3">For the following objects inside the source: prop, link; the object MUST be copied into the target from the source, first removing any existing objects with the same distinctive ID. (<xref rid="id"></xref>).</req></p></li>
         <li>
-          <p>If more than one
-            <src>set-parameter</src>directive is given for the same parameter, all are applied, in the sequence given in the profile.
+          <p><req level="must" id="req-modify-param-multi">If more than one
+            <src>set-parameter</src>directive is given for the same parameter, all MUST BE applied, in the sequence given in the profile.</req>
           </p>
         </li>
       </ul>
@@ -1061,38 +1063,34 @@ intermediate:
         <p>Contents may be added to controls using an add directive inside an alter directive. There are two forms of alteration: with implicit and explicit bindings.</p>
         <section id="add-to-control">
           <head>Implicit binding</head>
-          <p>An
+          <p><req level="must" id="req-modify-alter-add-implicit">An
             <src>add</src>directive with no
-            <src>by-id</src>is taken to apply to the control as a whole. Its
-            <src>position</src>may be either of two values:
-            <code>starting</code>and
-            <code>ending</code>.
+            <src>by-id</src> child MUST be considered an implicit binding, and will apply to the control as a whole.</req>
           </p>
-          <p>The contents of the add directive are then added to the control contents in the target, either after its
+          <p><req level="must" id="req-modify-alter-add-implicit0contents">The contents of an implicitly bound add directive MUST be added to the control contents in the target, either after its
             <tgt>title</tgt>when
             <src>position</src>is
             <code>starting</code>, or at the end if its position is
-            <code>ending</code>, or not given.
+            <code>ending</code>, or if no valid poisition is given.</req>
           </p>
-          <p>However, control contents in catalogs must appear in the order
-            <code>title, param, prop, link, part, control</code>. Subsequent to adding new objects, the control contents are sorted to appear in the required order. As a consequence, a new
+          <p><req level="must" id="req-modify-alter-add-implicit-position">When an add directive is implicitly bound, the
+            <src>position</src>values
+            <code>before</code>and
+            <code>after</code>MUST be treated like
+            <code>starting</code>and
+            <code>ending</code>, respectively.</req>
+          </p>
+          <p>Control contents in catalogs must appear in the order
+            <code>title, param, prop, link, part, control</code> per the OSCAL model documentation. <req level="must" id="req-modify-alter-add-implicit-order">After processing an implicitly bound add directive, the control contents MUST be sorted to appear in the required order: a new
             <tgt>prop</tgt>appears after any
             <src>prop</src>already in the control, when
             <src>position</src>is
             <code>ending</code>, or not given, or before any
             <src>prop</src>in the control when
             <src>position</src>is
-            <code>starting</code>.
+            <code>starting</code>.</req>
           </p>
-          <p>When add has no
-            <src>ref-id</src>(has an implicit binding), the
-            <src>position</src>values
-            <code>before</code>and
-            <code>after</code>are treated like
-            <code>starting</code>and
-            <code>ending</code>, respectively.
-            <revisit>The schema permits these values.</revisit>
-          </p>
+
           <mapping>
             <p>An addition operating on a control with implicit binding and position
               <code>starting</code>
@@ -1190,43 +1188,28 @@ control:
         </section>
         <section id="add-to-element">
           <head>Explicit binding</head>
-          <p>An explicit binding on an addition permits inserting new contents anywhere in a control, not only at the top level. It is given by a
-            <src>ref-id</src>on the
-            <src>add</src>directive. The value of the
-            <src>ref-id</src>must correspond to the value of an
-            <src>id</src>on an object inside the control, and not the control itself. If
-            <src>ref-id</src>does not correspond to such a value, the
-            <src>add</src>directive is inoperative. A warning MAY be issued in such a case.
+          <p>An explicit binding on an addition permits inserting new contents anywhere in a control, not only at the top level. <req level="must" id="req-modify-alter-add-explicit">An
+            <src>add</src>directive with a
+            <src>by-id</src> child MUST be considered an explicit binding, and applies to only a single object inside the control.</req> <req level="must" id="req-modify-alter-add-explicit-id">When an add directive is explitly bound, the value of the
+            <src>by-id</src> child MUST correspond to the value of an
+              <src>id</src>on an object inside the control, and not the control itself.</req> <req level="must" id="req-modify-alter-add-explicit-id-ignore">If
+            <src>by-id</src>does not correspond to such a value, the
+                <src>add</src>directive MUST be considered inoperative and ignored.</req> <req level="may" id="req-modify-alter-add-explicit-id-warning">An inoperative add directive MAY result in a warning.</req>
           </p>
           <p>The object with
-            <src>id</src>equal to the
-            <src>ref-id</src>is considered the
+            <src>id</src>equal to the value of
+            <src>by-id</src>is considered the
             <term>target</term>of the addition.
           </p>
-          <p>Additionally, with an explicit binding given by a
-            <src>ref-id</src>,
-            <src>position</src>may have any of the values
-            <code>starting</code>,
-            <code>ending</code>,
-            <code>before</code>and
-            <code>after</code>.
-          </p>
-          <p>When
-            <src>position</src>is
+          <p><req level="must" id="req-modify-alter-add-explicit-inside">When
+            <src>position</src> has a value of
             <code>starting</code>or
-            <code>ending</code>, the new contents are added at the beginning or ending of the target object, inside that object, as are additions into controls (using implicit bindings).
+            <code>ending</code>, the contents of the source MUST be added inside the target, either at the start or end of its contents, respectively.</req>
           </p>
-          <p>Additionally, a
-            <src>position</src>given as
-            <code>before</code>indicates the addition should be made directly before the target object, while
-            <code>after</code>indicates the addition should appear directly after the target object.
-          </p> <!-- SAB: Preserving this comment
-            
-            Unlike additions with implicit bindings, an explicit binding does not
-                provide for sorting of newly added objects to ensure correct ordering.
-                Consequently, profile authors must take care that additions they make into control
-                contents using explicit bindings will produce results valid to the catalog
-                schema. -->
+          <p><req level="must" id="req-modify-alter-add-explicit-outside">When
+            <src>position</src> has a value of
+            <code>before</code> or <code>after</code>, the contents of the source MUST be added outside the target, either directly before or after it, respectively.</req>
+          </p>
           <mapping>
             <p>An addition operating on a control with explicit binding and position
               <code>after</code>
@@ -1261,7 +1244,7 @@ alter:
   control-id: a1
   add:
     position: after
-    ref-id: a1.b1
+    by-id: a1.b1
     props:
       - name: basis
         value: allocated
@@ -1308,18 +1291,13 @@ control:
             </p>
           </mapping>
         </section>
-        <section>
-          <head>Usage of
-            <src>add</src>directives modifying controls inside controls
+        <section id="nested-controls">
+          <head>Modifying controls inside controls
           </head>
-          <p>OSCAL supports control extensions inside controls in the form of
+          <p>OSCAL supports controls inside controls in the form of
             <src>control</src>objects inside
             <src>control</src>objects. Because the semantics of the
-            <src>add</src>directive target any (object) contents of controls, they can be used to target these control extensions for modification as well as other contents.
-          </p>
-          <p>Because such a control can already be modified using implicit bindings, it is recommended that they not be targeted with explicit bindings. Using an implicit binding supports more robust alteration since contents in the target can be ordered properly by the resolution processor.
-            <revisit>XXX can we guarantee valid results here and do we have to specify a sort/order?</revisit>However, it is not an error to target control objects in this way, manipulating them in the same way as other targets may be manipulated.
-          </p>
+            <src>add</src> and remove directives target any (object) contents of controls, they can be used to target these child controls for modification as well as other contents. <req level="must" id="req-modify-alter-add-nested">Profile Resolution tools MUST be able to correctly handle add directives targetting nested controls. This includes directives that target a child control as well as directives that target a parent control and modify the child. </req> </p>
         </section>
       </section>
       <section id="remove-directive">
@@ -1327,70 +1305,35 @@ control:
         <p>Contents inside controls can be removed from them in catalog targets. In combination with adding new contents, this feature can be used to edit controls as well as amend them.</p>
         <p>A
           <src>remove</src>directive inside an
-          <src>alter</src>directive identifies an object or set of objects inside a control to be removed. It does this using any of five child objects. These are
-          <em>additive</em>; that is, if more than one is given, all must match:
+          <src>alter</src>directive identifies an object or set of objects inside a control to be removed. It does this using any of five child objects.
         </p>
+        <p><req level="must" id="req-modify-alter-remove-match"> An object inside the control MUST be removed from the output if and only if it meets all of the criteria given by the child objects of the remove directive.</req> When more than one child appears under the remove directive, an object would need to match all of them, otherwise it is not removed. </p>
         <ul>
           <li>
             <p>
-              <src>by-id</src>, like
-              <src>add:by-id</src>, matches an object by its
-              <src>id</src>value.
-            </p>
-            <p>Because
-              <src>id</src>values are unique, the remove directive will remove only a single object. Ordinarily this would not combined with other identifiers for removal.
+              <req level="must" id="req-modify-alter-remove-by-id">The remove directive criteria <src>by-id</src> MUST match an object if and only its value is identical to the <src>id</src> value of that object.</req> Because
+              <src>id</src>values are unique, this criteria will result in the remove directive removing only a single object.
             </p>
           </li>
           <li>
             <p>
-              <src>name-ref</src>keys to the
-              <src>name</src>child object on any object inside the control.
-            </p>
-            <p>Any object inside the control with the assigned
-              <src>name</src>, is removed (typically providing there is also a match on
-              <src>ns</src>).
+              <req level="must" id="req-modify-alter-remove-name-ref">The remove directive criteria <src>name-ref</src> MUST match an object if and only its value is identical to the value of that object's <src>name</src> child.</req>
             </p>
           </li>
           <li>
-            <p>
-              <src>ns-ref</src>keys to the
-              <src>ns</src>child object on any object inside the control.
-            </p>
-            <p>Any object inside the control with the assigned
-              <src>name</src>, is removed (typically providing there is also a match on
-              <src>name</src>).
-            </p>
+            <p><req level="must" id="req-modify-alter-remove-ns-ref">The remove directive criteria <src>ns-ref</src> MUST match an object if and only its value is identical to the value of that object's <src>ns</src> child.</req></p>
           </li>
           <li>
-            <p>
-              <src>class-ref</src>keys to the
-              <src>class</src>child object on any object inside the control. All objects with matching
-              <src>class</src>are removed.
-            </p>
+            <p><req level="must" id="req-modify-alter-remove-class-ref">The remove directive criteria <src>class-ref</src> MUST match an object if and only its value is identical to the value of that object's <src>class</src> child.</req></p>
           </li>
           <li>
-            <p>
-              <src>item-name</src>keys to the object or property name; for example,
-              <code>remove: item-name: prop</code>has the effect of removing all
+            <p><req level="must" id="req-modify-alter-remove-item-name">The remove directive criteria <src>item-name</src> MUST match an object if and only its value is identical to the value of that object's serialized name.</req> For example,
+              <code>remove:item-name:prop</code>has the effect of removing all
               <src>prop</src>objects from inside the control.
-            </p> <!-- SAB: Preserving this comment
-              
-              (NB: explain how this
-                  maps into JSON when items are grouped) -->
+            </p>
+            <p><req level="must" id="req-modify-alter-remove-item-name-array">In serialization formats that use arrays of objects in the OSCAL model, an object's name MUST be considered the singular form of its containing parent array. </req> For example, in the JSON format, remove:item-name:link would remove all of the objects inside of the <src>links</src> array. </p>
           </li>
         </ul>
-        <p>Unlike an
-          <src>add</src>directive, a
-          <src>remove</src>may not be bound implicitly to the control; its binding, to contents inside the control, must be explicit.
-        </p>
-        <p>To remove an control, simply avoid selecting it into the profile, or exclude it specifically using
-          <src>import/exclude-controls</src>.
-        </p>
-        <p>As with
-          <src>add</src>, a remove that targets any object outside the control, is inoperative. Similarly, a remove directive that indicates that all
-          <tgt>prop</tgt>objects should be removed from the target catalog, applies only to
-          <src>prop</src>
-        </p>
       </section>
     </section>
   </section>
@@ -1401,29 +1344,22 @@ control:
       <p>
         <tgt>back-matter</tgt>in the result is produced by combining all objects within
         <src>back-matter</src>in all source catalogs, with the
-        <src>back-matter</src>in the input profile. The merge method and merge structuring directives are ignored. The following requirements MUST be adhered to by the processor:
+        <src>back-matter</src>in the input profile.
       </p>
       <ul>
+        <li><p><req level="must" id="req-backmatter">The output's backmatter MUST be generated by copying in each <src>resource</src> object from the backmatters of the imported catalogs/profiles in top-to-bottom order, then by copying in each <src>resource</src> object from the backmatter of the source profile itself. These objects MUST be processed in the order they are given in their respective documents.</req></p></li>
         <li>
-          <p>Each import&apos;s backmatter is processed in order it was provided in the source profile, then the source profile&apos;s backmatter is processed.</p>
-        </li>
-        <li>
-          <p>Each
-            <src>resource</src>is added to the target in the order given inside the import.
-          </p>
-        </li>
-        <li>
-          <p>If a
+          <p><req level="must" id="req-backmatter-dupe">If a given
             <src>resource</src>has the same
-            <src>uuid</src>as a resource that has already been added, the previous resource is removed, and the more recent one added.
+            <src>uuid</src>as a resource that has already been added, the previous resource MUST be removed, and the more recent one added, unless superceded by other requirements.</req>
           </p>
         </li>
         <li>
-          <p>A resource with a child prop of name:keep and value:always can only be replaced following the above rule by a duplicate that also has the keep always prop.</p>
+          <p><req level="must" id="req-backmatter-keep">A <src>resource</src> with a child <src>prop</src> of <src>name:keep</src> and <src>value:always</src> MUST NOT be replaced by the addition of another <src>resource</src>, unless the new resource also has a child <src>prop</src> of <src>name:keep</src> and <src>value:always</src>.</req></p>
         </li>
       </ul>
-      <p>Tools MAY check for pruning conditions
-        <xref rid="cleanup" />as resources are added as long as the final result is the same as if the pruning had taken place at the end of all resource addition.
+      <p><req level="may" id="req-backmatter-prune">Tools MAY check for pruning conditions
+        <xref rid="cleanup" />as resources are added as long as the final result is the same as if the pruning had taken place at the end of all resource addition.</req>
       </p>
       <p>Placing the keep always prop on a resource in a catalog has the effect of ensuring it will always appear in the output produced by any profile importing that catalog, even if nothing links to the resource. This version of the resource will also be the one copied, unless a later-imported catalog or importing profile offers its own version marked to keep always.</p>
     </section>
@@ -1432,26 +1368,26 @@ control:
       <p>The following requirements MUST be followed with regards to the Metadata section of the output catalog:</p>
       <ul>
         <li>
-          <p>The output catalog MUST have a unique top-level UUID (metadata:uuid). This UUID may be generated as seen fit by the tool, as long as it is reasonable to assume it is globally unique. It is RECOMMENDED that tools use a combination of meaningful text and a uniquely generated value (Ex.
+          <p><req level="must" id="req-meta-uuid">The output catalog's metadata MUST have a unique top-level UUID (metadata:uuid). This UUID may be generated as seen fit by the tool, as long as it is reasonable to assume it is globally unique. It is RECOMMENDED that tools use a combination of meaningful text and a uniquely generated value (Ex.
             <code>{{sourceprofilename}}-RESOLVED-{{GUIDv5}}</code>).
-          </p>
+          </req></p>
         </li>
         <li>
-          <p>The value of metadata:version in the target MUST be set with a string that identifies the version of this document. This SHOULD be used to track updates to this specific output document.</p>
+          <p><req level="must" id="req-meta-version">The value of metadata:version in the target MUST be set with a string that identifies the version of that document.</req> <req level="should" id="req-meta-version-track">The metadata:version SHOULD be used to track updates to this specific output document.</req></p>
         </li>
         <li>
-          <p>The value of metadata:oscal-version in the target MUST be set with a string that identifies the version of OSCAL used by this tool to resolve the profile (ex. 1.0.0). This value MUST be determined by compiling the oscal-versions from each imported document and the source profile, and taking the most recent minor version. If this version is more recent than what the resolution tool is using, then the value of the output oscal-version MUST be the version that the tool used internally. If any of the above OSCAL versions (imported document versions, source profile version, tool version) are of a different major version (the first digit differs), the tool SHOULD provide an error and cease processing.</p>
+          <p><req level="must" id="req-meta-oscal-version">The value of metadata:oscal-version in the target MUST be set with a string that identifies the version of OSCAL used by this tool to resolve the profile (ex. 1.0.0). This value MUST be determined by compiling the oscal-versions from each imported document and the source profile, and taking the most recent minor version. If this version is more recent than what the resolution tool is using, then the value of the output oscal-version MUST be the version that the tool used internally.</req> <req level="must" id="req-meta-oscalversion-error">If any of the above OSCAL versions (imported document versions, source profile version, tool version) are of a different major version (the first digit differs), the tool SHOULD provide an error and cease processing.</req></p>
         </li>
         <li>
-          <p>The value of metadata:last-modified in the target MUST be set with a valid timestamp representing the time the profile resolution completed.</p>
+          <p><req level="must" id="req-meta-last-modified">The value of metadata:last-modified in the target MUST be set with a valid timestamp representing the time the profile resolution completed.</req></p>
         </li>
         <li>
-          <p>The value of metadata:source-profile in the target SHOULD be set with a valid URI that points to the profile that resulted in this catalog. If there are privacy or security concerns, the value MAY be set to anything, in which case the simple existence of the source-profile property indicates that this is a resolved profile.</p>
+          <p><req level="should" id="req-meta-source-profile">The value of metadata:source-profile in the target SHOULD be set with a valid URI that points to the profile that resulted in this catalog. </req> <req level="may" id="req-meta-source-profile-privacy"> If there are privacy or security concerns, the value of metadata:source-profile MAY be set to anything, in which case the simple existence of the source-profile property indicates that this is a resolved profile.</req></p>
         </li>
         <li>
-          <p>The value of metadata:resolution-tool in the target SHOULD be set with a string that represents the tool that was used to resolve this catalog.</p> <!-- TODO: Should this be generalized? -->
+          <p><req level="should" id="req-meta-resolution-tool">The value of metadata:resolution-tool in the target SHOULD be set with a string that represents the tool that was used to resolve this catalog.</req></p> <!-- TODO: Should this be generalized? -->
         </li>
-        <li>For any metadata:roles or metadata:parties that exist in the source catalogs, if they have a <src>prop</src> child with name:keep and value:always, they are to be copied as is into the output metadata.</li>
+        <li><p><req level="must" id="req-meta-keep">For any metadata:roles or metadata:parties that exist in the source catalogs, if they have a <src>prop</src> child with name:keep and value:always, they are to be copied as is into the output metadata.</req></p></li>
       </ul>
       <p>Beyond these requirements, tools are free to use any and all of the objects inside metadata to provide additional information downstream.</p>
       <p>Because of options in producing metadata and especially the requirement for a timestamp, developers and users should note that two different resolutions of the same profile will not, ordinarily, be identical inside
@@ -1460,25 +1396,31 @@ control:
     </section>
     <section id="cleanup">
       <head>Pruning and Ordering</head>
-      <p>The processor SHOULD prune the result catalog to remove unused values. A given object is considered unused if it meets ALL of the following criteria:</p>
+      <p><req level="should" id="req-prune">The processor SHOULD prune the resulting output catalog by removing unused objects. </req></p>
       <ul>
         <li>
-          <p>The object does not have a child prop with name:keep and value:always</p> <!-- TODO: "keep" props in documentation -->
+          <p><req level="must" id="req-prune-keep">Any object that has a child <src>prop</src> with a <src>name</src> of "keep" and a <src>value</src> of "always" MUST NOT be pruned.</req></p>
         </li>
         <li>
-          <p>The object is not explicitly included
-            <xref rid="select-phase" />.
+          <p><req level="must" id="req-prune-include">If an object was explicitly included in the
+            <xref rid="select-phase" />, it MUST NOT be pruned.</req>
           </p>
         </li>
         <li>
-          <p>There are no references to the object anywhere in the final result catalog, except in other objects that also meet all other pruning criteria. A reference to a given object exists if &quot;#{distinctiveID}&quot; appears anywhere, where {distinctiveID} is the distinctive ID of the object
-            <xref rid="id" />.
+          <p><req level="must" id="req-prune-custom">If an object was referenced in a <src>custom</src> section of the source profile, it MUST NOT be pruned.</req></p>
+        </li>
+        <li>
+          <p><req level="must" id="req-prune-modify">If an object was referenced in the <src>modify</src> section of the source profile, it MUST NOT be pruned. Any objects removed in that section are still removed.</req></p>
+        </li>
+        <li>
+          <p><req level="must" id="req-prune-ref">If the object appears in a reference anywhere in the final result catalog, except in other objects that also meet all other pruning criteria, it MUST NOT be removed. A reference to a given object exists if &quot;#{distinctiveID}&quot; appears anywhere, where {distinctiveID} is the distinctive ID of the object
+            <xref rid="id" />.</req>
           </p>
         </li>
       </ul>
       <p>Implementers should note that pruning need not take place after all other steps. As long as all above criteria are respected, pruning can happen at any time, and doing so is a likely performance and memory overhead improvement.</p>
-      <p>Tools MUST reorder the output catalog into canonical order
-        <xref rid="order" />, except where this specification provides different ordering requirements.
+      <p><req level="must" id="req-reorder">Tools MUST reorder the output catalog into canonical order
+        <xref rid="order" />, except where this specification provides different ordering requirements.</req>
       </p>
     </section>
   </section>
@@ -1487,19 +1429,19 @@ control:
     <section id="id">
       <head>Distinct ID of Objects</head>
       <p>Whenever this specification refers to
-        <q>distinctiveness</q>, it MUST be interpreted as is defined in this section with regards to the object in question.
+        <q>distinctiveness</q>, it is to be interpreted as is defined in this section with regards to the object in question.
       </p>
-      <p>control,param,group - distinctiveness is defined by the value of the
-        <q>id</q>child object.
+      <p><req level="must" id="req-id-id">For the objects control, param, and group, distinctiveness MUST be determined by the value of the
+        <q>id</q>child object.</req>
       </p>
-      <p>resource - distinctiveness is defined by the value of the
+      <p><req level="must" id="req-id-uuid">For the object resource, distinctiveness MUST be determined by the value of the
         <q>uuid</q>
-        <xref rid="target-back-matter" />.
+        <xref rid="target-back-matter" />.</req>
       </p>
     </section>
     <section id="multiformat">
       <head>Dealing with Multiple Formats</head>
-      <p>Profile Resolution tools SHOULD be able to handle source profiles, imported catalogs, and imported profiles that are serialized in XML, JSON, or YAML. A different serialization format of any given input MUST NOT result in a differing output catalog.</p>
+      <p><req level="should" id="req-multiformat">Profile Resolution tools SHOULD be able to handle source profiles, imported catalogs, and imported profiles that are serialized in XML, JSON, or YAML.</req> <req level="must" id="req-multiformat-differ">A different serialization format of any given input MUST NOT result in a differing output catalog.</req></p>
       <p>In order to help bootstrap this format management, the following resources are provided for implementers:</p>
       <ul>
         <li>
@@ -1511,14 +1453,14 @@ control:
       <p>The following sections provide additional requirements and guidance for each format.</p>
       <section id="xmlrequirements">
         <head>Requirements and Guidance for XML Output</head>
-        <p>See
-          <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/xml-definitions/">the complete XML reference</a>for model requirements.
+        <p><req level="must" id="req-output-xml">The final Catalog output, if using XML, MUST be valid as defined by the XML model documentation for the OSCAL Catalog. See
+          <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/xml-definitions/">the complete XML reference</a>for model requirements.</req>
         </p> <!-- TODO: Add Namespace --> <!-- TODO: Consult XML Wizards on namespacing and other XML requirements -->
       </section>
       <section id="jsonrequirements">
         <head>Requirements and Guidance for JSON Output</head>
-        <p>See the
-          <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/json-reference/">complete JSON reference</a>for model requirements.
+        <p><req level="must" id="req-output-json">The final Catalog output, if using JSON, MUST be valid as defined by the JSON model documentation for the OSCAL Catalog. See the
+          <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/json-reference/">complete JSON reference</a>for model requirements. </req>
         </p>
         <p>The JSON format, in general use, does not require the preservation of order of fields. As order matters in OSCAL, care should be taken to adhere to the canonical OSCAL order
           <xref rid="order" />when outputting a catalog in JSON.
@@ -1526,7 +1468,7 @@ control:
       </section>
       <section id="yamlrequirements">
         <head>Requirements and Guidance for YAML Output</head>
-        <p>YAML is considered a simple variation on the JSON format. Beyond cosmetic differences there are no differences in the information structure between these formats. Therefore, the
+        <p><req level="must" id="req-output-yaml">The final Catalog output, if using YAML, MUST be valid as defined by the JSON model documentation for the OSCAL Catalog. </req> YAML is considered a simple variation on the JSON format. Beyond cosmetic differences there are no differences in the information structure between these formats. Therefore, the
           <a href="https://pages.nist.gov/OSCAL/reference/latest/complete/json-reference/">complete JSON reference</a>provides model requirements.
         </p>
         <p>The YAML format, in general use, does not require the preservation of order of fields. As order matters in OSCAL, care should be taken to adhere to the canonical OSCAL order
@@ -1539,7 +1481,7 @@ control:
           <term>canonical order</term>. This order is provided by the OSCAL Metaschema files for a given document type (see
           <a href="https://pages.nist.gov/OSCAL/concepts/layer/overview/#modeling-approach">an overview of Metaschema</a>.
         </p>
-        <p>When the output format is XML, tools MUST use the OSCAL canonical order as described above. When using the YAML or JSON formats, order conveys no meaning, and is not considered important.</p>
+        <p><req level="must" id="req-order">When the output format is XML, tools MUST use the OSCAL canonical order as described above. When using the YAML or JSON formats, order conveys no meaning, and is not considered important.</req></p>
       </section>
       <section id="comments-in-result">
         <head>Comments in result documents</head>

--- a/src/specifications/profile-resolution/profile-resolution-specml.xml
+++ b/src/specifications/profile-resolution/profile-resolution-specml.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="spec-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="specml.rnc" type="application/relax-ng-compact-syntax"?>
+<!--<?xml-stylesheet type="text/xsl" href="specml-html-xslt1.xsl"?>-->
+<?xml-stylesheet type="text/css" href="specml.css"?>
 <SPECIFICATION xmlns="http://csrc.nist.gov/ns/oscal/specml">
   <head>OSCAL Profile Resolution</head>
   <section id="draft">

--- a/src/specifications/profile-resolution/specml.rnc
+++ b/src/specifications/profile-resolution/specml.rnc
@@ -30,8 +30,10 @@ mapping.elem = element mapping {
 
 section.elem = element section { attribute id { xsd:ID }?, head.elem, misc, section.elem* }
 
-inline-mixed = (text | a | code | term | revisit | propose | em | strong | q | src | tgt | xpath | xref | int )*
+inline-mixed = (text | a | code | term | revisit | propose | em | strong | q | src | tgt | xpath | xref | int | inter | req )*
 
+req = element req { attribute id { xsd:ID }?, attribute level { text }?, inline-mixed }
+inter = element inter { text }
 a       = element a       { attribute href { text }, text }
 code    = element code    { text }
 term    = element term    { text }


### PR DESCRIPTION
# Committer Notes

This pull request includes the following changes to the Profile Resolution Specification:

- Added requirement tagging to the XML source. added "req" to the .rnc schema
- Added a draft status notice to the document and the landing page of the OSCAL website
- Fixed errors in the Modify section (ref-id -> by-id, removed extraneous text)
- Editorial fixes throughout document