### PR TITLE
Random function: Iterate over sequence of characters, not positions

### DIFF
--- a/src/utils/util/resolver-pipeline/random-util.xsl
+++ b/src/utils/util/resolver-pipeline/random-util.xsl
@@ -83,14 +83,15 @@ v4 UUID
         <xsl:sequence use-when="function-available('random-number-generator')">
             <xsl:variable name="PRNG" as="map(xs:string, item())" select="random-number-generator($seed)"/>
             <xsl:variable name="template-length" as="xs:integer" select="string-length($template)"/>
-            <!-- Draw one long stream from PRNG, advancing state in each iteration. -->
+            <xsl:variable name="template-char-seq" as="xs:string*"
+                select="$template ! string-to-codepoints(.) ! codepoints-to-string(.)"/>
+            <!-- Draw one long stream from PRNG over sequence of characters in concatenated template,
+                advancing state in each iteration. -->
             <xsl:variable name="random-chars" as="xs:string">
                 <xsl:value-of>
-                    <xsl:iterate select="(0 to ($seq-length * $template-length - 1))">
+                    <xsl:iterate select="for $idx in (1 to $seq-length) return $template-char-seq">
                         <xsl:param name="PRNG" as="map(xs:string, item())" select="$PRNG"/>
-                        <xsl:variable name="this-char" as="xs:string"
-                            select="substring($template, (1 + current() mod $template-length), 1)"/>
-                        <xsl:apply-templates select="$this-char" mode="uuid-char">
+                        <xsl:apply-templates select="current()" mode="uuid-char">
                             <xsl:with-param name="PRNG" select="$PRNG"/>
                         </xsl:apply-templates>
                         <xsl:next-iteration>


### PR DESCRIPTION
Implementing an idea from @wendellpiez: Instead of iterating over a
numeric sequence that represents the position of each character in a
long string, iterate over the sequence of characters.

This change is in the implementation only, not in the function output.
I used ad hoc modifications of the `label="seq-length=10000"` scenario
in the XSpec test to check that the original and modified functions
produce the same UUID sequence.

# Committer Notes

This PR simplifies some code inside a function.

This PR is not urgent, so no worries if the team can't review it for a while.

Acceleration wasn't an explicit requirement, but I used `measure-time="true"` in an ad hoc XSpec file running in Oxygen to compare the speed of the original and modified functions. The modified function here is slightly faster, e.g., 6% or 8% less time to generate 100,000 strings of length 100 each.

### All Submissions:

- [x] Have you selected the correct base branch per  [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

This is not a core feature.

### ~~Changes to Core Features:~~

- ~~[ ] Have you added an explanation of what your changes do and why you'd like us to include them?~~
- ~~[ ] Have you written new tests for your core changes, as applicable?~~
- ~~[ ] Have you included examples of how to use your new feature(s)?~~
- ~~[ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~~
