### PR TITLE
Remove extra `>` which shows in the built schemas

### DIFF
--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -21,7 +21,7 @@
       <description>Used by the assessment plan and POA&amp;M to import information about the system.</description>
       <define-flag name="href" required="yes" as-type="uri-reference">
          <formal-name>System Security Plan Reference</formal-name>
-         <description>>A resolvable URL reference to the system security plan for the system being assessed.</description>
+         <description>A resolvable URL reference to the system security plan for the system being assessed.</description>
          <remarks>
             <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code> <code>resource</code> in the same document.</p>
             <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is <a href="/concepts/layer/assessment/assessment-plan/#key-concepts">within the scope of the containing OSCAL document</a>.</p>


### PR DESCRIPTION
# Committer Notes

In the `assessment-result` metaschema there's an extra closing triangle bracket (`>`) that shows up in the built schemas.
You can see one example of it in the [jsonschema](https://github.com/usnistgov/OSCAL/blob/c221bb1fd85455f61ba9b66c3290efbfa3d9266c/json/schema/oscal_assessment-plan_schema.json#L765).

### All Submissions:

- [x] Have you selected the correct base branch per  [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?
