### PR TITLE
Remove extra `>` which shows in the built schemas

### DIFF
--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -107,7 +107,7 @@
       <define-flag name="uuid" required="yes" as-type="uuid">
          <formal-name>Assessment Activity Universally Unique Identifier</formal-name>
          <!-- Identifier Declaration -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a>> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this assessment activity elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>activity</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this assessment activity elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>activity</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
       </define-flag>
       <model>
          <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
@@ -873,7 +873,7 @@
             <group-as name="relevant-evidence" in-json="ARRAY"/>
             <define-flag name="href" required="no" as-type="uri-reference">
                <formal-name>Relevant Evidence Reference</formal-name>
-               <description>>A resolvable URL reference to relevant evidence.</description>
+               <description>A resolvable URL reference to relevant evidence.</description>
                <remarks>
                   <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code> <code>resource</code> in the same document.</p>
                   <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is <a href="/concepts/layer/assessment/assessment-plan/#key-concepts">within the scope of the containing OSCAL document</a>.</p>

--- a/src/metaschema/oscal_assessment-results_metaschema.xml
+++ b/src/metaschema/oscal_assessment-results_metaschema.xml
@@ -329,7 +329,7 @@
     <description>Used by assessment-results to import information about the original plan for assessing the system.</description>
     <define-flag name="href" required="yes" as-type="uri-reference">
       <formal-name>Assessment Plan Reference</formal-name>
-      <description>>A resolvable URL reference to the assessment plan governing the assessment activities.</description>
+      <description>A resolvable URL reference to the assessment plan governing the assessment activities.</description>
       <remarks>
         <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code>
           <code>resource</code> in the same document.</p>


### PR DESCRIPTION
# Committer Notes

Similarly to PR #1133, I came across 3 more place where there's an extra closing triangle bracket (`>`) that shows up in the built schemas.
This time I did a global search in the metaschemas for `>>`, so there aren't suppose to be anymore places where this occurs.

### All Submissions:

- [x] Have you selected the correct base branch per  [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?
