### PR TITLE
Fix name typo from `prop` to `props`

### DIFF
--- a/src/metaschema/oscal_assessment-results_metaschema.xml
+++ b/src/metaschema/oscal_assessment-results_metaschema.xml
@@ -99,7 +99,7 @@
       </define-field>
 
       <assembly ref="property" max-occurs="unbounded">
-        <group-as name="prop" in-json="ARRAY"/>
+        <group-as name="props" in-json="ARRAY"/>
       </assembly>
       <assembly ref="link" max-occurs="unbounded">
         <group-as name="links" in-json="ARRAY"/>


### PR DESCRIPTION
# Committer Notes

In all metaschemas, the name `props` is used to signify the list of metadata properties.
This PR fixes an obvious typo in the assessment results metaschema where the name `prop` is used instead of `props`.

This will most likely break backwards compatibility, but since this is an obvious typo/fix I think it is worth considering for versions earlier than `v2.0`.

### All Submissions:

- [x] Have you selected the correct base branch per  [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?
