### PR TITLE
Use XSpec variable instead of entity

### DIFF
--- a/src/utils/util/resolver-pipeline/testing/1_selected/select-rlink.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/select-rlink.xspec
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE x:description [
-<!ENTITY filedir "../../../../../../../src/specifications/profile-resolution/profile-resolution-examples/catalogs" >
-]>
 <x:description xmlns="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:opr="http://csrc.nist.gov/ns/oscal/profile-resolution"
+    xmlns:ov="http://csrc.nist.gov/ns/oscal/test/variable"
     xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     stylesheet="../../oscal-profile-resolve-select.xsl">
+    
+    <!-- Location of sample files, relative to compiled test in xspec/ subdirectory -->
+    <x:variable name="ov:filedir" as="xs:string" select="resolve-uri('../../../../../../specifications/profile-resolution/profile-resolution-examples')"/>
+
     <x:scenario label="Direct import by file href">
         <x:context>
             <profile>
-                <import href="&filedir;/xyz-tiny_catalog.xml">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
                     <include-controls>
                         <with-id>z3</with-id>
                     </include-controls>
@@ -50,7 +53,7 @@
                 <back-matter>
                     <resource uuid="6e57d296-39c1-4e83-8107-4dcc2ede751b">
                         <title>Tiny Catalog</title>
-                        <rlink href="&filedir;/xyz-tiny_catalog.xml"/>
+                        <rlink href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml"/>
                     </resource>
                 </back-matter>
             </profile>
@@ -95,8 +98,8 @@
                 <back-matter>
                     <resource uuid="6e57d296-39c1-4e83-8107-4dcc2ede751b">
                         <title>Tiny Catalog</title>
-                        <rlink href="&filedir;/xyz-tiny_catalog.xml"/>
-                        <rlink href="&filedir;/xyz-tiny_catalog.json"/>
+                        <rlink href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml"/>
+                        <rlink href="{$ov:filedir}/catalogs/xyz-tiny_catalog.json"/>
                     </resource>
                 </back-matter>
             </profile>


### PR DESCRIPTION
Minor follow-up to #1101: For consistency with select.xspec, make select-rlink.xspec use an XSpec variable instead of an entity,
for the path to the profile resolution examples.

I qualified this change by running the test in Oxygen.

### All Submissions:

- [x] Have you selected the correct base branch per  [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?


### ~~Changes to Core Features:~~

- ~~[ ] Have you added an explanation of what your changes do and why you'd like us to include them?~~
- ~~[ ] Have you written new tests for your core changes, as applicable?~~
- ~~[ ] Have you included examples of how to use your new feature(s)?~~
- ~~[ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~~