### PR TITLE
Add support for yaml OSCAL files validation

### DIFF
--- a/src/utils/util/oscal-content-validator.py
+++ b/src/utils/util/oscal-content-validator.py
@@ -6,6 +6,7 @@ import json
 import argparse
 from jsonschema import validate
 import xmlschema
+import yaml
 
 
 def _get_oscal_file_type(filename):
@@ -13,6 +14,8 @@ def _get_oscal_file_type(filename):
         return "json"
     elif filename.endswith("xml") or filename.endswith("xsd"):
         return "xml"
+    elif filename.endswith("yaml") or filename.endswith("yml"):
+        return "yaml"
     else:
         raise("Not a valid OSCAL file.")
 
@@ -21,6 +24,8 @@ def read_file(filename, ftype):
     with io.open(filename, 'r', encoding="utf-8") as f:
         if ftype == "json":
             filedata = json.load(f)
+        if ftype == "yaml":
+            filedata = yaml.load(f)
         else:
             filedata = f.read()
     return filedata, ftype
@@ -41,7 +46,8 @@ def oscal_validator(oscal_schema, oscal_data):
     schema, stype = read_file(oscal_schema, _get_oscal_file_type(oscal_schema))
     data, ftype = read_file(oscal_data, _get_oscal_file_type(oscal_data))
 
-    if ftype == 'json':
+    if ftype == 'json' or ftype == 'yaml':
+        # Yaml files are validated using the json schema
         validate(data, schema)
     if ftype == 'xml':
         xmlschema.validate(data, schema)

--- a/src/utils/util/oscal-content-validator.py
+++ b/src/utils/util/oscal-content-validator.py
@@ -6,7 +6,7 @@ import json
 import argparse
 from jsonschema import validate
 import xmlschema
-import yaml
+from ruamel.yaml import YAML
 
 
 def _get_oscal_file_type(filename):
@@ -25,6 +25,7 @@ def read_file(filename, ftype):
         if ftype == "json":
             filedata = json.load(f)
         if ftype == "yaml":
+            yaml = YAML()
             filedata = yaml.load(f)
         else:
             filedata = f.read()

--- a/src/utils/util/requirements.txt
+++ b/src/utils/util/requirements.txt
@@ -1,2 +1,3 @@
 jsonschema
 xmlschema
+pyyaml

--- a/src/utils/util/requirements.txt
+++ b/src/utils/util/requirements.txt
@@ -1,3 +1,3 @@
-jsonschema
-xmlschema
-ruamel.yaml
+jsonschema==4.4.0
+ruamel.yaml==0.17.10
+xmlschema==1.9.2

--- a/src/utils/util/requirements.txt
+++ b/src/utils/util/requirements.txt
@@ -1,3 +1,3 @@
 jsonschema
 xmlschema
-pyyaml
+ruamel.yaml


### PR DESCRIPTION
Add support for yaml OSCAL files validation


# Committer Notes

Added support for yaml OSCAL files validation to `oscal-content-validatory.py`.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?
