### PR TITLE
Remove duplicated constructs in OSCAL metaschemas

### DIFF
--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -1063,20 +1063,9 @@
          <assembly ref="link" max-occurs="unbounded">
             <group-as name="links" in-json="ARRAY"/>
          </assembly>
-         <define-field name="status" as-type="token" min-occurs="1">
-            <formal-name>Status</formal-name>
-            <description>Describes the status of the associated risk.</description>
-            <constraint>
-               <allowed-values target="." allow-other="yes">
-                  <enum value="open">The risk has been identified.</enum>
-                  <enum value="investigating">The identified risk is being investigated. (Open risk)</enum>
-                  <enum value="remediating">Remediation activities are underway, but are not yet complete. (Open risk)</enum>
-                  <enum value="deviation-requested">A risk deviation, such as false positive, risk reduction, or operational requirement has been submitted for approval. (Open risk)</enum>
-                  <enum value="deviation-approved">A risk deviation, such as false positive, risk reduction, or operational requirement has been approved. (Open risk)</enum>
-                  <enum value="closed">The risk has been resolved.</enum>
-               </allowed-values>
-            </constraint>
-         </define-field>
+         <field ref="risk-status" as-type="token" min-occurs="1">
+            <use-name>status</use-name>
+         </field>
          <assembly ref="origin" max-occurs="unbounded">
             <group-as name="origins" in-json="ARRAY"/>
             <remarks>


### PR DESCRIPTION
# Committer Notes

Cleanup of OSCAL Metaschemas to remove duplicate constructs.

### All Submissions:

- [ ] Have you selected the correct base branch per  [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
