### PR TITLE
Fix enum typos from inteneral->internal, closes #1067.

### DIFF
--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -182,7 +182,7 @@
       </allowed-values>
 
       <allowed-values target="prop[@name='implementation-point']/@value">
-        <enum value="inteneral">The component is implemented within the system boundary.</enum>
+        <enum value="internal">The component is implemented within the system boundary.</enum>
         <enum value="external">The component is implemented outside the system boundary.</enum>
       </allowed-values>
       <!-- ========================================================================================================== -->

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -139,7 +139,7 @@
                   </allowed-values>
 
                   <allowed-values target="prop[@name='implementation-point']/@value">
-                        <enum value="inteneral">The component is implemented within the system boundary.</enum>
+                        <enum value="internal">The component is implemented within the system boundary.</enum>
                         <enum value="external">The component is implemented outside the system boundary.</enum>
                   </allowed-values>
 


### PR DESCRIPTION
# Committer Notes

Minor typo fix that closes usnistgov/OSCAL#1067.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [X] Do all automated CI/CD checks pass?

### Changes to Core Features:

- ~Have you added an explanation of what your changes do and why you'd like us to include them?~
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
