### PR TITLE
Reindent metaschemas to a conventional 4 spaces indentation

### DIFF
--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -1,1720 +1,1720 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" abstract="yes">
-   <schema-name>OSCAL Assessment Layer Format -- Common Modules</schema-name>
-   <schema-version>1.0.1</schema-version>
-   <short-name>oscal-assessment-common</short-name>
-   <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
-   <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
-   <remarks>
-      <p>This contains all modules common to the assessment plan, assessment results, and POAM models. </p>
-      <p>The root of the OSCAL Assessment Plan format is <code>assessment-plan</code>.</p>
-      <p>The root of the OSCAL Assessment Results format is <code>assessment-results</code>.</p>
-      <p>The root of the OSCAL Plan of Action and Milestones (POA&amp;M) format is <code>plan-of-action-and-milestones</code>.</p>
-   </remarks>
-   <!-- IMPORT STATEMENTS -->
-   <import href="oscal_control-common_metaschema.xml"/>
-   <import href="oscal_implementation-common_metaschema.xml"/>
+    <schema-name>OSCAL Assessment Layer Format -- Common Modules</schema-name>
+    <schema-version>1.0.1</schema-version>
+    <short-name>oscal-assessment-common</short-name>
+    <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
+    <remarks>
+        <p>This contains all modules common to the assessment plan, assessment results, and POAM models. </p>
+        <p>The root of the OSCAL Assessment Plan format is <code>assessment-plan</code>.</p>
+        <p>The root of the OSCAL Assessment Results format is <code>assessment-results</code>.</p>
+        <p>The root of the OSCAL Plan of Action and Milestones (POA&amp;M) format is <code>plan-of-action-and-milestones</code>.</p>
+    </remarks>
+    <!-- IMPORT STATEMENTS -->
+    <import href="oscal_control-common_metaschema.xml"/>
+    <import href="oscal_implementation-common_metaschema.xml"/>
 
-   <!-- SSP Import -->
-   <define-assembly name="import-ssp">
-      <formal-name>Import System Security Plan</formal-name>
-      <description>Used by the assessment plan and POA&amp;M to import information about the system.</description>
-      <define-flag name="href" required="yes" as-type="uri-reference">
-         <formal-name>System Security Plan Reference</formal-name>
-         <description>A resolvable URL reference to the system security plan for the system being assessed.</description>
-         <remarks>
-            <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code> <code>resource</code> in the same document.</p>
-            <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is <a href="/concepts/layer/assessment/assessment-plan/#key-concepts">within the scope of the containing OSCAL document</a>.</p>
-            <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URI pointing to the location of the referenced resource. A relative URI will be resolved relative to the location of the document containing the link.</p>
-         </remarks>
-      </define-flag>
-
-      <model>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-   </define-assembly>
-
-   <!-- =========== -->
-   <!-- === NEW === -->
-   <!-- =========== -->
-   <define-assembly name="local-objective">
-      <formal-name>Assessment-Specific Control Objective</formal-name>
-      <description>A local definition of a control objective for this assessment. Uses catalog syntax for control objective and assessment actions.</description>
-      <flag ref="control-id" required="yes">
-         <remarks>
-            <p>The specified <code>control-id</code> must be a valid value within the baseline identified by the target system's SSP via the <code>import-profile</code> statement.</p>
-         </remarks>
-      </flag>
-      <model>
-         <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-            <formal-name>Objective Description</formal-name>
-            <description>A human-readable description of this control objective.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="part" min-occurs="1" max-occurs="unbounded">
-            <group-as name="parts" in-json="ARRAY" />
-         </assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-      <constraint>
-         <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]">
-            <enum value="objective" deprecated="1.0.1">**(deprecated)** Use 'assessment-objective' instead.</enum>
-            <enum value="assessment" deprecated="1.0.1">**(deprecated)** Use 'assessment-method' instead</enum>
-            <enum value="assessment-objective">The part defines an assessment objective.</enum>
-            <enum value="assessment-method">The part defines an assessment method.</enum>
-         </allowed-values>
-         <has-cardinality target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('objective','assessment-objective')]" max-occurs="1" />
-         <has-cardinality target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']" min-occurs="1" max-occurs="1" />
-         <has-cardinality target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('objects','assessment-objects')]" min-occurs="1" max-occurs="1" />
-         <has-cardinality target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('objective','assessment-objective')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name='method-id']" min-occurs="1" />
-      </constraint>
-   </define-assembly>
-   <define-assembly name="assessment-method">
-      <formal-name>Assessment Method</formal-name>
-      <description>A local definition of a control objective. Uses catalog syntax for control objective and assessment activities.</description>
-      <define-flag name="uuid" required="yes" as-type="uuid">
-         <formal-name>Assessment Method Universally Unique Identifier</formal-name>
-         <!-- Identifier Declaration -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this assessment method elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>assessment method</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-      </define-flag>
-      <model>
-         <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-            <formal-name>Assessment Method Description</formal-name>
-            <description>A human-readable description of this assessment method.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="assessment-part" min-occurs="1" max-occurs="1"/>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-   </define-assembly>
-
-   <!-- ===============================  -->
-   <!-- ========= NEW CONTENT =========  -->
-   <!-- ===============================  -->
-   <define-assembly name="activity">
-      <formal-name>Activity</formal-name>
-      <description>Identifies an assessment or related process that can be performed. In the assessment plan, this is an intended activity which may be associated with an assessment task. In the assessment results, this an activity that was actually performed as part of an assessment.</description>
-      <define-flag name="uuid" required="yes" as-type="uuid">
-         <formal-name>Assessment Activity Universally Unique Identifier</formal-name>
-         <!-- Identifier Declaration -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this assessment activity elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>activity</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-      </define-flag>
-      <model>
-         <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
-            <formal-name>Included Activity Title</formal-name>
-            <description>The title for this included activity.</description>
-         </define-field>
-         <define-field name="description" min-occurs="1" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-            <formal-name>Included Activity Description</formal-name>
-            <description>A human-readable description of this included activity.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <define-assembly name="step" min-occurs="0" max-occurs="unbounded">
-            <formal-name>Step</formal-name>
-            <description>Identifies an individual step in a series of steps related to an activity, such as an assessment test or examination procedure.</description>
-            <group-as name="steps" in-json="ARRAY"/>
-            <define-flag name="uuid" required="yes" as-type="uuid">
-               <formal-name>Step Universally Unique Identifier</formal-name>
-               <!-- Identifier Declaration -->
-               <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this step elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>step</code> (in a series of steps) can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <model>
-               <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
-                  <formal-name>Step Title</formal-name>
-                  <description>The title for this step.</description>
-               </define-field>
-               <define-field name="description" min-occurs="1" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-                  <formal-name>Step Description</formal-name>
-                  <description>A human-readable description of this step.</description>
-               </define-field>
-               <assembly ref="property" max-occurs="unbounded">
-                  <group-as name="props" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="link" max-occurs="unbounded">
-                  <group-as name="links" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="reviewed-controls">
-                  <remarks>
-                     <p>This can be optionally used to define the set of controls and control objectives that are assessed by this step.</p>
-                  </remarks>
-               </assembly>
-               <assembly ref="responsible-role" max-occurs="unbounded">
-                  <group-as name="responsible-roles" in-json="ARRAY"/>
-                  <remarks>
-                     <p>Identifies the roles, and optionally the parties, associated with this step that is part of an assessment activity.</p>
-                  </remarks>
-               </assembly>
-               <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-            </model>
-            <constraint>
-               <is-unique id="unique-step-responsible-role" target="responsible-role">
-                  <key-field target="@role-id"/>
-                  <remarks>
-                     <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
-                  </remarks>
-               </is-unique>
-            </constraint>
-         </define-assembly>
-         <assembly ref="reviewed-controls">
-            <use-name>related-controls</use-name>
+    <!-- SSP Import -->
+    <define-assembly name="import-ssp">
+        <formal-name>Import System Security Plan</formal-name>
+        <description>Used by the assessment plan and POA&amp;M to import information about the system.</description>
+        <define-flag name="href" required="yes" as-type="uri-reference">
+            <formal-name>System Security Plan Reference</formal-name>
+            <description>A resolvable URL reference to the system security plan for the system being assessed.</description>
             <remarks>
-               <p>This can be optionally used to define the set of controls and control objectives that are assessed or remediated by this activity.</p>
+                <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code> <code>resource</code> in the same document.</p>
+                <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is <a href="/concepts/layer/assessment/assessment-plan/#key-concepts">within the scope of the containing OSCAL document</a>.</p>
+                <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URI pointing to the location of the referenced resource. A relative URI will be resolved relative to the location of the document containing the link.</p>
             </remarks>
-         </assembly>
-         <assembly ref="responsible-role" max-occurs="unbounded">
-            <group-as name="responsible-roles" in-json="ARRAY"/>
+        </define-flag>
+
+        <model>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+    </define-assembly>
+
+    <!-- =========== -->
+    <!-- === NEW === -->
+    <!-- =========== -->
+    <define-assembly name="local-objective">
+        <formal-name>Assessment-Specific Control Objective</formal-name>
+        <description>A local definition of a control objective for this assessment. Uses catalog syntax for control objective and assessment actions.</description>
+        <flag ref="control-id" required="yes">
             <remarks>
-               <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                <p>The specified <code>control-id</code> must be a valid value within the baseline identified by the target system's SSP via the <code>import-profile</code> statement.</p>
             </remarks>
-         </assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-      <constraint>
-         <!-- TODO: Dave to double-check constraints here -->
-         <allowed-values target="prop/@name" allow-other="yes">
-            <enum value="method">The assessment method to use. This typically appears on parts with the name "assessment".</enum>
-         </allowed-values>
-         <has-cardinality target="prop[@name='method']" min-occurs="1"/>
-         <allowed-values target="prop[@name='method']/@value">
-            <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
-            <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
-            <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
-         </allowed-values>
-         <is-unique id="unique-activity-responsible-role" target="responsible-role">
-            <key-field target="@role-id"/>
-            <remarks>
-               <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-            </remarks>
-         </is-unique>
-      </constraint>
-   </define-assembly>
-
-   <define-assembly name="task">
-      <formal-name>Task</formal-name>
-      <description>Represents a scheduled event or milestone, which may be associated with a series of assessment actions.</description>
-      <define-flag name="uuid" required="yes" as-type="uuid">
-         <formal-name>Task Universally Unique Identifier</formal-name>
-         <!-- Identifier Declaration -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this task elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>task</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-      </define-flag>
-      <define-flag name="type" required="yes" as-type="token">
-         <formal-name>Task Type</formal-name>
-         <description>The type of task.</description>
-         <constraint>
-            <allowed-values allow-other="yes">
-               <enum value="milestone">The task represents a planned milestone.</enum>
-               <enum value="action">The task represents a specific assessment action to be performed.</enum>
-            </allowed-values>
-         </constraint>
-      </define-flag>
-
-      <model>
-         <define-field name="title" min-occurs="1" as-type="markup-line">
-            <formal-name>Task Title</formal-name>
-            <description>The title for this task.</description>
-         </define-field>
-         <define-field name="description" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-            <formal-name>Task Description</formal-name>
-            <description>A human-readable description of this task.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <define-assembly name="timing">
-            <formal-name>Event Timing</formal-name>
-            <description>The timing under which the task is intended to occur.</description>
-            <model>
-               <choice>
-                  <define-assembly name="on-date" min-occurs="1">
-                     <formal-name>On Date Condition</formal-name>
-                     <description>The task is intended to occur on the specified date.</description>
-                     <define-flag name="date" as-type="dateTime-with-timezone" required="yes">
-                        <formal-name>On Date Condition</formal-name>
-                        <description>The task must occur on the specified date.</description>
-                     </define-flag>
-                  </define-assembly>
-                  <define-assembly name="within-date-range" min-occurs="1">
-                     <formal-name>On Date Range Condition</formal-name>
-                     <description>The task is intended to occur within the specified date range.</description>
-                     <define-flag name="start" as-type="dateTime-with-timezone" required="yes">
-                        <formal-name>Start Date Condition</formal-name>
-                        <description>The task must occur on or after the specified date.</description>
-                     </define-flag>
-                     <define-flag name="end" as-type="dateTime-with-timezone" required="yes">
-                        <formal-name>End Date Condition</formal-name>
-                        <description>The task must occur on or before the specified date.</description>
-                     </define-flag>
-                  </define-assembly>
-                  <define-assembly name="at-frequency" min-occurs="1">
-                     <formal-name>Frequency Condition</formal-name>
-                     <description>The task is intended to occur at the specified frequency.</description>
-                     <define-flag name="period" as-type="positiveInteger" required="yes">
-                        <formal-name>Period</formal-name>
-                        <description>The task must occur after the specified period has elapsed.</description>
-                     </define-flag>
-                     <define-flag name="unit" as-type="string" required="yes">
-                        <formal-name>Time Unit</formal-name>
-                        <description>The unit of time for the period.</description>
-                        <constraint>
-                           <allowed-values>
-                              <enum value="seconds">The period is specified in seconds.</enum>
-                              <enum value="minutes">The period is specified in minutes.</enum>
-                              <enum value="hours">The period is specified in hours.</enum>
-                              <enum value="days">The period is specified in days.</enum>
-                              <enum value="months">The period is specified in calendar months.</enum>
-                              <enum value="years">The period is specified in calendar years.</enum>
-                           </allowed-values>
-                        </constraint>
-                     </define-flag>
-                  </define-assembly>
-               </choice>
-            </model>
-         </define-assembly>
-         <define-assembly name="dependency" max-occurs="unbounded">
-            <formal-name>Task Dependency</formal-name>
-            <description>Used to indicate that a task is dependent on another task.</description>
-            <group-as name="dependencies" in-json="ARRAY"/>
-            <define-flag name="task-uuid" required="yes" as-type="uuid">
-               <formal-name>Task Universally Unique Identifier Reference</formal-name>
-               <!-- Identifier Reference -->
-               <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a unique task.</description>
-            </define-flag>
-            <model>
-               <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-            </model>
-         </define-assembly>
-         <assembly ref="task" min-occurs="0" max-occurs="unbounded">
-            <group-as name="tasks" in-json="ARRAY"/>
-         </assembly>
-
-         <define-assembly name="associated-activity" min-occurs="0" max-occurs="unbounded">
-            <formal-name>Associated Activity</formal-name>
-            <description>Identifies an individual activity to be performed as part of a task.</description>
-            <group-as name="associated-activities" in-json="ARRAY"/>
-            <define-flag name="activity-uuid" required="yes" as-type="uuid">
-               <formal-name>Activity Universally Unique Identifier Reference</formal-name>
-               <!-- Identifier Reference -->
-               <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an activity defined in the list of activities.</description>
-            </define-flag>
-            <model>
-               <assembly ref="property" max-occurs="unbounded">
-                  <group-as name="props" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="link" max-occurs="unbounded">
-                  <group-as name="links" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="responsible-role" max-occurs="unbounded">
-                  <group-as name="responsible-roles" in-json="ARRAY"/>
-                  <remarks>
-                     <p>Identifies the person or organization responsible for performing a specific role defined by the activity.</p>
-                  </remarks>
-               </assembly>
-<!--               <choice>
--->                  <assembly ref="assessment-subject" min-occurs="1" max-occurs="unbounded">
-                     <use-name>subject</use-name>
-                     <group-as name="subjects" in-json="ARRAY"/>
-                  </assembly>
-<!--                  <assembly ref="assessment-subject-placeholder">
-                     <use-name>subject-placeholder</use-name>
-                  </assembly>
-               </choice>
--->               <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-            </model>
-            <constraint>
-               <is-unique id="unique-associated-activity-responsible-role" target="responsible-role">
-                  <key-field target="@role-id"/>
-                  <remarks>
-                     <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-                  </remarks>
-               </is-unique>
-            </constraint>
-         </define-assembly>
-         <assembly ref="assessment-subject" max-occurs="unbounded">
-            <use-name>subject</use-name>
-            <group-as name="subjects" in-json="ARRAY"/>
-            <remarks>
-               <p>The assessment subjects that the activity was performed against.</p>
-            </remarks>
-         </assembly>
-         <assembly ref="responsible-role" max-occurs="unbounded">
-            <group-as name="responsible-roles" in-json="ARRAY"/>
-            <remarks>
-               <p>Identifies the person or organization responsible for performing a specific role related to the task.</p>
-               <!-- todo: role id and party id scope is defined at the document level.  Refer to root object within which the data is declared for...mention resolved through imports.  Note: wh-->
-            </remarks>
-         </assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-   </define-assembly>
-   <!-- =========== -->
-   <!-- = END NEW = -->
-   <!-- =========== -->
-
-   <!-- ********** OBJECTIVES Assembly ********** -->
-   <define-assembly name="reviewed-controls">
-      <formal-name>Reviewed Controls and Control Objectives</formal-name>
-      <description>Identifies the controls being assessed and their control objectives.</description>
-      <model>
-         <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-            <formal-name>Control Objective Description</formal-name>
-            <description>A human-readable description of control objectives.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-
-         <define-assembly name="control-selection" min-occurs="1" max-occurs="unbounded">
-            <formal-name>Assessed Controls</formal-name>
-            <description>Identifies the controls being assessed. In the assessment plan, these are the planned controls. In the assessment results, these are the actual controls, and reflects any changes from the plan.</description>
-            <group-as name="control-selections" in-json="ARRAY"/>
-            <model>
-               <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-                  <formal-name>Assessed Controls Description</formal-name>
-                  <description>A human-readable description of in-scope controls specified for assessment.</description>
-               </define-field>
-               <assembly ref="property" max-occurs="unbounded">
-                  <group-as name="props" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="link" max-occurs="unbounded">
-                  <group-as name="links" in-json="ARRAY"/>
-               </assembly>
-               <choice>
-                  <assembly ref="include-all" min-occurs="1"/>
-                  <assembly ref="select-control-by-id" min-occurs="1" max-occurs="unbounded">
-                     <use-name>include-control</use-name>
-                     <group-as name="include-controls" in-json="ARRAY"/>
-                     <remarks>
-                        <p>Used to select a control for inclusion by the control's identifier. Specific control statements can be selected by their statement identifier.</p>
-                     </remarks>
-                  </assembly>
-               </choice>
-               <assembly ref="select-control-by-id" max-occurs="unbounded">
-                  <use-name>exclude-control</use-name>
-                  <group-as name="exclude-controls" in-json="ARRAY"/>
-                  <remarks>
-                     <p>Used to select a control for exclusion by the control's identifier. Specific control statements can be excluded by their statement identifier.</p>
-                  </remarks>
-               </assembly>
-               <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-            </model>
-            <remarks>
-               <p>The <code>include-all</code>, specifies all control identified in the <strong>baseline</strong> are included in the scope if this assessment, as specified by the <code>include-profile</code> statement within the linked SSP.</p>
-               <p>Any control specified within <code>exclude-controls</code> must first be within a range of explicitly included controls, via <code>include-controls</code> or <code>include-all</code>.</p>
-            </remarks>
-         </define-assembly>
-
-         <define-assembly name="control-objective-selection" min-occurs="0" max-occurs="unbounded">
-            <formal-name>Referenced Control Objectives</formal-name>
-            <description>Identifies the control objectives of the assessment. In the assessment plan, these are the planned objectives. In the assessment results, these are the assessed objectives, and reflects any changes from the plan.</description>
-            <group-as name="control-objective-selections" in-json="ARRAY"/>
-            <model>
-               <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-                  <formal-name>Control Objectives Description</formal-name>
-                  <description>A human-readable description of this collection of control objectives.</description>
-               </define-field>
-               <assembly ref="property" max-occurs="unbounded">
-                  <group-as name="props" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="link" max-occurs="unbounded">
-                  <group-as name="links" in-json="ARRAY"/>
-               </assembly>
-               <choice>
-                  <assembly ref="include-all" min-occurs="1"/>
-                  <assembly ref="select-objective-by-id" min-occurs="1" max-occurs="unbounded">
-                     <use-name>include-objective</use-name>
-                     <group-as name="include-objectives" in-json="ARRAY"/>
-                     <remarks>
-                        <p>Used to select a control objective for inclusion by the control objective's identifier.</p>
-                     </remarks>
-                  </assembly>
-               </choice>
-               <assembly ref="select-objective-by-id" max-occurs="unbounded">
-                  <use-name>exclude-objective</use-name>
-                  <group-as name="exclude-objectives" in-json="ARRAY"/>
-                  <remarks>
-                     <p>Used to select a control objective for exclusion by the control objective's identifier.</p>
-                  </remarks>
-               </assembly>
-               <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-            </model>
-            <remarks>
-               <p>The <code>include-all</code> field, specifies all control objectives for any in-scope control. In-scope controls are defined in the <code>control-selection</code>.</p>
-               <p>Any control objective specified within <code>exclude-controls</code> must first be within a range of explicitly included control objectives, via <code>include-objectives</code> or <code>include-all</code>.</p>
-            </remarks>
-         </define-assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-      <remarks>
-         <p>In the context of an assessment plan, this construct is used to identify the controls and control objectives that are to be assessed. In the context of an assessment result, this construct is used to identify the actual controls and objectives that were assessed, reflecting any changes from the plan.</p>
-         <p>When resolving the selection of controls and control objectives, the following processing will occur:</p>
-         <p>1. Controls will be resolved by creating a set of controls based on the control-selections by first handling the includes, and then removing any excluded controls.</p>
-         <p>2. The set of control objectives will be resolved from the set of controls that was generated in the previous step. The set of control objectives is based on the control-objective-selection by first handling the includes, and then removing any excluded control objectives.</p>
-      </remarks>
-   </define-assembly>
-
-   <define-assembly name="select-control-by-id" scope="local">
-      <formal-name>Select Control</formal-name>
-      <description>Used to select a control for inclusion/exclusion based on one or more control identifiers. A set of statement identifiers can be used to target the inclusion/exclusion to only specific control statements providing more granularity over the specific statements that are within the asessment scope.</description>
-      <flag ref="control-id" required="yes"/>
-      <model>
-         <define-field name="statement-id" as-type="token" min-occurs="0" max-occurs="unbounded" >
-            <formal-name>Include Specific Statements</formal-name>
-            <description>Used to constrain the selection to only specificity identified statements.</description>
-            <group-as name="statement-ids" in-json="ARRAY"/>
-         </define-field>
-      </model>
-   </define-assembly>
-
-   <define-assembly name="select-objective-by-id">
-      <formal-name>Select Objective</formal-name>
-      <description>Used to select a control objective for inclusion/exclusion based on the control objective's identifier.</description>
-      <flag ref="objective-id" required="yes"/>
-   </define-assembly>
-
-   <!-- ********** ASSESSMENT SUBJECT Assembly ********** -->
-   <define-assembly name="assessment-subject-placeholder">
-      <formal-name>Assessment Subject Placeholder</formal-name>
-      <description>Used when the assessment subjects will be determined as part of one or more other assessment activities. These assessment subjects will be recorded in the assessment results in the assessment log.</description>
-      <define-flag name="uuid" required="yes" as-type="uuid">
-         <formal-name>Assessment Subject Placeholder Universally Unique Identifier</formal-name>
-          <!-- Identifier Declaration -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier for a set of assessment subjects that will be identified by a task or an activity that is part of a task. The locally defined <em>UUID</em> of the <code>assessment subject placeholder</code> can be used to reference the data item locally or globally (e.g., in an <a href="/concepts/identifier-use/#scope">imported OSCAL instance</a>). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-      </define-flag>
-      <model>
-         <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-            <formal-name>Assessment Subject Placeholder Description</formal-name>
-            <description>A human-readable description of intent of this assessment subject placeholder.</description>
-         </define-field>
-         <define-assembly name="source" min-occurs="1" max-occurs="unbounded">
-            <formal-name>Assessment Subject Source</formal-name>
-            <description>Assessment subjects will be identified while conducting the referenced activity-instance.</description>
-            <group-as name="sources" in-json="ARRAY"/>
-            <define-flag name="task-uuid" required="yes" as-type="uuid">
-               <formal-name>Task Universally Unique Identifier</formal-name>
-               <!-- Identifier Declaration -->
-               <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference (in this or other OSCAL instances) an assessment activity to be performed as part of the event. The locally defined <em>UUID</em> of the <code>task</code> can be used to reference the data item locally or globally (e.g., in an <a href="/concepts/identifier-use/#scope">imported OSCAL instance</a>). This UUID should be assigned <em>per-subject</em>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-         </define-assembly>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-   </define-assembly>
-
-   <define-assembly name="assessment-subject">
-      <formal-name>Subject of Assessment</formal-name>
-      <description>Identifies system elements being assessed, such as components, inventory items, and locations. In the assessment plan, this identifies a planned assessment subject. In the assessment results this is an actual assessment subject, and reflects any changes from the plan. exactly what will be the focus of this assessment. Any subjects not identified in this way are out-of-scope.</description>
-      <define-flag name="type" as-type="token" required="yes">
-         <formal-name>Subject Type</formal-name>
-         <description>Indicates the type of assessment subject, such as a component, inventory, item, location, or party represented by this selection statement.</description>
-         <constraint>
-            <allowed-values allow-other="yes">
-               <enum value="component">The referenced assessment subject is a component defined in the SSP, or in the <code>local-definitions</code> of an Assessment Plan or Assessment Results.</enum>
-               <enum value="inventory-item">The referenced assessment subject is a inventory item defined in the SSP, or in the <code>local-definitions</code> of an Assessment Plan or Assessment Results.</enum>
-               <enum value="location">The referenced assessment subject is a <code>location</code> defined in the <code>metadata</code> of the SSP, Assessment Plan, or Assessment Results.</enum>
-               <enum value="party">The referenced assessment subject is a person or team to interview, who is defined as a <code>party</code> in the <code>metadata</code> of the SSP, Assessment Plan, or Assessment Results.</enum>
-               <enum value="user">The referenced assessment subject is a <code>user</code> defined in the SSP, or in the <code>local-definitions</code> of an Assessment Plan or Assessment Results.</enum>
-            </allowed-values>
-         </constraint>
-      </define-flag>
-      <model>
-         <define-field name="description"  min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-            <formal-name>Include Subjects Description</formal-name>
-            <description>A human-readable description of the collection of subjects being included in this assessment.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <choice>
-            <assembly ref="include-all" min-occurs="1"/>
-            <assembly ref="select-subject-by-id" min-occurs="1" max-occurs="unbounded">
-               <use-name>include-subject</use-name>
-               <group-as name="include-subjects" in-json="ARRAY"/>
+        </flag>
+        <model>
+            <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                <formal-name>Objective Description</formal-name>
+                <description>A human-readable description of this control objective.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
             </assembly>
-         </choice>
-         <assembly ref="select-subject-by-id" min-occurs="0" max-occurs="unbounded">
-            <use-name>exclude-subject</use-name>
-            <group-as name="exclude-subjects" in-json="ARRAY"/>
-         </assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-      <remarks>
-         <p>Processing of an include/exclude pair starts with processing the include, then removing matching entries in the exclude.</p>
-      </remarks>
-   </define-assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="part" min-occurs="1" max-occurs="unbounded">
+                <group-as name="parts" in-json="ARRAY" />
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+        <constraint>
+            <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]">
+                <enum value="objective" deprecated="1.0.1">**(deprecated)** Use 'assessment-objective' instead.</enum>
+                <enum value="assessment" deprecated="1.0.1">**(deprecated)** Use 'assessment-method' instead</enum>
+                <enum value="assessment-objective">The part defines an assessment objective.</enum>
+                <enum value="assessment-method">The part defines an assessment method.</enum>
+            </allowed-values>
+            <has-cardinality target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('objective','assessment-objective')]" max-occurs="1" />
+            <has-cardinality target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']" min-occurs="1" max-occurs="1" />
+            <has-cardinality target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('objects','assessment-objects')]" min-occurs="1" max-occurs="1" />
+            <has-cardinality target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('objective','assessment-objective')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name='method-id']" min-occurs="1" />
+        </constraint>
+    </define-assembly>
+    <define-assembly name="assessment-method">
+        <formal-name>Assessment Method</formal-name>
+        <description>A local definition of a control objective. Uses catalog syntax for control objective and assessment activities.</description>
+        <define-flag name="uuid" required="yes" as-type="uuid">
+            <formal-name>Assessment Method Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this assessment method elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>assessment method</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <model>
+            <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                <formal-name>Assessment Method Description</formal-name>
+                <description>A human-readable description of this assessment method.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="assessment-part" min-occurs="1" max-occurs="1"/>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+    </define-assembly>
 
-   <define-assembly name="select-subject-by-id">
-      <formal-name>Select Assessment Subject</formal-name>
-      <description>Identifies a set of assessment subjects to include/exclude by UUID.</description>
-      <flag ref="subject-uuid" required="yes"/>
-      <flag ref="subject-type" required="yes">
-         <use-name>type</use-name>
-      </flag>
-      <model>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-   </define-assembly>
-   
-   <define-flag name="subject-uuid" as-type="uuid" scope="local">
-      <formal-name>Subject Universally Unique Identifier Reference</formal-name>
-      <!-- Identifier Reference -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a component, inventory-item, location, party, user, or resource using it's UUID.</description>
-   </define-flag>
-   
-   <define-flag name="subject-type" as-type="token" scope="local">
-      <formal-name>Subject Universally Unique Identifier Reference Type</formal-name>
-      <description>Used to indicate the type of object pointed to by the <code>uuid-ref</code> within a subject.</description>
-      <constraint>
-         <allowed-values allow-other="yes">
-            <enum value="component">Component</enum>
-            <enum value="inventory-item">Inventory Item</enum>
-            <enum value="location">Location</enum>
-            <enum value="party">Interview Party</enum>
-            <enum value="user">User</enum>
-            <enum value="resource">Resource or Artifact</enum>
-         </allowed-values>
-      </constraint>
-   </define-flag>
-   
-   <define-assembly name="subject-reference" scope="local">
-      <formal-name>Identifies the Subject</formal-name>
-      <!-- Identifier Reference -->
-      <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a> identifier reference to a resource. Use type to indicate whether the identified resource is a component, inventory item, location, user, or something else.</description>
-      <flag ref="subject-uuid" required="yes"/>
-      <flag ref="subject-type" required="yes">
-         <use-name>type</use-name>
-      </flag>
-      <model>
-         <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
-            <!-- QUESTION: Is this needed, since the title from the target can be used? -->
-            <formal-name>Subject Reference Title</formal-name>
-            <description>The title or name for the referenced subject.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-      <remarks>
-         <p>The subject reference UUID could point to an item defined in the SSP, AP, or AR.</p>
-         <p>Tools should check look for the ID in every file imported directly or indirectly.</p>
-      </remarks>
-   </define-assembly>
-
-   <!-- ********** ASSET Assembly ********** -->
-   <define-assembly name="assessment-assets">
-      <formal-name>Assessment Assets</formal-name>
-      <description>Identifies the assets used to perform this assessment, such as the assessment team, scanning tools, and assumptions.</description>
-      <model>
-         <assembly ref="system-component" min-occurs="0" max-occurs="unbounded">
-            <use-name>component</use-name>
-            <group-as name="components" in-json="ARRAY"/>
-            <remarks>
-               <p>Used to add any components for tools used during the assessment. These are represented here to avoid mixing with system components.</p>
-               <p>The technology tools used by the assessor to perform the assessment, such as vulnerability scanners. In the assessment plan these are the intended tools. In the assessment results, these are the actual tools used, including any differences from the assessment plan.</p>
-            </remarks>
-         </assembly>
-         <define-assembly name="assessment-platform" min-occurs="1" max-occurs="unbounded">
-            <formal-name>Assessment Platform</formal-name>
-            <description>Used to represent the toolset used to perform aspects of the assessment.</description>
-            <group-as name="assessment-platforms" in-json="ARRAY"/>
-            <define-flag name="uuid" required="yes" as-type="uuid">
-               <formal-name>Assessment Platform Universally Unique Identifier</formal-name>
-               <!-- Identifier Declaration -->
-               <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this assessment platform elsewhere in this or other OSCAL instances. The locally defined <em>UUID</em> of the <code>assessment platform</code> can be used to reference the data item locally or globally (e.g., in an <a href="/concepts/identifier-use/#scope">imported OSCAL instance</a>). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <model>
-               <define-field name="title" max-occurs="1" as-type="markup-line">
-                  <formal-name>Assessment Platform Title</formal-name>
-                  <description>The title or name for the assessment platform.</description>
-               </define-field>
-               <assembly ref="property" max-occurs="unbounded">
-                  <group-as name="props" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="link" max-occurs="unbounded">
-                  <group-as name="links" in-json="ARRAY"/>
-               </assembly>
-               <define-assembly name="uses-component" min-occurs="0" max-occurs="unbounded">
-                  <formal-name>Uses Component</formal-name>
-                  <description>The set of components that are used by the assessment platform.</description>
-                  <group-as name="uses-components" in-json="ARRAY"/>
-                  <define-flag required="yes" name="component-uuid" as-type="uuid">
-                     <formal-name>Component Universally Unique Identifier Reference</formal-name>
-                     <!-- Identifier Reference -->
-                     <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a component that is implemented as part of an inventory item.</description>
-                  </define-flag>
-                  <model>
-                     <assembly ref="property" max-occurs="unbounded">
+    <!-- ===============================  -->
+    <!-- ========= NEW CONTENT =========  -->
+    <!-- ===============================  -->
+    <define-assembly name="activity">
+        <formal-name>Activity</formal-name>
+        <description>Identifies an assessment or related process that can be performed. In the assessment plan, this is an intended activity which may be associated with an assessment task. In the assessment results, this an activity that was actually performed as part of an assessment.</description>
+        <define-flag name="uuid" required="yes" as-type="uuid">
+            <formal-name>Assessment Activity Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this assessment activity elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>activity</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <model>
+            <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
+                <formal-name>Included Activity Title</formal-name>
+                <description>The title for this included activity.</description>
+            </define-field>
+            <define-field name="description" min-occurs="1" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                <formal-name>Included Activity Description</formal-name>
+                <description>A human-readable description of this included activity.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <define-assembly name="step" min-occurs="0" max-occurs="unbounded">
+                <formal-name>Step</formal-name>
+                <description>Identifies an individual step in a series of steps related to an activity, such as an assessment test or examination procedure.</description>
+                <group-as name="steps" in-json="ARRAY"/>
+                <define-flag name="uuid" required="yes" as-type="uuid">
+                    <formal-name>Step Universally Unique Identifier</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this step elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>step</code> (in a series of steps) can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+                <model>
+                    <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
+                        <formal-name>Step Title</formal-name>
+                        <description>The title for this step.</description>
+                    </define-field>
+                    <define-field name="description" min-occurs="1" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                        <formal-name>Step Description</formal-name>
+                        <description>A human-readable description of this step.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
                         <group-as name="props" in-json="ARRAY"/>
-                     </assembly>
-                     <assembly ref="link" max-occurs="unbounded">
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
                         <group-as name="links" in-json="ARRAY"/>
-                     </assembly>
-                     <assembly ref="responsible-party" max-occurs="unbounded">
-                        <group-as name="responsible-parties" in-json="ARRAY"/>
-                     </assembly>
-                     <field ref="remarks" in-xml="WITH_WRAPPER"/>
-                  </model>
-                  <constraint>
-                     <is-unique id="unique-ssp-uses-component-responsible-party" target="responsible-party">
+                    </assembly>
+                    <assembly ref="reviewed-controls">
+                        <remarks>
+                            <p>This can be optionally used to define the set of controls and control objectives that are assessed by this step.</p>
+                        </remarks>
+                    </assembly>
+                    <assembly ref="responsible-role" max-occurs="unbounded">
+                        <group-as name="responsible-roles" in-json="ARRAY"/>
+                        <remarks>
+                            <p>Identifies the roles, and optionally the parties, associated with this step that is part of an assessment activity.</p>
+                        </remarks>
+                    </assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                </model>
+                <constraint>
+                    <is-unique id="unique-step-responsible-role" target="responsible-role">
                         <key-field target="@role-id"/>
                         <remarks>
-                           <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                            <p>Since multiple <code>party-uuid</code> entries can be provided, each role-id must be referenced only once.</p>
                         </remarks>
-                     </is-unique>
-                  </constraint>
-               </define-assembly>
-               <field ref="remarks" in-xml="WITH_WRAPPER"/>
-            </model>
-         </define-assembly>
-      </model>
-      <constraint>
-         <is-unique id="unique-ssp-assessment-assets-component" target="component">
-            <key-field target="@uuid"/>
-            <remarks>
-               <p>Since multiple assessment <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
-            </remarks>
-         </is-unique>
-      </constraint>
-   </define-assembly>
-
-   <!-- ********** Assemblies used within RESULTS and POA&M Items ********** -->
-   <define-assembly name="finding-target">
-      <formal-name>Objective Status</formal-name>
-      <description>Captures an assessor's conclusions regarding the degree to which an objective is satisfied.</description>
-      <define-flag name="type" as-type="string" required="yes">
-         <formal-name>Finding Target Type</formal-name>
-         <description>Identifies the type of the target.</description>
-         <constraint>
-            <allowed-values>
-               <enum value="statement-id">A reference to a control statement identifier within a control.</enum>
-               <enum value="objective-id">A reference to a control objective identifier within a control.</enum>
+                    </is-unique>
+                </constraint>
+            </define-assembly>
+            <assembly ref="reviewed-controls">
+                <use-name>related-controls</use-name>
+                <remarks>
+                    <p>This can be optionally used to define the set of controls and control objectives that are assessed or remediated by this activity.</p>
+                </remarks>
+            </assembly>
+            <assembly ref="responsible-role" max-occurs="unbounded">
+                <group-as name="responsible-roles" in-json="ARRAY"/>
+                <remarks>
+                    <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+        <constraint>
+            <!-- TODO: Dave to double-check constraints here -->
+            <allowed-values target="prop/@name" allow-other="yes">
+                <enum value="method">The assessment method to use. This typically appears on parts with the name "assessment".</enum>
             </allowed-values>
-         </constraint>
-         <remarks>
-            <p>The target will always be a reference to: 1) a control statement, or 2) a control objective. In the former case, there is always a single top-level statement within a control. Thus, if the entire control is targeted, this statement identifier can be used.</p>
-         </remarks>
-      </define-flag>
-      <define-flag name="target-id" as-type="token" required="yes">
-         <formal-name>Finding Target Identifier Reference</formal-name>
-         <!-- Identifier Reference -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference for a specific target qualified by the <code>type</code>.</description>
-      </define-flag>
-      <model>
-         <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
-            <formal-name>Objective Status Title</formal-name>
-            <description>The title for this objective status.</description>
-         </define-field>
-         <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-            <formal-name>Objective Status Description</formal-name>
-            <description>A human-readable description of the assessor's conclusions regarding the degree to which an objective is satisfied.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <define-assembly name="status" min-occurs="1">
-            <formal-name>Objective Status</formal-name>
-            <description>A determination of if the objective is satisfied or not within a given system.</description>
-            <define-flag name="state" as-type="token" required="yes">
-               <formal-name>Objective Status State</formal-name>
-               <description>An indication as to whether the objective is satisfied or not.</description>
-            <constraint>
-                  <allowed-values>
-                  <enum value="satisfied">The objective has been completely satisfied.</enum>
-                  <enum value="not-satisfied">The objective has not been completely satisfied, but may be partially satisfied.</enum>
-               </allowed-values>
-            </constraint>
-            </define-flag>
-            <define-flag name="reason" as-type="token">
-            <formal-name>Objective Status Reason</formal-name>
-            <description>The reason the objective was given it's status.</description>
-            <constraint>
-                  <allowed-values allow-other="yes">
-                  <enum value="pass">The target system or system component satisfied all the conditions.</enum>
-                  <enum value="fail">The target system or system component did not satisfy all the conditions.</enum>
-                  <enum value="other">Some other event took place that is not a pass or a fail. </enum>
-               </allowed-values>
-            </constraint>
-         <remarks>
-            <p>Reason may contain any value, and should be used to communicate additional information regarding the status.</p>
-         </remarks>
-            </define-flag>
-            <model>
-               <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-            </model>
-         </define-assembly>
-         <assembly ref="implementation-status">
-            <remarks>
-               <p>The <code>implementation-status</code> is used to qualify the <code>status</code> value to indicate the degree to which the control was found to be implemented.</p>
-            </remarks>
-         </assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-   </define-assembly>
-
-   <define-assembly name="observation">
-      <formal-name>Observation</formal-name>
-      <description>Describes an individual observation.</description>
-      <define-flag name="uuid" required="yes" as-type="uuid">
-         <formal-name>Observation Universally Unique Identifier</formal-name>
-         <!-- Identifier Declaration -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <em>cross-instance</em> scope that can be used to reference this observation elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>observation</code> can be used to reference the data item locally or globally (e.g., in an imorted OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-      </define-flag>
-      <model>
-         <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
-            <formal-name>Observation Title</formal-name>
-            <description>The title for this observation.</description>
-         </define-field>
-         <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER"
-            as-type="markup-multiline">
-            <formal-name>Observation Description</formal-name>
-            <description>A human-readable description of this assessment observation.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <define-field name="method" min-occurs="1" max-occurs="unbounded">
-            <formal-name>Observation Method</formal-name>
-            <description>Identifies how the observation was made.</description>
-            <group-as name="methods" in-json="ARRAY"/>
-            <constraint>
-               <allowed-values target="." allow-other="yes">
-                  <enum value="EXAMINE">An inspection was performed.</enum>
-                  <enum value="INTERVIEW">An interview was performed.</enum>
-                  <enum value="TEST">A manual or automated test was performed.</enum>
-                  <enum value="UNKNOWN">This is only for use when converting historic content to OSCAL, where the conversion process cannot initially identify the appropriate method(s).</enum>
-               </allowed-values>
-            </constraint>
-         </define-field>
-
-         <define-field name="type" as-type="token" max-occurs="unbounded">
-            <formal-name>Observation Type</formal-name>
-            <description>Identifies the nature of the observation. More than one may be used to further qualify and enable filtering.</description>
-            <group-as name="types" in-json="ARRAY"/>
-            <constraint>
-               <allowed-values target="." allow-other="yes">
-                  <enum value="ssp-statement-issue">A difference between the SSP implementation statement, and actual implementation.</enum>
-                  <enum value="control-objective">An observation about the status of a the associated control objective.</enum>
-                  <enum value="mitigation">A mitigating factor was identified.</enum>
-                  <enum value="finding">An assessment finding. Used for observations made by tools, penetration testing, and other means.</enum>
-                  <enum value="historic">An observation from a past assessment, which was converted to OSCAL at a later date.</enum>
-               </allowed-values>
-            </constraint>
-         </define-field>
-         <assembly ref="origin" max-occurs="unbounded">
-            <group-as name="origins" in-json="ARRAY"/>
-            <remarks>
-               <p>Used to identify the individual and/or tool that gathered the evidence resulting in the observation identification.</p>
-            </remarks>
-         </assembly>
-         <assembly ref="subject-reference" min-occurs="0" max-occurs="unbounded">
-            <use-name>subject</use-name>
-            <group-as name="subjects" in-json="ARRAY"/>
-            <remarks>
-               <p>Identifies who was interviewed, or what was tested or inspected.</p>
-            </remarks>
-         </assembly>
-
-         <define-assembly name="relevant-evidence" max-occurs="unbounded">
-            <formal-name>Relevant Evidence</formal-name>
-            <description>Links this observation to relevant evidence.</description>
-            <group-as name="relevant-evidence" in-json="ARRAY"/>
-            <define-flag name="href" required="no" as-type="uri-reference">
-               <formal-name>Relevant Evidence Reference</formal-name>
-               <description>A resolvable URL reference to relevant evidence.</description>
-               <remarks>
-                  <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code> <code>resource</code> in the same document.</p>
-                  <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is <a href="/concepts/layer/assessment/assessment-plan/#key-concepts">within the scope of the containing OSCAL document</a>.</p>
-                  <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URI pointing to the location of the referenced resource. A relative URI will be resolved relative to the location of the document containing the link.</p>
-               </remarks>
-            </define-flag>
-            <model>
-               <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-                  <formal-name>Relevant Evidence Description</formal-name>
-                  <description>A human-readable description of this evidence.</description>
-               </define-field>
-               <assembly ref="property" max-occurs="unbounded">
-                  <group-as name="props" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="link" max-occurs="unbounded">
-                  <group-as name="links" in-json="ARRAY"/>
-               </assembly>
-               <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-            </model>
-         </define-assembly>
-         <define-field name="collected" as-type="dateTime-with-timezone" min-occurs="1" max-occurs="1">
-            <formal-name>collected field</formal-name>
-            <description>Date/time stamp identifying when the finding information was collected.</description>
-         </define-field>
-         <define-field name="expires" as-type="dateTime-with-timezone" min-occurs="0" max-occurs="1">
-            <formal-name>expires field</formal-name>
-            <description>Date/time identifying when the finding information is out-of-date and no longer valid. Typically used with continuous assessment scenarios.</description>
-         </define-field>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-<!--      <constraint>
-         <!-\- TODO: review these and figure out where these go -\->
-         <allowed-values target="origin/@type" allow-other="no">
-            <!-\\- CHANGED: "tool" to "******" -\\->
-            <enum value="tool">An assessment tool, defined in the assets section of the assessment plan or results.</enum>
-            <enum value="test-method">A test method defined in the assessment-activities section of the assessment plan or results.</enum>
-            <enum value="task">A task defined in the schedule of the assessment plan or results.</enum>
-            <enum value="included-activity">An assessment activity defined in the assessment-activities section of the assessment plan or results.</enum>
-            <enum value="other">The UUID points elsewhere in the this file or an imported file.</enum>
-         </allowed-values>
-      </constraint>
--->   </define-assembly>
-
-   <define-assembly name="origin">
-      <formal-name>Origin</formal-name>
-      <description>Identifies the source of the finding, such as a tool, interviewed person, or activity.</description>
-      <model>
-         <assembly ref="origin-actor" min-occurs="1" max-occurs="unbounded">
-            <use-name>actor</use-name>
-            <group-as name="actors" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="related-task" max-occurs="unbounded">
-            <group-as name="related-tasks" in-json="ARRAY"/>
-         </assembly>
-      </model>
-   </define-assembly>
-
-   <define-assembly name="origin-actor">
-      <formal-name>Originating Actor</formal-name>
-      <description>The actor that produces an observation, a finding, or a risk. One or more actor type can be used to specify a person that is using a tool.</description>
-      <define-flag name="type" as-type="token" required="yes">
-         <formal-name>Actor Type</formal-name>
-         <description>The kind of actor.</description>
-         <constraint>
-            <allowed-values>
-               <enum value="tool">A reference to a tool component defined with the assessment assets.</enum>
-               <enum value="assessment-platform">A reference to an assessment-platform defined with the assessment assets.</enum>
-               <enum value="party">A reference to a party defined within the document metadata.</enum>
+            <has-cardinality target="prop[@name='method']" min-occurs="1"/>
+            <allowed-values target="prop[@name='method']/@value">
+                <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
+                <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
+                <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
             </allowed-values>
-         </constraint>
-      </define-flag>
-      <define-flag name="actor-uuid" as-type="uuid" required="yes">
-         <formal-name>Actor Universally Unique Identifier Reference</formal-name>
-         <!-- Identifier Reference -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the tool or person based on the associated type.</description>
-      </define-flag>
-      <define-flag name="role-id" as-type="token">
-         <formal-name>Actor Role</formal-name>
-         <description>For a party, this can optionally be used to specify the role the actor was performing.</description>
-      </define-flag>
-      <model>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-      </model>
-   </define-assembly>
+            <is-unique id="unique-activity-responsible-role" target="responsible-role">
+                <key-field target="@role-id"/>
+                <remarks>
+                    <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
 
-   <define-assembly name="related-task">
-      <formal-name>Task Reference</formal-name>
-      <description>Identifies an individual task for which the containing object is a consequence of.</description>
-      <define-flag name="task-uuid" required="yes" as-type="uuid">
-         <formal-name>Task Universally Unique Identifier Reference</formal-name>
-         <!-- Identifier Reference -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a unique task.</description>
-      </define-flag>
-      <model>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="responsible-party" max-occurs="unbounded">
-            <group-as name="responsible-parties" in-json="ARRAY"/>
-            <remarks>
-               <p>Identifies the person or organization responsible for performing a specific role defined by the activity.</p>
-            </remarks>
-         </assembly>
-         <assembly ref="assessment-subject" max-occurs="unbounded">
-            <use-name>subject</use-name>
-            <group-as name="subjects" in-json="ARRAY"/>
-            <remarks>
-               <p>The assessment subjects that the task was performed against.</p>
-            </remarks>
-         </assembly>
-         <define-assembly name="identified-subject">
-            <formal-name>Identified Subject</formal-name>
-            <description>Used to detail assessment subjects that were identfied by this task.</description>
-
-            <define-flag name="subject-placeholder-uuid" required="yes" as-type="uuid">
-               <formal-name>Assessment Subject Placeholder Universally Unique Identifier Reference</formal-name>
-               <!-- Identifier Reference -->
-               <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a unique assessment subject placeholder defined by this task.</description>
-            </define-flag>
-            <model>
-               <assembly ref="assessment-subject" min-occurs="1" max-occurs="unbounded">
-                  <use-name>subject</use-name>
-                  <group-as name="subjects" in-json="ARRAY"/>
-                  <remarks>
-                     <p>The assessment subjects that the task identified, which will be used by another task through a subject-placeholder reference. Such a task will "consume" these subjects.</p>
-                  </remarks>
-               </assembly>
-            </model>
-         </define-assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-      <constraint>
-         <is-unique id="unique-ssp-related-task-responsible-party" target="responsible-party">
-            <key-field target="@role-id"/>
-            <remarks>
-               <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-            </remarks>
-         </is-unique>
-      </constraint>
-   </define-assembly>
-
-   <define-field name="threat-id" as-type="uri">
-      <!-- This is an id because it is an externally provided identifier -->
-      <formal-name>Threat ID</formal-name>
-      <description>A pointer, by ID, to an externally-defined threat.</description>
-      <json-value-key>id</json-value-key>
-      <define-flag name="system" as-type="uri" required="yes">
-         <formal-name>Threat Type Identification System</formal-name>
-         <description>Specifies the source of the threat information.</description>
-         <constraint>
-            <allowed-values allow-other="yes">
-               <enum value="https://fedramp.gov">The value conforms to FedRAMP definitions.</enum>
-            </allowed-values>
-         </constraint>
-      </define-flag>
-      <define-flag name="href" as-type="uri-reference">
-         <formal-name>Threat Information Resource Reference</formal-name>
-         <description>An optional location for the threat data, from which this ID originates.</description>
-      </define-flag>
-   </define-field>
-
-   <define-assembly name="risk">
-      <formal-name>Identified Risk</formal-name>
-      <description>An identified risk.</description>
-      <define-flag name="uuid" required="yes" as-type="uuid">
-         <formal-name>Risk Universally Unique Identifier</formal-name>
-         <!-- Identifier Declaration -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this risk elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>risk</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-      </define-flag>
-      <model>
-         <define-field name="title" min-occurs="1" max-occurs="1" as-type="markup-line">
-            <formal-name>Risk Title</formal-name>
-            <description>The title for this risk.</description>
-         </define-field>
-         <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-            <formal-name>Risk Description</formal-name>
-            <description>A human-readable summary of the identified risk, to include a statement of how the risk impacts the system.</description>
-         </define-field>
-         <define-field name="statement" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-            <!-- QUESTION: how is this different from description? -->
-            <!-- TODO: remove this -->
-            <formal-name>Risk Statement</formal-name>
-            <description>An summary of impact for how the risk affects the system.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <define-field name="status" as-type="token" min-occurs="1">
-            <formal-name>Status</formal-name>
-            <description>Describes the status of the associated risk.</description>
+    <define-assembly name="task">
+        <formal-name>Task</formal-name>
+        <description>Represents a scheduled event or milestone, which may be associated with a series of assessment actions.</description>
+        <define-flag name="uuid" required="yes" as-type="uuid">
+            <formal-name>Task Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this task elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>task</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <define-flag name="type" required="yes" as-type="token">
+            <formal-name>Task Type</formal-name>
+            <description>The type of task.</description>
             <constraint>
-               <allowed-values target="." allow-other="yes">
-                  <enum value="open">The risk has been identified.</enum>
-                  <enum value="investigating">The identified risk is being investigated. (Open risk)</enum>
-                  <enum value="remediating">Remediation activities are underway, but are not yet complete. (Open risk)</enum>
-                  <enum value="deviation-requested">A risk deviation, such as false positive, risk reduction, or operational requirement has been submitted for approval. (Open risk)</enum>
-                  <enum value="deviation-approved">A risk deviation, such as false positive, risk reduction, or operational requirement has been approved. (Open risk)</enum>
-                  <enum value="closed">The risk has been resolved.</enum>
-               </allowed-values>
+                <allowed-values allow-other="yes">
+                    <enum value="milestone">The task represents a planned milestone.</enum>
+                    <enum value="action">The task represents a specific assessment action to be performed.</enum>
+                </allowed-values>
             </constraint>
-         </define-field>
-         <assembly ref="origin" max-occurs="unbounded">
-            <group-as name="origins" in-json="ARRAY"/>
-            <remarks>
-               <p>Used to identify the individual and/or tool that identified this risk.</p>
-            </remarks>
-         </assembly>
-         <field ref="threat-id" min-occurs="0" max-occurs="unbounded">
-            <!-- QUESTION: Should this be moved to risk? -->
-            <group-as name="threat-ids" in-json="ARRAY"/>
-         </field>
+        </define-flag>
 
-         <assembly ref="characterization" min-occurs="0" max-occurs="unbounded">
-            <group-as name="characterizations" in-json="ARRAY"/>
-         </assembly>
-         <define-assembly name="mitigating-factor" max-occurs="unbounded">
-            <formal-name>Mitigating Factor</formal-name>
-            <description>Describes an existing mitigating factor that may affect the overall determination of the risk, with an optional link to an implementation statement in the SSP.</description>
-            <group-as name="mitigating-factors" in-json="ARRAY"/>
-            <define-flag name="uuid" required="yes" as-type="uuid">
-               <formal-name>Mitigating Factor Universally Unique Identifier</formal-name>
-               <!-- Identifier Declaration -->
-               <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this mitigating factor elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>mitigating factor</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <define-flag name="implementation-uuid" as-type="uuid">
-               <formal-name>Implementation UUID</formal-name>
-               <!-- Identifier Declaration -->
-               <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this implementation statement elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>s. The locally defined <em>UUID</em> of the <code>implementation statement</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <model>
-               <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-                  <formal-name>Mitigating Factor Description</formal-name>
-                  <description>A human-readable description of this mitigating factor.</description>
-               </define-field>
-               <assembly ref="property" max-occurs="unbounded">
-                  <group-as name="props" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="link" max-occurs="unbounded">
-                  <group-as name="links" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="subject-reference" min-occurs="0" max-occurs="unbounded">
-                  <use-name>subject</use-name>
-                  <group-as name="subjects" in-json="ARRAY"/>
-                  <remarks>
-                     <p>Links identifiable elements of the system to this mitigating factor, such as an inventory-item or component.</p>
-                  </remarks>
-               </assembly>
-            </model>
-         </define-assembly>
+        <model>
+            <define-field name="title" min-occurs="1" as-type="markup-line">
+                <formal-name>Task Title</formal-name>
+                <description>The title for this task.</description>
+            </define-field>
+            <define-field name="description" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                <formal-name>Task Description</formal-name>
+                <description>A human-readable description of this task.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <define-assembly name="timing">
+                <formal-name>Event Timing</formal-name>
+                <description>The timing under which the task is intended to occur.</description>
+                <model>
+                    <choice>
+                        <define-assembly name="on-date" min-occurs="1">
+                            <formal-name>On Date Condition</formal-name>
+                            <description>The task is intended to occur on the specified date.</description>
+                            <define-flag name="date" as-type="dateTime-with-timezone" required="yes">
+                                <formal-name>On Date Condition</formal-name>
+                                <description>The task must occur on the specified date.</description>
+                            </define-flag>
+                        </define-assembly>
+                        <define-assembly name="within-date-range" min-occurs="1">
+                            <formal-name>On Date Range Condition</formal-name>
+                            <description>The task is intended to occur within the specified date range.</description>
+                            <define-flag name="start" as-type="dateTime-with-timezone" required="yes">
+                                <formal-name>Start Date Condition</formal-name>
+                                <description>The task must occur on or after the specified date.</description>
+                            </define-flag>
+                            <define-flag name="end" as-type="dateTime-with-timezone" required="yes">
+                                <formal-name>End Date Condition</formal-name>
+                                <description>The task must occur on or before the specified date.</description>
+                            </define-flag>
+                        </define-assembly>
+                        <define-assembly name="at-frequency" min-occurs="1">
+                            <formal-name>Frequency Condition</formal-name>
+                            <description>The task is intended to occur at the specified frequency.</description>
+                            <define-flag name="period" as-type="positiveInteger" required="yes">
+                                <formal-name>Period</formal-name>
+                                <description>The task must occur after the specified period has elapsed.</description>
+                            </define-flag>
+                            <define-flag name="unit" as-type="string" required="yes">
+                                <formal-name>Time Unit</formal-name>
+                                <description>The unit of time for the period.</description>
+                                <constraint>
+                                    <allowed-values>
+                                        <enum value="seconds">The period is specified in seconds.</enum>
+                                        <enum value="minutes">The period is specified in minutes.</enum>
+                                        <enum value="hours">The period is specified in hours.</enum>
+                                        <enum value="days">The period is specified in days.</enum>
+                                        <enum value="months">The period is specified in calendar months.</enum>
+                                        <enum value="years">The period is specified in calendar years.</enum>
+                                    </allowed-values>
+                                </constraint>
+                            </define-flag>
+                        </define-assembly>
+                    </choice>
+                </model>
+            </define-assembly>
+            <define-assembly name="dependency" max-occurs="unbounded">
+                <formal-name>Task Dependency</formal-name>
+                <description>Used to indicate that a task is dependent on another task.</description>
+                <group-as name="dependencies" in-json="ARRAY"/>
+                <define-flag name="task-uuid" required="yes" as-type="uuid">
+                    <formal-name>Task Universally Unique Identifier Reference</formal-name>
+                    <!-- Identifier Reference -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a unique task.</description>
+                </define-flag>
+                <model>
+                    <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                </model>
+            </define-assembly>
+            <assembly ref="task" min-occurs="0" max-occurs="unbounded">
+                <group-as name="tasks" in-json="ARRAY"/>
+            </assembly>
 
-         <define-field name="deadline" as-type="dateTime-with-timezone">
-            <formal-name>Risk Resolution Deadline</formal-name>
-            <description>The date/time by which the risk must be resolved.</description>
-         </define-field>
-
-         <assembly ref="response" min-occurs="0" max-occurs="unbounded">
-            <group-as name="remediations" in-json="ARRAY"/>
-         </assembly>
-         <define-assembly name="risk-log">
-            <formal-name>Risk Log</formal-name>
-            <description>A log of all risk-related tasks taken.</description>
-            <model>
-               <define-assembly name="entry" min-occurs="1" max-occurs="unbounded">
-                  <formal-name>Risk Log Entry</formal-name>
-                  <description>Identifies an individual risk response that occurred as part of managing an identified risk.</description>
-                  <group-as name="entries" in-json="ARRAY"/>
-                  <define-flag name="uuid" required="yes" as-type="uuid">
-                     <formal-name>Risk Log Entry Universally Unique Identifier</formal-name>
-                     <!-- Identifier Declaration -->
-                     <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this risk log entry elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>risk log entry</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-                  </define-flag>
-                  <model>
-                     <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
-                        <formal-name>Title</formal-name>
-                        <description>The title for this risk log entry.</description>
-                     </define-field>
-                     <define-field name="description" min-occurs="0" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-                        <formal-name>Risk Task Description</formal-name>
-                        <description>A human-readable description of what was done regarding the risk.</description>
-                     </define-field>
-                     <define-field name="start" as-type="dateTime-with-timezone" min-occurs="1" max-occurs="1">
-                        <formal-name>Start</formal-name>
-                        <description>Identifies the start date and time of the event.</description>
-                     </define-field>
-                     <define-field name="end" as-type="dateTime-with-timezone" max-occurs="1">
-                        <formal-name>End</formal-name>
-                        <description>Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time.</description>
-                     </define-field>
-                     <assembly ref="property" max-occurs="unbounded">
+            <define-assembly name="associated-activity" min-occurs="0" max-occurs="unbounded">
+                <formal-name>Associated Activity</formal-name>
+                <description>Identifies an individual activity to be performed as part of a task.</description>
+                <group-as name="associated-activities" in-json="ARRAY"/>
+                <define-flag name="activity-uuid" required="yes" as-type="uuid">
+                    <formal-name>Activity Universally Unique Identifier Reference</formal-name>
+                    <!-- Identifier Reference -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an activity defined in the list of activities.</description>
+                </define-flag>
+                <model>
+                    <assembly ref="property" max-occurs="unbounded">
                         <group-as name="props" in-json="ARRAY"/>
-                     </assembly>
-                     <assembly ref="link" max-occurs="unbounded">
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
                         <group-as name="links" in-json="ARRAY"/>
-                     </assembly>
-                     <assembly ref="logged-by" max-occurs="unbounded">
-                        <group-as name="logged-by" in-json="ARRAY"/>
-                     </assembly>
-                     <field ref="risk-status">
-                        <use-name>status-change</use-name>
+                    </assembly>
+                    <assembly ref="responsible-role" max-occurs="unbounded">
+                        <group-as name="responsible-roles" in-json="ARRAY"/>
                         <remarks>
-                           <p>Identifies a change in risk status made resulting from the task described by this risk log entry. This allows the risk's status history to be captured as a sequence of risk log entries.</p>
+                            <p>Identifies the person or organization responsible for performing a specific role defined by the activity.</p>
                         </remarks>
-                     </field>
-                     <define-assembly name="related-response" max-occurs="unbounded">
-                        <formal-name>Risk Response Reference</formal-name>
-                        <description>Identifies an individual risk response that this log entry is for.</description>
-                        <group-as name="related-responses" in-json="ARRAY"/>
-                        <define-flag name="response-uuid" required="yes" as-type="uuid">
-                           <formal-name>Response Universally Unique Identifier Reference</formal-name>
-                           <!-- Identifier Reference -->
-                           <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a unique risk response.</description>
+                    </assembly>
+<!--                    <choice>
+-->                        <assembly ref="assessment-subject" min-occurs="1" max-occurs="unbounded">
+                            <use-name>subject</use-name>
+                            <group-as name="subjects" in-json="ARRAY"/>
+                        </assembly>
+<!--                        <assembly ref="assessment-subject-placeholder">
+                            <use-name>subject-placeholder</use-name>
+                        </assembly>
+                    </choice>
+-->                    <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                </model>
+                <constraint>
+                    <is-unique id="unique-associated-activity-responsible-role" target="responsible-role">
+                        <key-field target="@role-id"/>
+                        <remarks>
+                            <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                        </remarks>
+                    </is-unique>
+                </constraint>
+            </define-assembly>
+            <assembly ref="assessment-subject" max-occurs="unbounded">
+                <use-name>subject</use-name>
+                <group-as name="subjects" in-json="ARRAY"/>
+                <remarks>
+                    <p>The assessment subjects that the activity was performed against.</p>
+                </remarks>
+            </assembly>
+            <assembly ref="responsible-role" max-occurs="unbounded">
+                <group-as name="responsible-roles" in-json="ARRAY"/>
+                <remarks>
+                    <p>Identifies the person or organization responsible for performing a specific role related to the task.</p>
+                    <!-- todo: role id and party id scope is defined at the document level.  Refer to root object within which the data is declared for...mention resolved through imports.  Note: wh-->
+                </remarks>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+    </define-assembly>
+    <!-- =========== -->
+    <!-- = END NEW = -->
+    <!-- =========== -->
+
+    <!-- ********** OBJECTIVES Assembly ********** -->
+    <define-assembly name="reviewed-controls">
+        <formal-name>Reviewed Controls and Control Objectives</formal-name>
+        <description>Identifies the controls being assessed and their control objectives.</description>
+        <model>
+            <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                <formal-name>Control Objective Description</formal-name>
+                <description>A human-readable description of control objectives.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+
+            <define-assembly name="control-selection" min-occurs="1" max-occurs="unbounded">
+                <formal-name>Assessed Controls</formal-name>
+                <description>Identifies the controls being assessed. In the assessment plan, these are the planned controls. In the assessment results, these are the actual controls, and reflects any changes from the plan.</description>
+                <group-as name="control-selections" in-json="ARRAY"/>
+                <model>
+                    <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                        <formal-name>Assessed Controls Description</formal-name>
+                        <description>A human-readable description of in-scope controls specified for assessment.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                    </assembly>
+                    <choice>
+                        <assembly ref="include-all" min-occurs="1"/>
+                        <assembly ref="select-control-by-id" min-occurs="1" max-occurs="unbounded">
+                            <use-name>include-control</use-name>
+                            <group-as name="include-controls" in-json="ARRAY"/>
+                            <remarks>
+                                <p>Used to select a control for inclusion by the control's identifier. Specific control statements can be selected by their statement identifier.</p>
+                            </remarks>
+                        </assembly>
+                    </choice>
+                    <assembly ref="select-control-by-id" max-occurs="unbounded">
+                        <use-name>exclude-control</use-name>
+                        <group-as name="exclude-controls" in-json="ARRAY"/>
+                        <remarks>
+                            <p>Used to select a control for exclusion by the control's identifier. Specific control statements can be excluded by their statement identifier.</p>
+                        </remarks>
+                    </assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                </model>
+                <remarks>
+                    <p>The <code>include-all</code>, specifies all control identified in the <strong>baseline</strong> are included in the scope if this assessment, as specified by the <code>include-profile</code> statement within the linked SSP.</p>
+                    <p>Any control specified within <code>exclude-controls</code> must first be within a range of explicitly included controls, via <code>include-controls</code> or <code>include-all</code>.</p>
+                </remarks>
+            </define-assembly>
+
+            <define-assembly name="control-objective-selection" min-occurs="0" max-occurs="unbounded">
+                <formal-name>Referenced Control Objectives</formal-name>
+                <description>Identifies the control objectives of the assessment. In the assessment plan, these are the planned objectives. In the assessment results, these are the assessed objectives, and reflects any changes from the plan.</description>
+                <group-as name="control-objective-selections" in-json="ARRAY"/>
+                <model>
+                    <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                        <formal-name>Control Objectives Description</formal-name>
+                        <description>A human-readable description of this collection of control objectives.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                    </assembly>
+                    <choice>
+                        <assembly ref="include-all" min-occurs="1"/>
+                        <assembly ref="select-objective-by-id" min-occurs="1" max-occurs="unbounded">
+                            <use-name>include-objective</use-name>
+                            <group-as name="include-objectives" in-json="ARRAY"/>
+                            <remarks>
+                                <p>Used to select a control objective for inclusion by the control objective's identifier.</p>
+                            </remarks>
+                        </assembly>
+                    </choice>
+                    <assembly ref="select-objective-by-id" max-occurs="unbounded">
+                        <use-name>exclude-objective</use-name>
+                        <group-as name="exclude-objectives" in-json="ARRAY"/>
+                        <remarks>
+                            <p>Used to select a control objective for exclusion by the control objective's identifier.</p>
+                        </remarks>
+                    </assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                </model>
+                <remarks>
+                    <p>The <code>include-all</code> field, specifies all control objectives for any in-scope control. In-scope controls are defined in the <code>control-selection</code>.</p>
+                    <p>Any control objective specified within <code>exclude-controls</code> must first be within a range of explicitly included control objectives, via <code>include-objectives</code> or <code>include-all</code>.</p>
+                </remarks>
+            </define-assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+        <remarks>
+            <p>In the context of an assessment plan, this construct is used to identify the controls and control objectives that are to be assessed. In the context of an assessment result, this construct is used to identify the actual controls and objectives that were assessed, reflecting any changes from the plan.</p>
+            <p>When resolving the selection of controls and control objectives, the following processing will occur:</p>
+            <p>1. Controls will be resolved by creating a set of controls based on the control-selections by first handling the includes, and then removing any excluded controls.</p>
+            <p>2. The set of control objectives will be resolved from the set of controls that was generated in the previous step. The set of control objectives is based on the control-objective-selection by first handling the includes, and then removing any excluded control objectives.</p>
+        </remarks>
+    </define-assembly>
+
+    <define-assembly name="select-control-by-id" scope="local">
+        <formal-name>Select Control</formal-name>
+        <description>Used to select a control for inclusion/exclusion based on one or more control identifiers. A set of statement identifiers can be used to target the inclusion/exclusion to only specific control statements providing more granularity over the specific statements that are within the asessment scope.</description>
+        <flag ref="control-id" required="yes"/>
+        <model>
+            <define-field name="statement-id" as-type="token" min-occurs="0" max-occurs="unbounded" >
+                <formal-name>Include Specific Statements</formal-name>
+                <description>Used to constrain the selection to only specificity identified statements.</description>
+                <group-as name="statement-ids" in-json="ARRAY"/>
+            </define-field>
+        </model>
+    </define-assembly>
+
+    <define-assembly name="select-objective-by-id">
+        <formal-name>Select Objective</formal-name>
+        <description>Used to select a control objective for inclusion/exclusion based on the control objective's identifier.</description>
+        <flag ref="objective-id" required="yes"/>
+    </define-assembly>
+
+    <!-- ********** ASSESSMENT SUBJECT Assembly ********** -->
+    <define-assembly name="assessment-subject-placeholder">
+        <formal-name>Assessment Subject Placeholder</formal-name>
+        <description>Used when the assessment subjects will be determined as part of one or more other assessment activities. These assessment subjects will be recorded in the assessment results in the assessment log.</description>
+        <define-flag name="uuid" required="yes" as-type="uuid">
+            <formal-name>Assessment Subject Placeholder Universally Unique Identifier</formal-name>
+             <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier for a set of assessment subjects that will be identified by a task or an activity that is part of a task. The locally defined <em>UUID</em> of the <code>assessment subject placeholder</code> can be used to reference the data item locally or globally (e.g., in an <a href="/concepts/identifier-use/#scope">imported OSCAL instance</a>). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <model>
+            <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                <formal-name>Assessment Subject Placeholder Description</formal-name>
+                <description>A human-readable description of intent of this assessment subject placeholder.</description>
+            </define-field>
+            <define-assembly name="source" min-occurs="1" max-occurs="unbounded">
+                <formal-name>Assessment Subject Source</formal-name>
+                <description>Assessment subjects will be identified while conducting the referenced activity-instance.</description>
+                <group-as name="sources" in-json="ARRAY"/>
+                <define-flag name="task-uuid" required="yes" as-type="uuid">
+                    <formal-name>Task Universally Unique Identifier</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference (in this or other OSCAL instances) an assessment activity to be performed as part of the event. The locally defined <em>UUID</em> of the <code>task</code> can be used to reference the data item locally or globally (e.g., in an <a href="/concepts/identifier-use/#scope">imported OSCAL instance</a>). This UUID should be assigned <em>per-subject</em>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+            </define-assembly>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+    </define-assembly>
+
+    <define-assembly name="assessment-subject">
+        <formal-name>Subject of Assessment</formal-name>
+        <description>Identifies system elements being assessed, such as components, inventory items, and locations. In the assessment plan, this identifies a planned assessment subject. In the assessment results this is an actual assessment subject, and reflects any changes from the plan. exactly what will be the focus of this assessment. Any subjects not identified in this way are out-of-scope.</description>
+        <define-flag name="type" as-type="token" required="yes">
+            <formal-name>Subject Type</formal-name>
+            <description>Indicates the type of assessment subject, such as a component, inventory, item, location, or party represented by this selection statement.</description>
+            <constraint>
+                <allowed-values allow-other="yes">
+                    <enum value="component">The referenced assessment subject is a component defined in the SSP, or in the <code>local-definitions</code> of an Assessment Plan or Assessment Results.</enum>
+                    <enum value="inventory-item">The referenced assessment subject is a inventory item defined in the SSP, or in the <code>local-definitions</code> of an Assessment Plan or Assessment Results.</enum>
+                    <enum value="location">The referenced assessment subject is a <code>location</code> defined in the <code>metadata</code> of the SSP, Assessment Plan, or Assessment Results.</enum>
+                    <enum value="party">The referenced assessment subject is a person or team to interview, who is defined as a <code>party</code> in the <code>metadata</code> of the SSP, Assessment Plan, or Assessment Results.</enum>
+                    <enum value="user">The referenced assessment subject is a <code>user</code> defined in the SSP, or in the <code>local-definitions</code> of an Assessment Plan or Assessment Results.</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+        <model>
+            <define-field name="description"  min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                <formal-name>Include Subjects Description</formal-name>
+                <description>A human-readable description of the collection of subjects being included in this assessment.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <choice>
+                <assembly ref="include-all" min-occurs="1"/>
+                <assembly ref="select-subject-by-id" min-occurs="1" max-occurs="unbounded">
+                    <use-name>include-subject</use-name>
+                    <group-as name="include-subjects" in-json="ARRAY"/>
+                </assembly>
+            </choice>
+            <assembly ref="select-subject-by-id" min-occurs="0" max-occurs="unbounded">
+                <use-name>exclude-subject</use-name>
+                <group-as name="exclude-subjects" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+        <remarks>
+            <p>Processing of an include/exclude pair starts with processing the include, then removing matching entries in the exclude.</p>
+        </remarks>
+    </define-assembly>
+
+    <define-assembly name="select-subject-by-id">
+        <formal-name>Select Assessment Subject</formal-name>
+        <description>Identifies a set of assessment subjects to include/exclude by UUID.</description>
+        <flag ref="subject-uuid" required="yes"/>
+        <flag ref="subject-type" required="yes">
+            <use-name>type</use-name>
+        </flag>
+        <model>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+    </define-assembly>
+    
+    <define-flag name="subject-uuid" as-type="uuid" scope="local">
+        <formal-name>Subject Universally Unique Identifier Reference</formal-name>
+        <!-- Identifier Reference -->
+        <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a component, inventory-item, location, party, user, or resource using it's UUID.</description>
+    </define-flag>
+    
+    <define-flag name="subject-type" as-type="token" scope="local">
+        <formal-name>Subject Universally Unique Identifier Reference Type</formal-name>
+        <description>Used to indicate the type of object pointed to by the <code>uuid-ref</code> within a subject.</description>
+        <constraint>
+            <allowed-values allow-other="yes">
+                <enum value="component">Component</enum>
+                <enum value="inventory-item">Inventory Item</enum>
+                <enum value="location">Location</enum>
+                <enum value="party">Interview Party</enum>
+                <enum value="user">User</enum>
+                <enum value="resource">Resource or Artifact</enum>
+            </allowed-values>
+        </constraint>
+    </define-flag>
+    
+    <define-assembly name="subject-reference" scope="local">
+        <formal-name>Identifies the Subject</formal-name>
+        <!-- Identifier Reference -->
+        <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a> identifier reference to a resource. Use type to indicate whether the identified resource is a component, inventory item, location, user, or something else.</description>
+        <flag ref="subject-uuid" required="yes"/>
+        <flag ref="subject-type" required="yes">
+            <use-name>type</use-name>
+        </flag>
+        <model>
+            <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
+                <!-- QUESTION: Is this needed, since the title from the target can be used? -->
+                <formal-name>Subject Reference Title</formal-name>
+                <description>The title or name for the referenced subject.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+        <remarks>
+            <p>The subject reference UUID could point to an item defined in the SSP, AP, or AR.</p>
+            <p>Tools should check look for the ID in every file imported directly or indirectly.</p>
+        </remarks>
+    </define-assembly>
+
+    <!-- ********** ASSET Assembly ********** -->
+    <define-assembly name="assessment-assets">
+        <formal-name>Assessment Assets</formal-name>
+        <description>Identifies the assets used to perform this assessment, such as the assessment team, scanning tools, and assumptions.</description>
+        <model>
+            <assembly ref="system-component" min-occurs="0" max-occurs="unbounded">
+                <use-name>component</use-name>
+                <group-as name="components" in-json="ARRAY"/>
+                <remarks>
+                    <p>Used to add any components for tools used during the assessment. These are represented here to avoid mixing with system components.</p>
+                    <p>The technology tools used by the assessor to perform the assessment, such as vulnerability scanners. In the assessment plan these are the intended tools. In the assessment results, these are the actual tools used, including any differences from the assessment plan.</p>
+                </remarks>
+            </assembly>
+            <define-assembly name="assessment-platform" min-occurs="1" max-occurs="unbounded">
+                <formal-name>Assessment Platform</formal-name>
+                <description>Used to represent the toolset used to perform aspects of the assessment.</description>
+                <group-as name="assessment-platforms" in-json="ARRAY"/>
+                <define-flag name="uuid" required="yes" as-type="uuid">
+                    <formal-name>Assessment Platform Universally Unique Identifier</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this assessment platform elsewhere in this or other OSCAL instances. The locally defined <em>UUID</em> of the <code>assessment platform</code> can be used to reference the data item locally or globally (e.g., in an <a href="/concepts/identifier-use/#scope">imported OSCAL instance</a>). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+                <model>
+                    <define-field name="title" max-occurs="1" as-type="markup-line">
+                        <formal-name>Assessment Platform Title</formal-name>
+                        <description>The title or name for the assessment platform.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                    </assembly>
+                    <define-assembly name="uses-component" min-occurs="0" max-occurs="unbounded">
+                        <formal-name>Uses Component</formal-name>
+                        <description>The set of components that are used by the assessment platform.</description>
+                        <group-as name="uses-components" in-json="ARRAY"/>
+                        <define-flag required="yes" name="component-uuid" as-type="uuid">
+                            <formal-name>Component Universally Unique Identifier Reference</formal-name>
+                            <!-- Identifier Reference -->
+                            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a component that is implemented as part of an inventory item.</description>
                         </define-flag>
                         <model>
-                           <assembly ref="property" max-occurs="unbounded">
-                              <group-as name="props" in-json="ARRAY"/>
-                           </assembly>
-                           <assembly ref="link" max-occurs="unbounded">
-                              <group-as name="links" in-json="ARRAY"/>
-                           </assembly>
-                           <assembly ref="related-task" max-occurs="unbounded">
-                              <group-as name="related-tasks" in-json="ARRAY"/>
-                              <remarks>
-                                 <p>This is used to identify the task(s) that this log entry was generated for.</p>
-                              </remarks>
-                           </assembly>
-                           <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                            <assembly ref="property" max-occurs="unbounded">
+                                <group-as name="props" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="link" max-occurs="unbounded">
+                                <group-as name="links" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="responsible-party" max-occurs="unbounded">
+                                <group-as name="responsible-parties" in-json="ARRAY"/>
+                            </assembly>
+                            <field ref="remarks" in-xml="WITH_WRAPPER"/>
                         </model>
-                     </define-assembly>
-                     <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-                  </model>
-                  <constraint>
-                     <allowed-values target="prop/@name" allow-other="yes">
-                        <enum value="type">The type of remediation tracking entry. Can be multi-valued.</enum>
-                     </allowed-values>
-                     <allowed-values target="prop[@name='type']/@value" allow-other="yes">
-                        <enum value="vendor-check-in">Contacted vendor to determine the status of a pending fix to a known vulnerability.</enum>
-                        <enum value="status-update">Information related to the current state of response to this risk.</enum>
-                        <enum value="milestone-complete">A significant step in the response plan has been achieved.</enum>
-                        <enum value="mitigation">An activity was completed that reduces the likelihood or impact of this risk.</enum>
-                        <enum value="remediated">An activity was completed that eliminates the likelihood or impact of this risk.</enum>
-                        <!-- QUESTION: Is this needed, since this is handled by the status field? -->
-                        <enum value="closed">The risk is no longer applicable to the system.</enum>
-                        <enum value="dr-submission">A deviation request was made to the authorizing official.</enum>
-                        <enum value="dr-updated">A previously submitted deviation request has been modified.</enum>
-                        <enum value="dr-approved">The authorizing official approved the deviation.</enum>
-                        <enum value="dr-rejected">The authorizing official rejected the deviation.</enum>
-                     </allowed-values>
-                  </constraint>
-               </define-assembly>
-            </model>
-         </define-assembly>
+                        <constraint>
+                            <is-unique id="unique-ssp-uses-component-responsible-party" target="responsible-party">
+                                <key-field target="@role-id"/>
+                                <remarks>
+                                    <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                                </remarks>
+                            </is-unique>
+                        </constraint>
+                    </define-assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER"/>
+                </model>
+            </define-assembly>
+        </model>
+        <constraint>
+            <is-unique id="unique-ssp-assessment-assets-component" target="component">
+                <key-field target="@uuid"/>
+                <remarks>
+                    <p>Since multiple assessment <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
 
-         <define-assembly name="related-observation" max-occurs="unbounded">
-            <formal-name>Related Observation</formal-name>
-            <description>Relates the finding to a set of referenced observations that were used to determine the finding.</description>
-            <group-as name="related-observations" in-json="ARRAY"/>
-            <define-flag name="observation-uuid" as-type="uuid" required="yes">
-               <formal-name>Observation Universally Unique Identifier Reference</formal-name>
-               <!-- Identifier Reference -->
-               <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an observation defined in the list of observations.</description>
-            </define-flag>
-         </define-assembly>
-      </model>
-      <constraint>
-         <allowed-values target="prop/@name">
-            <enum value="false-positive">The risk has been confirmed to be a false positive.</enum>
-            <enum value="accepted">The risk has been accepted. No further action will be taken.</enum>
-            <enum value="risk-adjusted">The risk has been adjusted.</enum>
-            <enum value="priority">A numeric value indicating the sequence in which risks should be addressed. (Lower numbers are higher priority)</enum>
-         </allowed-values>
-         <matches target="prop[@name='priority']/@value" datatype="integer" />
-      </constraint>
-   </define-assembly>
-
-   <define-assembly name="logged-by">
-      <formal-name>Logged By</formal-name>
-      <description>Used to indicate who created a log entry in what role.</description>
-      <define-flag name="party-uuid" as-type="uuid" required="yes">
-         <formal-name>Party UUID Reference</formal-name>
-         <!-- Identifier Reference -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the party who is making the log entry.</description>
-      </define-flag>
-      <define-flag name="role-id" as-type="token">
-         <formal-name>Actor Role</formal-name>
-         <description>A point to the role-id of the role in which the party is making the log entry.</description>
-      </define-flag>
-   </define-assembly>
-
-   <define-field name="risk-status" as-type="token">
-      <formal-name>Risk Status</formal-name>
-      <description>Describes the status of the associated risk.</description>
-      <constraint>
-         <allowed-values target="." allow-other="yes">
-            <enum value="open">The risk has been identified.</enum>
-            <enum value="investigating">The identified risk is being investigated. (Open risk)</enum>
-            <enum value="remediating">Remediation activities are underway, but are not yet complete. (Open risk)</enum>
-            <enum value="deviation-requested">A risk deviation, such as false positive, risk reduction, or operational requirement has been submitted for approval. (Open risk)</enum>
-            <enum value="deviation-approved">A risk deviation, such as false positive, risk reduction, or operational requirement has been approved. (Open risk)</enum>
-            <enum value="closed">The risk has been resolved.</enum>
-         </allowed-values>
-      </constraint>
-   </define-field>
-
-   <define-assembly name="characterization">
-      <formal-name>Characterization</formal-name>
-      <description>A collection of descriptive data about the containing object from a specific origin.</description>
-      <model>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="origin" min-occurs="1">
-            <remarks>
-               <p>metadata about the specific actor that generated this descriptive data.</p>
-            </remarks>
-         </assembly>
-         <define-assembly name="facet" min-occurs="1" max-occurs="unbounded">
-            <formal-name>Facet</formal-name>
-            <description>An individual characteristic that is part of a larger set produced by the same actor.</description>
-            <group-as name="facets" in-json="ARRAY"/>
-            <define-flag name="name" as-type="token" required="yes">
-               <formal-name>Facet Name</formal-name>
-               <description>The name of the risk metric within the specified system.</description>
-            </define-flag>
-            <define-flag name="system" as-type="uri" required="yes">
-               <formal-name>Naming System</formal-name>
-               <description>Specifies the naming system under which this risk metric is organized, which allows for the same names to be used in different systems controlled by different parties. This avoids the potential of a name clash.</description>
-               <constraint>
-                  <allowed-values allow-other="yes"><!-- Other values -->
-                     <enum value="http://fedramp.gov"/>
-                     <enum value="http://csrc.nist.gov/ns/oscal"/>
-                     <enum value="http://csrc.nist.gov/ns/oscal/unknown">The facet is from an unknown taxonomy. The meaning of the name is tool or organization specific.</enum>
-                     <enum value="http://cve.mitre.org"/>
-                     <!-- To identify which CVSS values to use -->
-                     <enum value="http://www.first.org/cvss/v2.0"/>
-                     <enum value="http://www.first.org/cvss/v3.0"/>
-                     <enum value="http://www.first.org/cvss/v3.1"/>
-                  </allowed-values>
-               </constraint>
-            </define-flag>
-            <define-flag name="value" as-type="string" required="yes">
-               <formal-name>Facet Value</formal-name>
-               <description>Indicates the value of the facet.</description>
-            </define-flag>
-            <model>
-               <assembly ref="property" max-occurs="unbounded">
-                  <group-as name="props" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="link" max-occurs="unbounded">
-                  <group-as name="links" in-json="ARRAY"/>
-               </assembly>
-               <field ref="remarks" in-xml="WITH_WRAPPER"/>
-            </model>
+    <!-- ********** Assemblies used within RESULTS and POA&M Items ********** -->
+    <define-assembly name="finding-target">
+        <formal-name>Objective Status</formal-name>
+        <description>Captures an assessor's conclusions regarding the degree to which an objective is satisfied.</description>
+        <define-flag name="type" as-type="string" required="yes">
+            <formal-name>Finding Target Type</formal-name>
+            <description>Identifies the type of the target.</description>
             <constraint>
-               <allowed-values target="prop/@name">
-                  <enum value="state">Indicates if the facet is 'initial' as first identified, or 'adjusted' indicating that the value has be changed after some adjustments have been made (e.g., to identify residual risk).</enum>
-               </allowed-values>
-               <allowed-values target="prop[@name='risk-state']/@value" allow-other="yes"><!-- For values related to initial and residual (mitigated) risk -->
-                  <enum value="initial">As first identified.</enum>
-                  <enum value="adjusted">Indicates that residual risk remains after some adjustments have been made.</enum>
-               </allowed-values>
-               <!-- TODO: What about "vulnerability-id", "plugin-id"? Should this be added to FedRAMP? -->
-               <allowed-values target="(.)[@system='http://csrc.nist.gov/oscal']/@name" allow-other="yes">
-                  <enum value="likelihood">General likelihood rating.</enum>
-                  <enum value="impact">General impact rating.</enum>
-                  <enum value="risk">General risk rating.</enum>
-                  <enum value="severity">General severity rating.</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://fedramp.gov']/@name" allow-other="yes">
-                  <enum value="likelihood">Likelihood as defined by FedRAMP. The <code>class</code> can be used to specify 'initial' and 'adjusted' risk states.</enum>
-                  <enum value="impact">Impact as defined by FedRAMP. The <code>class</code> can be used to specify 'initial' and 'adjusted' risk states.</enum>
-                  <enum value="risk">Risk as calculated according to FedRAMP. The <code>class</code> can be used to specify 'initial' and 'adjusted' risk states.</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://cve.mitre.org']/@name">
-                  <enum value="cve-id">An identifier managed by the CVE program (see <a>https://cve.mitre.org/</a>).</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0']/@name">
-                  <enum value="access-vector" >Base: Access Vector</enum>
-                  <enum value="access-complexity" >Base: Access Complexity</enum>
-                  <enum value="authentication" >Base: Authentication</enum>
-                  <enum value="confidentiality-impact"  >Base: Confidentiality Impact</enum>
-                  <enum value="integrity-impact"  >Base: Integrity Impact</enum>
-                  <enum value="availability-impact"  >Base: Availability Impact</enum>
-                  <enum value="exploitability"  >Temporal: Exploitability</enum>
-                  <enum value="remediation-level" >Temporal: Remediation Level</enum>
-                  <enum value="report-confidence" >Temporal: Report Confidence</enum>
-                  <enum value="collateral-damage-potential">Environmental: Collateral Damage Potential</enum>
-                  <enum value="target-distribution" >Environmental: Target Distribution</enum>
-                  <enum value="confidentiality-requirement" >Environmental: Confidentiality Requirement</enum>
-                  <enum value="integrity-requirement" >Environmental: Integrity Requirement</enum>
-                  <enum value="availability-requirement" >Environmental: Availability Requirement</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='access-vector']/@value">
-                  <enum value="local">Local</enum>
-                  <enum value="adjacent-network">Network Adjacent</enum>
-                  <enum value="network">Network</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='access-complexity']/@value">
-                  <enum value="high">High</enum>
-                  <enum value="medium">Medium</enum>
-                  <enum value="low">Low</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='authentication']/@value">
-                  <enum value="multiple">Multiple</enum>
-                  <enum value="single">Single</enum>
-                  <enum value="none">None</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name=('confidentiality-impact', 'integrity-impact', 'availability-impact')]/@value">
-                  <enum value="none">None</enum>
-                  <enum value="partial">Partial</enum>
-                  <enum value="complete">Complete</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='exploitability']/@value">
-                  <enum value="unproven">Unproven</enum>
-                  <enum value="proof-of-concept">Proof-of-Concept</enum>
-                  <enum value="functional">Functional</enum>
-                  <enum value="high">High</enum>
-                  <enum value="not-defined">Not Defined</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='remediation-level']/@value">
-                  <enum value="official-fix">Official Fix</enum>
-                  <enum value="temporary-fix">Temporary Fix</enum>
-                  <enum value="workaround">Workaround</enum>
-                  <enum value="unavailable">Unavailable</enum>
-                  <enum value="not-defined">Not Defined</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='report-confidence']/@value">
-                  <enum value="unconfirmed">Unconfirmed</enum>
-                  <enum value="uncorroborated">Uncorroborated</enum>
-                  <enum value="confirmed">Confirmed</enum>
-                  <enum value="not-defined">Not Defined</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='collateral-damage-potential']/@value">
-                  <enum value="none">None</enum>
-                  <enum value="low">Low (light loss)</enum>
-                  <enum value="low-medium">Low Medium</enum>
-                  <enum value="medium-high">Medium High</enum>
-                  <enum value="high">High (catastrophic loss)</enum>
-                  <enum value="not-defined">Not Defined</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name=('target-distribution', 'confidentiality-requirement', 'integrity-requirement', 'availability-requirement')]/@value">
-                  <enum value="none"></enum>
-                  <enum value="low"></enum>
-                  <enum value="medium"></enum>
-                  <enum value="high"></enum>
-                  <enum value="not-defined"></enum>
-               </allowed-values>
-
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1')]/@name">
-                  <enum value="attack-vector" >Base: Attack Vector</enum>
-                  <enum value="access-complexity" >Base: Attack Complexity</enum>
-                  <enum value="privileges-required" >Base: Privileges Required</enum>
-                  <enum value="user-interaction" >Base: User Interaction</enum>
-                  <enum value="scope"  >Base: Scope</enum>
-                  <enum value="confidentiality-impact"  >Base: Confidentiality Impact</enum>
-                  <enum value="integrity-impact"  >Base: Integrity Impact</enum>
-                  <enum value="availability-impact"  >Base: Availability Impact</enum>
-                  <enum value="exploit-code-maturity"  >Temporal: Exploit Code Maturity</enum>
-                  <enum value="remediation-level" >Temporal: Remediation Level</enum>
-                  <enum value="report-confidence" >Temporal: Report Confidence</enum>
-                  <enum value="modified-attack-vector">Environmental: Modified Attack Vector</enum>
-                  <enum value="modified-attack-complexity">Environmental: Modified Attack Complexity</enum>
-                  <enum value="modified-privileges-required">Environmental: Modified Privileges Required</enum>
-                  <enum value="modified-user-interaction">Environmental: Modified User Interaction</enum>
-                  <enum value="modified-scope" >Environmental: Modified Scope</enum>
-                  <enum value="modified-confidentiality" >Environmental: Modified Confidentiality</enum>
-                  <enum value="modified-integrity" >Environmental: Modified Integrity</enum>
-                  <enum value="modified-availability" >Environmental: Modified Availability</enum>
-                  <enum value="confidentiality-requirement" >Environmental: Confidentiality Requirement Modifier</enum>
-                  <enum value="integrity-requirement" >Environmental: Integrity Requirement Modifier</enum>
-                  <enum value="availability-requirement" >Environmental: Availability Requirement Modifier</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='access-vector']/@value">
-                  <enum value="network">Network</enum>
-                  <enum value="adjacent">Adjacent</enum>
-                  <enum value="local">Local</enum>
-                  <enum value="physical">Physical</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='access-complexity']/@value">
-                  <enum value="high">High</enum>
-                  <enum value="low">Low</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name=('privileges-required', 'confidentiality-impact', 'integrity-impact', 'availability-impact')]/@value">
-                  <enum value="none">None</enum>
-                  <enum value="low">Low</enum>
-                  <enum value="high">High</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='user-interaction']/@value">
-                  <enum value="none">None</enum>
-                  <enum value="required">Required</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='scope']/@value">
-                  <enum value="unchanged">Unchanged</enum>
-                  <enum value="changed">Changed</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='exploit-code-maturity']/@value">
-                  <enum value="not-defined">Not Defined</enum>
-                  <enum value="unproven">Unproven</enum>
-                  <enum value="proof-of-concept">Proof-of-Concept</enum>
-                  <enum value="functional">Functional</enum>
-                  <enum value="high">High</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='remediation-level']/@value">
-                  <enum value="not-defined">Not Defined</enum>
-                  <enum value="official-fix">Official Fix</enum>
-                  <enum value="temporary-fix">Temporary Fix</enum>
-                  <enum value="workaround">Workaround</enum>
-                  <enum value="unavailable">Unavailable</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='report-confidence']/@value">
-                  <enum value="not-defined">Not Defined</enum>
-                  <enum value="unknown">Unknown</enum>
-                  <enum value="reasonable">Reasonable</enum>
-                  <enum value="confirmed">Confirmed</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name=('confidentiality-requirement', 'integrity-requirement', 'availability-requirement')]/@value">
-                  <enum value="not-defined">Not Defined</enum>
-                  <enum value="low">Low</enum>
-                  <enum value="medium">Medium</enum>
-                  <enum value="high">High</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='modified-attack-vector']/@value">
-                  <enum value="not-defined">Not Defined</enum>
-                  <enum value="network">Network</enum>
-                  <enum value="adjacent">Adjacent</enum>
-                  <enum value="local">Local</enum>
-                  <enum value="physical">Physical</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='modified-attack-complexity']/@value">
-                  <enum value="not-defined">Not Defined</enum>
-                  <enum value="high">High</enum>
-                  <enum value="low">Low</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name=('modified-privileges-required', 'modified-confidentiality', 'modified-integrity', 'modified-availability')]/@value">
-                  <enum value="not-defined">Not Defined</enum>
-                  <enum value="none">None</enum>
-                  <enum value="low">Low</enum>
-                  <enum value="high">High</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='modified-user-interaction']/@value">
-                  <enum value="not-defined">Not Defined</enum>
-                  <enum value="none">None</enum>
-                  <enum value="required">Required</enum>
-               </allowed-values>
-               <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='modified-scope']/@value">
-                  <enum value="not-defined">Not Defined</enum>
-                  <enum value="unchanged">Unchanged</enum>
-                  <enum value="changed">Changed</enum>
-               </allowed-values>
+                <allowed-values>
+                    <enum value="statement-id">A reference to a control statement identifier within a control.</enum>
+                    <enum value="objective-id">A reference to a control objective identifier within a control.</enum>
+                </allowed-values>
             </constraint>
-         </define-assembly>
-      </model>
-   </define-assembly>
-
-   <define-assembly name="response" scope="local">
-      <formal-name>Risk Response</formal-name>
-      <description>Describes either recommended or an actual plan for addressing the risk.</description>
-      <define-flag name="uuid" required="yes" as-type="uuid">
-         <formal-name>Remediation Universally Unique Identifier</formal-name>
-         <!-- Identifier Declaration -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this remediation elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>risk response</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-      </define-flag>
-      <define-flag name="lifecycle" as-type="token" required="yes">
-         <formal-name>Remediation Intent</formal-name>
-         <description>Identifies whether this is a recommendation, such as from an assessor or tool, or an actual plan accepted by the system owner.</description>
-         <constraint>
-            <allowed-values allow-other="yes">
-               <enum value="recommendation">Recommended Remediation</enum>
-               <enum value="planned">The actions intended to resolve the risk.</enum>
-               <enum value="completed">This remediation activities were performed to address the risk.</enum>
-            </allowed-values>
-         </constraint>
-      </define-flag>
-      <model>
-         <define-field name="title" min-occurs="1" max-occurs="1" as-type="markup-line">
-            <formal-name>Response Title</formal-name>
-            <description>The title for this response activity.</description>
-         </define-field>
-         <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-            <formal-name>Response Description</formal-name>
-            <description>A human-readable description of this response plan.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="origin" max-occurs="unbounded">
-            <group-as name="origins" in-json="ARRAY"/>
             <remarks>
-               <p>Used to identify the individual and/or tool that generated this recommended or planned response.</p>
+                <p>The target will always be a reference to: 1) a control statement, or 2) a control objective. In the former case, there is always a single top-level statement within a control. Thus, if the entire control is targeted, this statement identifier can be used.</p>
             </remarks>
-         </assembly>
+        </define-flag>
+        <define-flag name="target-id" as-type="token" required="yes">
+            <formal-name>Finding Target Identifier Reference</formal-name>
+            <!-- Identifier Reference -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference for a specific target qualified by the <code>type</code>.</description>
+        </define-flag>
+        <model>
+            <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
+                <formal-name>Objective Status Title</formal-name>
+                <description>The title for this objective status.</description>
+            </define-field>
+            <define-field name="description" min-occurs="0" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                <formal-name>Objective Status Description</formal-name>
+                <description>A human-readable description of the assessor's conclusions regarding the degree to which an objective is satisfied.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <define-assembly name="status" min-occurs="1">
+                <formal-name>Objective Status</formal-name>
+                <description>A determination of if the objective is satisfied or not within a given system.</description>
+                <define-flag name="state" as-type="token" required="yes">
+                    <formal-name>Objective Status State</formal-name>
+                    <description>An indication as to whether the objective is satisfied or not.</description>
+                <constraint>
+                        <allowed-values>
+                        <enum value="satisfied">The objective has been completely satisfied.</enum>
+                        <enum value="not-satisfied">The objective has not been completely satisfied, but may be partially satisfied.</enum>
+                    </allowed-values>
+                </constraint>
+                </define-flag>
+                <define-flag name="reason" as-type="token">
+                <formal-name>Objective Status Reason</formal-name>
+                <description>The reason the objective was given it's status.</description>
+                <constraint>
+                        <allowed-values allow-other="yes">
+                        <enum value="pass">The target system or system component satisfied all the conditions.</enum>
+                        <enum value="fail">The target system or system component did not satisfy all the conditions.</enum>
+                        <enum value="other">Some other event took place that is not a pass or a fail. </enum>
+                    </allowed-values>
+                </constraint>
+            <remarks>
+                <p>Reason may contain any value, and should be used to communicate additional information regarding the status.</p>
+            </remarks>
+                </define-flag>
+                <model>
+                    <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                </model>
+            </define-assembly>
+            <assembly ref="implementation-status">
+                <remarks>
+                    <p>The <code>implementation-status</code> is used to qualify the <code>status</code> value to indicate the degree to which the control was found to be implemented.</p>
+                </remarks>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+    </define-assembly>
 
-         <define-assembly name="required-asset" max-occurs="unbounded">
-            <!-- QUESTION: Do we need to identify a set of remediation assets similar to assessment-assets -->
-            <formal-name>Required Asset</formal-name>
-            <description>Identifies an asset required to achieve remediation.</description>
-            <group-as name="required-assets" in-json="ARRAY"/>
-            <define-flag name="uuid" required="yes" as-type="uuid">
-               <formal-name>Required Universally Unique Identifier</formal-name>
-               <!-- Identifier Declaration -->
-               <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this required asset elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>asset</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <model>
-               <assembly ref="subject-reference" min-occurs="0" max-occurs="unbounded">
-                  <use-name>subject</use-name>
-                  <group-as name="subjects" in-json="ARRAY"/>
-                  <remarks>
-                     <p>Identifies an asset associated with this requirement, such as a party, system component, or inventory-item.</p>
-                  </remarks>
-               </assembly>
-               <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
-                  <formal-name>Title for Required Asset</formal-name>
-                  <description>The title for this required asset.</description>
-               </define-field>
-               <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-                  <formal-name>Description of Required Asset</formal-name>
-                  <description>A human-readable description of this required asset.</description>
-               </define-field>
-               <assembly ref="property" max-occurs="unbounded">
-                  <group-as name="props" in-json="ARRAY"/>
-               </assembly>
-               <assembly ref="link" max-occurs="unbounded">
-                  <group-as name="links" in-json="ARRAY"/>
-               </assembly>
-               <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-            </model>
-         </define-assembly>
-         <assembly ref="task" min-occurs="0" max-occurs="unbounded">
-            <group-as name="tasks" in-json="ARRAY"/>
-         </assembly>
-         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-      </model>
-      <constraint>
-         <allowed-values target="prop/@name" allow-other="yes">
-            <enum value="type"></enum>
-         </allowed-values>
-         <allowed-values target="prop[@name='type']/@value" allow-other="yes">
-            <enum value="avoid">The risk will be eliminated.</enum>
-            <enum value="mitigate">The risk will be reduced.</enum>
-            <enum value="transfer">The risk will be transferred to another organization or entity.</enum>
-            <enum value="accept">The risk will continue to exist without further efforts to address it. (Sometimes referred to as "Operationally required")</enum>
-            <enum value="share">The risk will be partially transferred to another organization or entity.</enum>
-            <enum value="contingency">Plans will be made to address the risk impact if the risk occurs. (This is a form of mitigation.)</enum>
-            <enum value="none">No response, such as when the identified risk is found to be a false positive.</enum>
-         </allowed-values>
-      </constraint>
-   </define-assembly>
+    <define-assembly name="observation">
+        <formal-name>Observation</formal-name>
+        <description>Describes an individual observation.</description>
+        <define-flag name="uuid" required="yes" as-type="uuid">
+            <formal-name>Observation Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <em>cross-instance</em> scope that can be used to reference this observation elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>observation</code> can be used to reference the data item locally or globally (e.g., in an imorted OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <model>
+            <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
+                <formal-name>Observation Title</formal-name>
+                <description>The title for this observation.</description>
+            </define-field>
+            <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER"
+                as-type="markup-multiline">
+                <formal-name>Observation Description</formal-name>
+                <description>A human-readable description of this assessment observation.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <define-field name="method" min-occurs="1" max-occurs="unbounded">
+                <formal-name>Observation Method</formal-name>
+                <description>Identifies how the observation was made.</description>
+                <group-as name="methods" in-json="ARRAY"/>
+                <constraint>
+                    <allowed-values target="." allow-other="yes">
+                        <enum value="EXAMINE">An inspection was performed.</enum>
+                        <enum value="INTERVIEW">An interview was performed.</enum>
+                        <enum value="TEST">A manual or automated test was performed.</enum>
+                        <enum value="UNKNOWN">This is only for use when converting historic content to OSCAL, where the conversion process cannot initially identify the appropriate method(s).</enum>
+                    </allowed-values>
+                </constraint>
+            </define-field>
 
-   <define-flag name="objective-id" as-type="token" scope="local">
-      <!-- This is an id to sync with control syntax -->
-      <formal-name>Objective ID</formal-name>
-      <description>Points to an assessment objective.</description>
-   </define-flag>
+            <define-field name="type" as-type="token" max-occurs="unbounded">
+                <formal-name>Observation Type</formal-name>
+                <description>Identifies the nature of the observation. More than one may be used to further qualify and enable filtering.</description>
+                <group-as name="types" in-json="ARRAY"/>
+                <constraint>
+                    <allowed-values target="." allow-other="yes">
+                        <enum value="ssp-statement-issue">A difference between the SSP implementation statement, and actual implementation.</enum>
+                        <enum value="control-objective">An observation about the status of a the associated control objective.</enum>
+                        <enum value="mitigation">A mitigating factor was identified.</enum>
+                        <enum value="finding">An assessment finding. Used for observations made by tools, penetration testing, and other means.</enum>
+                        <enum value="historic">An observation from a past assessment, which was converted to OSCAL at a later date.</enum>
+                    </allowed-values>
+                </constraint>
+            </define-field>
+            <assembly ref="origin" max-occurs="unbounded">
+                <group-as name="origins" in-json="ARRAY"/>
+                <remarks>
+                    <p>Used to identify the individual and/or tool that gathered the evidence resulting in the observation identification.</p>
+                </remarks>
+            </assembly>
+            <assembly ref="subject-reference" min-occurs="0" max-occurs="unbounded">
+                <use-name>subject</use-name>
+                <group-as name="subjects" in-json="ARRAY"/>
+                <remarks>
+                    <p>Identifies who was interviewed, or what was tested or inspected.</p>
+                </remarks>
+            </assembly>
 
-   <define-assembly name="assessment-part"> <!--scope="local"-->
-      <!-- QUESTION: Is it confusing to use part here, given the control meaning of part? -->
-      <formal-name>Assessment Part</formal-name>
-      <description>A partition of an assessment plan or results or a child of another part.</description>
-      <use-name>part</use-name>
-      <define-flag name="uuid" as-type="uuid">
-         <!-- CHANGE: from uuiid to uuid -->
-         <formal-name>Part Identifier</formal-name>
-         <!-- Identifier Declaration -->
-         <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this part elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>part</code> can be used to reference the data item locally or globally (e.g., in an ported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-      </define-flag>
-      <define-flag name="name" as-type="token" required="yes">
-         <formal-name>Part Name</formal-name>
-         <description>A textual label that uniquely identifies the part's semantic type.</description>
-         <constraint>
-            <allowed-values allow-other="yes">
-               <!-- QUESTION: Should this be in sync with control part? Should these be defined here or should they be defined in the context of use? -->
-               <enum value="asset">An assessment asset.</enum>
-               <enum value="method">An assessment method.</enum>
-               <enum value="objective">Describes a set of control objectives.</enum>
+            <define-assembly name="relevant-evidence" max-occurs="unbounded">
+                <formal-name>Relevant Evidence</formal-name>
+                <description>Links this observation to relevant evidence.</description>
+                <group-as name="relevant-evidence" in-json="ARRAY"/>
+                <define-flag name="href" required="no" as-type="uri-reference">
+                    <formal-name>Relevant Evidence Reference</formal-name>
+                    <description>A resolvable URL reference to relevant evidence.</description>
+                    <remarks>
+                        <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code> <code>resource</code> in the same document.</p>
+                        <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is <a href="/concepts/layer/assessment/assessment-plan/#key-concepts">within the scope of the containing OSCAL document</a>.</p>
+                        <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URI pointing to the location of the referenced resource. A relative URI will be resolved relative to the location of the document containing the link.</p>
+                    </remarks>
+                </define-flag>
+                <model>
+                    <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                        <formal-name>Relevant Evidence Description</formal-name>
+                        <description>A human-readable description of this evidence.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                    </assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                </model>
+            </define-assembly>
+            <define-field name="collected" as-type="dateTime-with-timezone" min-occurs="1" max-occurs="1">
+                <formal-name>collected field</formal-name>
+                <description>Date/time stamp identifying when the finding information was collected.</description>
+            </define-field>
+            <define-field name="expires" as-type="dateTime-with-timezone" min-occurs="0" max-occurs="1">
+                <formal-name>expires field</formal-name>
+                <description>Date/time identifying when the finding information is out-of-date and no longer valid. Typically used with continuous assessment scenarios.</description>
+            </define-field>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+<!--        <constraint>
+            <!-\- TODO: review these and figure out where these go -\->
+            <allowed-values target="origin/@type" allow-other="no">
+                <!-\\- CHANGED: "tool" to "******" -\\->
+                <enum value="tool">An assessment tool, defined in the assets section of the assessment plan or results.</enum>
+                <enum value="test-method">A test method defined in the assessment-activities section of the assessment plan or results.</enum>
+                <enum value="task">A task defined in the schedule of the assessment plan or results.</enum>
+                <enum value="included-activity">An assessment activity defined in the assessment-activities section of the assessment plan or results.</enum>
+                <enum value="other">The UUID points elsewhere in the this file or an imported file.</enum>
             </allowed-values>
-         </constraint>
-      </define-flag>
-      <define-flag name="ns" as-type="uri">
-         <!-- CHANGED: data type to uri -->
-         <formal-name>Part Namespace</formal-name>
-         <description>A namespace qualifying the part's name. This allows different organizations to associate distinct semantics with the same name.</description>
-         <remarks>
-            <p>Provides a means to segment the value space for the <code>name</code>, so that different organizations and individuals can assert control over the allowed names and associated text used in a part. This allows the semantics associated with a given name to be defined on an organization-by-organization basis.</p>
-            <p>An organization MUST use a URI that they have control over. e.g., a domain registered to the organization in a URI, a registered uniform resource names (URN) namespace.</p>
-            <p>When a <code>ns</code> is not provided, its value should be assumed to be <code>http://csrc.nist.gov/ns/oscal</code> and the name should be a name defined by the associated OSCAL model.</p>
-         </remarks>
-      </define-flag>
-      <define-flag name="class" as-type="token">
-         <formal-name>Part Class</formal-name>
-         <description>A textual label that provides a sub-type or characterization of the part's <code>name</code>. This can be used to further distinguish or discriminate between the semantics of multiple parts of the same control with the same <code>name</code> and <code>ns</code>.</description>
-         <remarks>
-            <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
-            <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
-         </remarks>
-      </define-flag>
-      <model>
-         <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line" >
-            <formal-name>Part Title</formal-name>
-            <description>A name given to the part, which may be used by a tool for display and navigation.</description>
-         </define-field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </assembly>
-         <define-field name="prose" as-type="markup-multiline" in-xml="UNWRAPPED" min-occurs="0">
-            <!-- QUESTION: Is this the right name? -->
-            <formal-name>Part Text</formal-name>
-            <description>Permits multiple paragraphs, lists, tables etc.</description>
-         </define-field>
-         <assembly ref="assessment-part" max-occurs="unbounded">
-            <group-as name="parts" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-         </assembly>
-         <!-- <any/> -->
-      </model>
-      <constraint>
-         <allowed-values target=".[@name='objective']/prop/@name" allow-other="yes">
-            <enum value="method">The assessment method to use. This typically appears on parts with the name "objective".</enum>
-         </allowed-values>
-         <has-cardinality target=".[@name='objective']/prop[@name='method']" min-occurs="1"/>
-         <allowed-values target=".[@name='objective']/prop[@name='method']/@value">
-            <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
-            <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
-            <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
-         </allowed-values>
-      </constraint>
-      <remarks>
-         <p>A <code>part</code> provides for logical partitioning of prose, and can be thought of as a grouping structure (e.g., section). A <code>part</code> can have child parts allowing for arbitrary nesting of prose content (e.g., statement hierarchy). A <code>part</code> can contain <code>prop</code> objects that allow for enriching prose text with structured name/value information.</p>
-         <p>A <code>part</code> can be assigned an optional <code>id</code>, which allows for internal and external references to the textual concept contained within a <code>part</code>. A <code>id</code> provides a means for an OSCAL profile, or a higher layer OSCAL model to reference a specific part within a <code>catalog</code>. For example, an <code>id</code> can be used to reference or to make modifications to a control statement in a profile.</p>
-         <p>Use of <code>part</code> and <code>prop</code> provides for a wide degree of extensibility within the OSCAL catalog model. The optional <code>ns</code> provides a means to qualify a part's <code>name</code>, allowing for organization-specific vocabularies to be defined with clear semantics. Any organization that extends OSCAL in this way should consistently assign a <code>ns</code> value that represents the organization, making a given namespace qualified <code>name</code> unique to that organization. This allows the combination of <code>ns</code> and <code>name</code> to always be unique and unambiguous, even when mixed with extensions from other organizations. Each organization is responsible for governance of their own extensions, and is strongly encouraged to publish their extensions as standards to their user community. If no <code>ns</code> is provided, the name is expected to be in the "OSCAL" namespace.</p>
-         <p>To ensure a <code>ns</code> is unique to an organization and naming conflicts are avoided, a URI containing a DNS or other globally defined organization name should be used. For example, if FedRAMP and DoD both extend OSCAL, FedRAMP will use the <code>ns</code> "https://fedramp.gov", while DoD will use the <code>ns</code> "https://defense.gov" for any organization specific <code>name</code>.</p>
-         <p>Tools that process OSCAL content are not required to interpret unrecognized OSCAL extensions; however, OSCAL compliant tools should not modify or remove unrecognized extensions, unless there is a compelling reason to do so, such as data sensitivity.</p>
-      </remarks>
-   </define-assembly>
+        </constraint>
+-->    </define-assembly>
+
+    <define-assembly name="origin">
+        <formal-name>Origin</formal-name>
+        <description>Identifies the source of the finding, such as a tool, interviewed person, or activity.</description>
+        <model>
+            <assembly ref="origin-actor" min-occurs="1" max-occurs="unbounded">
+                <use-name>actor</use-name>
+                <group-as name="actors" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="related-task" max-occurs="unbounded">
+                <group-as name="related-tasks" in-json="ARRAY"/>
+            </assembly>
+        </model>
+    </define-assembly>
+
+    <define-assembly name="origin-actor">
+        <formal-name>Originating Actor</formal-name>
+        <description>The actor that produces an observation, a finding, or a risk. One or more actor type can be used to specify a person that is using a tool.</description>
+        <define-flag name="type" as-type="token" required="yes">
+            <formal-name>Actor Type</formal-name>
+            <description>The kind of actor.</description>
+            <constraint>
+                <allowed-values>
+                    <enum value="tool">A reference to a tool component defined with the assessment assets.</enum>
+                    <enum value="assessment-platform">A reference to an assessment-platform defined with the assessment assets.</enum>
+                    <enum value="party">A reference to a party defined within the document metadata.</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+        <define-flag name="actor-uuid" as-type="uuid" required="yes">
+            <formal-name>Actor Universally Unique Identifier Reference</formal-name>
+            <!-- Identifier Reference -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the tool or person based on the associated type.</description>
+        </define-flag>
+        <define-flag name="role-id" as-type="token">
+            <formal-name>Actor Role</formal-name>
+            <description>For a party, this can optionally be used to specify the role the actor was performing.</description>
+        </define-flag>
+        <model>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+        </model>
+    </define-assembly>
+
+    <define-assembly name="related-task">
+        <formal-name>Task Reference</formal-name>
+        <description>Identifies an individual task for which the containing object is a consequence of.</description>
+        <define-flag name="task-uuid" required="yes" as-type="uuid">
+            <formal-name>Task Universally Unique Identifier Reference</formal-name>
+            <!-- Identifier Reference -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a unique task.</description>
+        </define-flag>
+        <model>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="responsible-party" max-occurs="unbounded">
+                <group-as name="responsible-parties" in-json="ARRAY"/>
+                <remarks>
+                    <p>Identifies the person or organization responsible for performing a specific role defined by the activity.</p>
+                </remarks>
+            </assembly>
+            <assembly ref="assessment-subject" max-occurs="unbounded">
+                <use-name>subject</use-name>
+                <group-as name="subjects" in-json="ARRAY"/>
+                <remarks>
+                    <p>The assessment subjects that the task was performed against.</p>
+                </remarks>
+            </assembly>
+            <define-assembly name="identified-subject">
+                <formal-name>Identified Subject</formal-name>
+                <description>Used to detail assessment subjects that were identfied by this task.</description>
+
+                <define-flag name="subject-placeholder-uuid" required="yes" as-type="uuid">
+                    <formal-name>Assessment Subject Placeholder Universally Unique Identifier Reference</formal-name>
+                    <!-- Identifier Reference -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a unique assessment subject placeholder defined by this task.</description>
+                </define-flag>
+                <model>
+                    <assembly ref="assessment-subject" min-occurs="1" max-occurs="unbounded">
+                        <use-name>subject</use-name>
+                        <group-as name="subjects" in-json="ARRAY"/>
+                        <remarks>
+                            <p>The assessment subjects that the task identified, which will be used by another task through a subject-placeholder reference. Such a task will "consume" these subjects.</p>
+                        </remarks>
+                    </assembly>
+                </model>
+            </define-assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+        <constraint>
+            <is-unique id="unique-ssp-related-task-responsible-party" target="responsible-party">
+                <key-field target="@role-id"/>
+                <remarks>
+                    <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
+
+    <define-field name="threat-id" as-type="uri">
+        <!-- This is an id because it is an externally provided identifier -->
+        <formal-name>Threat ID</formal-name>
+        <description>A pointer, by ID, to an externally-defined threat.</description>
+        <json-value-key>id</json-value-key>
+        <define-flag name="system" as-type="uri" required="yes">
+            <formal-name>Threat Type Identification System</formal-name>
+            <description>Specifies the source of the threat information.</description>
+            <constraint>
+                <allowed-values allow-other="yes">
+                    <enum value="https://fedramp.gov">The value conforms to FedRAMP definitions.</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+        <define-flag name="href" as-type="uri-reference">
+            <formal-name>Threat Information Resource Reference</formal-name>
+            <description>An optional location for the threat data, from which this ID originates.</description>
+        </define-flag>
+    </define-field>
+
+    <define-assembly name="risk">
+        <formal-name>Identified Risk</formal-name>
+        <description>An identified risk.</description>
+        <define-flag name="uuid" required="yes" as-type="uuid">
+            <formal-name>Risk Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this risk elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>risk</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <model>
+            <define-field name="title" min-occurs="1" max-occurs="1" as-type="markup-line">
+                <formal-name>Risk Title</formal-name>
+                <description>The title for this risk.</description>
+            </define-field>
+            <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                <formal-name>Risk Description</formal-name>
+                <description>A human-readable summary of the identified risk, to include a statement of how the risk impacts the system.</description>
+            </define-field>
+            <define-field name="statement" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <!-- QUESTION: how is this different from description? -->
+                <!-- TODO: remove this -->
+                <formal-name>Risk Statement</formal-name>
+                <description>An summary of impact for how the risk affects the system.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <define-field name="status" as-type="token" min-occurs="1">
+                <formal-name>Status</formal-name>
+                <description>Describes the status of the associated risk.</description>
+                <constraint>
+                    <allowed-values target="." allow-other="yes">
+                        <enum value="open">The risk has been identified.</enum>
+                        <enum value="investigating">The identified risk is being investigated. (Open risk)</enum>
+                        <enum value="remediating">Remediation activities are underway, but are not yet complete. (Open risk)</enum>
+                        <enum value="deviation-requested">A risk deviation, such as false positive, risk reduction, or operational requirement has been submitted for approval. (Open risk)</enum>
+                        <enum value="deviation-approved">A risk deviation, such as false positive, risk reduction, or operational requirement has been approved. (Open risk)</enum>
+                        <enum value="closed">The risk has been resolved.</enum>
+                    </allowed-values>
+                </constraint>
+            </define-field>
+            <assembly ref="origin" max-occurs="unbounded">
+                <group-as name="origins" in-json="ARRAY"/>
+                <remarks>
+                    <p>Used to identify the individual and/or tool that identified this risk.</p>
+                </remarks>
+            </assembly>
+            <field ref="threat-id" min-occurs="0" max-occurs="unbounded">
+                <!-- QUESTION: Should this be moved to risk? -->
+                <group-as name="threat-ids" in-json="ARRAY"/>
+            </field>
+
+            <assembly ref="characterization" min-occurs="0" max-occurs="unbounded">
+                <group-as name="characterizations" in-json="ARRAY"/>
+            </assembly>
+            <define-assembly name="mitigating-factor" max-occurs="unbounded">
+                <formal-name>Mitigating Factor</formal-name>
+                <description>Describes an existing mitigating factor that may affect the overall determination of the risk, with an optional link to an implementation statement in the SSP.</description>
+                <group-as name="mitigating-factors" in-json="ARRAY"/>
+                <define-flag name="uuid" required="yes" as-type="uuid">
+                    <formal-name>Mitigating Factor Universally Unique Identifier</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this mitigating factor elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>mitigating factor</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+                <define-flag name="implementation-uuid" as-type="uuid">
+                    <formal-name>Implementation UUID</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this implementation statement elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>s. The locally defined <em>UUID</em> of the <code>implementation statement</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+                <model>
+                    <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                        <formal-name>Mitigating Factor Description</formal-name>
+                        <description>A human-readable description of this mitigating factor.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="subject-reference" min-occurs="0" max-occurs="unbounded">
+                        <use-name>subject</use-name>
+                        <group-as name="subjects" in-json="ARRAY"/>
+                        <remarks>
+                            <p>Links identifiable elements of the system to this mitigating factor, such as an inventory-item or component.</p>
+                        </remarks>
+                    </assembly>
+                </model>
+            </define-assembly>
+
+            <define-field name="deadline" as-type="dateTime-with-timezone">
+                <formal-name>Risk Resolution Deadline</formal-name>
+                <description>The date/time by which the risk must be resolved.</description>
+            </define-field>
+
+            <assembly ref="response" min-occurs="0" max-occurs="unbounded">
+                <group-as name="remediations" in-json="ARRAY"/>
+            </assembly>
+            <define-assembly name="risk-log">
+                <formal-name>Risk Log</formal-name>
+                <description>A log of all risk-related tasks taken.</description>
+                <model>
+                    <define-assembly name="entry" min-occurs="1" max-occurs="unbounded">
+                        <formal-name>Risk Log Entry</formal-name>
+                        <description>Identifies an individual risk response that occurred as part of managing an identified risk.</description>
+                        <group-as name="entries" in-json="ARRAY"/>
+                        <define-flag name="uuid" required="yes" as-type="uuid">
+                            <formal-name>Risk Log Entry Universally Unique Identifier</formal-name>
+                            <!-- Identifier Declaration -->
+                            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this risk log entry elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>risk log entry</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                        </define-flag>
+                        <model>
+                            <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
+                                <formal-name>Title</formal-name>
+                                <description>The title for this risk log entry.</description>
+                            </define-field>
+                            <define-field name="description" min-occurs="0" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                                <formal-name>Risk Task Description</formal-name>
+                                <description>A human-readable description of what was done regarding the risk.</description>
+                            </define-field>
+                            <define-field name="start" as-type="dateTime-with-timezone" min-occurs="1" max-occurs="1">
+                                <formal-name>Start</formal-name>
+                                <description>Identifies the start date and time of the event.</description>
+                            </define-field>
+                            <define-field name="end" as-type="dateTime-with-timezone" max-occurs="1">
+                                <formal-name>End</formal-name>
+                                <description>Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time.</description>
+                            </define-field>
+                            <assembly ref="property" max-occurs="unbounded">
+                                <group-as name="props" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="link" max-occurs="unbounded">
+                                <group-as name="links" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="logged-by" max-occurs="unbounded">
+                                <group-as name="logged-by" in-json="ARRAY"/>
+                            </assembly>
+                            <field ref="risk-status">
+                                <use-name>status-change</use-name>
+                                <remarks>
+                                    <p>Identifies a change in risk status made resulting from the task described by this risk log entry. This allows the risk's status history to be captured as a sequence of risk log entries.</p>
+                                </remarks>
+                            </field>
+                            <define-assembly name="related-response" max-occurs="unbounded">
+                                <formal-name>Risk Response Reference</formal-name>
+                                <description>Identifies an individual risk response that this log entry is for.</description>
+                                <group-as name="related-responses" in-json="ARRAY"/>
+                                <define-flag name="response-uuid" required="yes" as-type="uuid">
+                                    <formal-name>Response Universally Unique Identifier Reference</formal-name>
+                                    <!-- Identifier Reference -->
+                                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a unique risk response.</description>
+                                </define-flag>
+                                <model>
+                                    <assembly ref="property" max-occurs="unbounded">
+                                        <group-as name="props" in-json="ARRAY"/>
+                                    </assembly>
+                                    <assembly ref="link" max-occurs="unbounded">
+                                        <group-as name="links" in-json="ARRAY"/>
+                                    </assembly>
+                                    <assembly ref="related-task" max-occurs="unbounded">
+                                        <group-as name="related-tasks" in-json="ARRAY"/>
+                                        <remarks>
+                                            <p>This is used to identify the task(s) that this log entry was generated for.</p>
+                                        </remarks>
+                                    </assembly>
+                                    <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                                </model>
+                            </define-assembly>
+                            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                        </model>
+                        <constraint>
+                            <allowed-values target="prop/@name" allow-other="yes">
+                                <enum value="type">The type of remediation tracking entry. Can be multi-valued.</enum>
+                            </allowed-values>
+                            <allowed-values target="prop[@name='type']/@value" allow-other="yes">
+                                <enum value="vendor-check-in">Contacted vendor to determine the status of a pending fix to a known vulnerability.</enum>
+                                <enum value="status-update">Information related to the current state of response to this risk.</enum>
+                                <enum value="milestone-complete">A significant step in the response plan has been achieved.</enum>
+                                <enum value="mitigation">An activity was completed that reduces the likelihood or impact of this risk.</enum>
+                                <enum value="remediated">An activity was completed that eliminates the likelihood or impact of this risk.</enum>
+                                <!-- QUESTION: Is this needed, since this is handled by the status field? -->
+                                <enum value="closed">The risk is no longer applicable to the system.</enum>
+                                <enum value="dr-submission">A deviation request was made to the authorizing official.</enum>
+                                <enum value="dr-updated">A previously submitted deviation request has been modified.</enum>
+                                <enum value="dr-approved">The authorizing official approved the deviation.</enum>
+                                <enum value="dr-rejected">The authorizing official rejected the deviation.</enum>
+                            </allowed-values>
+                        </constraint>
+                    </define-assembly>
+                </model>
+            </define-assembly>
+
+            <define-assembly name="related-observation" max-occurs="unbounded">
+                <formal-name>Related Observation</formal-name>
+                <description>Relates the finding to a set of referenced observations that were used to determine the finding.</description>
+                <group-as name="related-observations" in-json="ARRAY"/>
+                <define-flag name="observation-uuid" as-type="uuid" required="yes">
+                    <formal-name>Observation Universally Unique Identifier Reference</formal-name>
+                    <!-- Identifier Reference -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an observation defined in the list of observations.</description>
+                </define-flag>
+            </define-assembly>
+        </model>
+        <constraint>
+            <allowed-values target="prop/@name">
+                <enum value="false-positive">The risk has been confirmed to be a false positive.</enum>
+                <enum value="accepted">The risk has been accepted. No further action will be taken.</enum>
+                <enum value="risk-adjusted">The risk has been adjusted.</enum>
+                <enum value="priority">A numeric value indicating the sequence in which risks should be addressed. (Lower numbers are higher priority)</enum>
+            </allowed-values>
+            <matches target="prop[@name='priority']/@value" datatype="integer" />
+        </constraint>
+    </define-assembly>
+
+    <define-assembly name="logged-by">
+        <formal-name>Logged By</formal-name>
+        <description>Used to indicate who created a log entry in what role.</description>
+        <define-flag name="party-uuid" as-type="uuid" required="yes">
+            <formal-name>Party UUID Reference</formal-name>
+            <!-- Identifier Reference -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the party who is making the log entry.</description>
+        </define-flag>
+        <define-flag name="role-id" as-type="token">
+            <formal-name>Actor Role</formal-name>
+            <description>A point to the role-id of the role in which the party is making the log entry.</description>
+        </define-flag>
+    </define-assembly>
+
+    <define-field name="risk-status" as-type="token">
+        <formal-name>Risk Status</formal-name>
+        <description>Describes the status of the associated risk.</description>
+        <constraint>
+            <allowed-values target="." allow-other="yes">
+                <enum value="open">The risk has been identified.</enum>
+                <enum value="investigating">The identified risk is being investigated. (Open risk)</enum>
+                <enum value="remediating">Remediation activities are underway, but are not yet complete. (Open risk)</enum>
+                <enum value="deviation-requested">A risk deviation, such as false positive, risk reduction, or operational requirement has been submitted for approval. (Open risk)</enum>
+                <enum value="deviation-approved">A risk deviation, such as false positive, risk reduction, or operational requirement has been approved. (Open risk)</enum>
+                <enum value="closed">The risk has been resolved.</enum>
+            </allowed-values>
+        </constraint>
+    </define-field>
+
+    <define-assembly name="characterization">
+        <formal-name>Characterization</formal-name>
+        <description>A collection of descriptive data about the containing object from a specific origin.</description>
+        <model>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="origin" min-occurs="1">
+                <remarks>
+                    <p>metadata about the specific actor that generated this descriptive data.</p>
+                </remarks>
+            </assembly>
+            <define-assembly name="facet" min-occurs="1" max-occurs="unbounded">
+                <formal-name>Facet</formal-name>
+                <description>An individual characteristic that is part of a larger set produced by the same actor.</description>
+                <group-as name="facets" in-json="ARRAY"/>
+                <define-flag name="name" as-type="token" required="yes">
+                    <formal-name>Facet Name</formal-name>
+                    <description>The name of the risk metric within the specified system.</description>
+                </define-flag>
+                <define-flag name="system" as-type="uri" required="yes">
+                    <formal-name>Naming System</formal-name>
+                    <description>Specifies the naming system under which this risk metric is organized, which allows for the same names to be used in different systems controlled by different parties. This avoids the potential of a name clash.</description>
+                    <constraint>
+                        <allowed-values allow-other="yes"><!-- Other values -->
+                            <enum value="http://fedramp.gov"/>
+                            <enum value="http://csrc.nist.gov/ns/oscal"/>
+                            <enum value="http://csrc.nist.gov/ns/oscal/unknown">The facet is from an unknown taxonomy. The meaning of the name is tool or organization specific.</enum>
+                            <enum value="http://cve.mitre.org"/>
+                            <!-- To identify which CVSS values to use -->
+                            <enum value="http://www.first.org/cvss/v2.0"/>
+                            <enum value="http://www.first.org/cvss/v3.0"/>
+                            <enum value="http://www.first.org/cvss/v3.1"/>
+                        </allowed-values>
+                    </constraint>
+                </define-flag>
+                <define-flag name="value" as-type="string" required="yes">
+                    <formal-name>Facet Value</formal-name>
+                    <description>Indicates the value of the facet.</description>
+                </define-flag>
+                <model>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                    </assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER"/>
+                </model>
+                <constraint>
+                    <allowed-values target="prop/@name">
+                        <enum value="state">Indicates if the facet is 'initial' as first identified, or 'adjusted' indicating that the value has be changed after some adjustments have been made (e.g., to identify residual risk).</enum>
+                    </allowed-values>
+                    <allowed-values target="prop[@name='risk-state']/@value" allow-other="yes"><!-- For values related to initial and residual (mitigated) risk -->
+                        <enum value="initial">As first identified.</enum>
+                        <enum value="adjusted">Indicates that residual risk remains after some adjustments have been made.</enum>
+                    </allowed-values>
+                    <!-- TODO: What about "vulnerability-id", "plugin-id"? Should this be added to FedRAMP? -->
+                    <allowed-values target="(.)[@system='http://csrc.nist.gov/oscal']/@name" allow-other="yes">
+                        <enum value="likelihood">General likelihood rating.</enum>
+                        <enum value="impact">General impact rating.</enum>
+                        <enum value="risk">General risk rating.</enum>
+                        <enum value="severity">General severity rating.</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://fedramp.gov']/@name" allow-other="yes">
+                        <enum value="likelihood">Likelihood as defined by FedRAMP. The <code>class</code> can be used to specify 'initial' and 'adjusted' risk states.</enum>
+                        <enum value="impact">Impact as defined by FedRAMP. The <code>class</code> can be used to specify 'initial' and 'adjusted' risk states.</enum>
+                        <enum value="risk">Risk as calculated according to FedRAMP. The <code>class</code> can be used to specify 'initial' and 'adjusted' risk states.</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://cve.mitre.org']/@name">
+                        <enum value="cve-id">An identifier managed by the CVE program (see <a>https://cve.mitre.org/</a>).</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0']/@name">
+                        <enum value="access-vector" >Base: Access Vector</enum>
+                        <enum value="access-complexity" >Base: Access Complexity</enum>
+                        <enum value="authentication" >Base: Authentication</enum>
+                        <enum value="confidentiality-impact"  >Base: Confidentiality Impact</enum>
+                        <enum value="integrity-impact"  >Base: Integrity Impact</enum>
+                        <enum value="availability-impact"  >Base: Availability Impact</enum>
+                        <enum value="exploitability"  >Temporal: Exploitability</enum>
+                        <enum value="remediation-level" >Temporal: Remediation Level</enum>
+                        <enum value="report-confidence" >Temporal: Report Confidence</enum>
+                        <enum value="collateral-damage-potential">Environmental: Collateral Damage Potential</enum>
+                        <enum value="target-distribution" >Environmental: Target Distribution</enum>
+                        <enum value="confidentiality-requirement" >Environmental: Confidentiality Requirement</enum>
+                        <enum value="integrity-requirement" >Environmental: Integrity Requirement</enum>
+                        <enum value="availability-requirement" >Environmental: Availability Requirement</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='access-vector']/@value">
+                        <enum value="local">Local</enum>
+                        <enum value="adjacent-network">Network Adjacent</enum>
+                        <enum value="network">Network</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='access-complexity']/@value">
+                        <enum value="high">High</enum>
+                        <enum value="medium">Medium</enum>
+                        <enum value="low">Low</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='authentication']/@value">
+                        <enum value="multiple">Multiple</enum>
+                        <enum value="single">Single</enum>
+                        <enum value="none">None</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name=('confidentiality-impact', 'integrity-impact', 'availability-impact')]/@value">
+                        <enum value="none">None</enum>
+                        <enum value="partial">Partial</enum>
+                        <enum value="complete">Complete</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='exploitability']/@value">
+                        <enum value="unproven">Unproven</enum>
+                        <enum value="proof-of-concept">Proof-of-Concept</enum>
+                        <enum value="functional">Functional</enum>
+                        <enum value="high">High</enum>
+                        <enum value="not-defined">Not Defined</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='remediation-level']/@value">
+                        <enum value="official-fix">Official Fix</enum>
+                        <enum value="temporary-fix">Temporary Fix</enum>
+                        <enum value="workaround">Workaround</enum>
+                        <enum value="unavailable">Unavailable</enum>
+                        <enum value="not-defined">Not Defined</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='report-confidence']/@value">
+                        <enum value="unconfirmed">Unconfirmed</enum>
+                        <enum value="uncorroborated">Uncorroborated</enum>
+                        <enum value="confirmed">Confirmed</enum>
+                        <enum value="not-defined">Not Defined</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name='collateral-damage-potential']/@value">
+                        <enum value="none">None</enum>
+                        <enum value="low">Low (light loss)</enum>
+                        <enum value="low-medium">Low Medium</enum>
+                        <enum value="medium-high">Medium High</enum>
+                        <enum value="high">High (catastrophic loss)</enum>
+                        <enum value="not-defined">Not Defined</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system='http://www.first.org/cvss/v2.0' and @name=('target-distribution', 'confidentiality-requirement', 'integrity-requirement', 'availability-requirement')]/@value">
+                        <enum value="none"></enum>
+                        <enum value="low"></enum>
+                        <enum value="medium"></enum>
+                        <enum value="high"></enum>
+                        <enum value="not-defined"></enum>
+                    </allowed-values>
+
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1')]/@name">
+                        <enum value="attack-vector" >Base: Attack Vector</enum>
+                        <enum value="access-complexity" >Base: Attack Complexity</enum>
+                        <enum value="privileges-required" >Base: Privileges Required</enum>
+                        <enum value="user-interaction" >Base: User Interaction</enum>
+                        <enum value="scope"  >Base: Scope</enum>
+                        <enum value="confidentiality-impact"  >Base: Confidentiality Impact</enum>
+                        <enum value="integrity-impact"  >Base: Integrity Impact</enum>
+                        <enum value="availability-impact"  >Base: Availability Impact</enum>
+                        <enum value="exploit-code-maturity"  >Temporal: Exploit Code Maturity</enum>
+                        <enum value="remediation-level" >Temporal: Remediation Level</enum>
+                        <enum value="report-confidence" >Temporal: Report Confidence</enum>
+                        <enum value="modified-attack-vector">Environmental: Modified Attack Vector</enum>
+                        <enum value="modified-attack-complexity">Environmental: Modified Attack Complexity</enum>
+                        <enum value="modified-privileges-required">Environmental: Modified Privileges Required</enum>
+                        <enum value="modified-user-interaction">Environmental: Modified User Interaction</enum>
+                        <enum value="modified-scope" >Environmental: Modified Scope</enum>
+                        <enum value="modified-confidentiality" >Environmental: Modified Confidentiality</enum>
+                        <enum value="modified-integrity" >Environmental: Modified Integrity</enum>
+                        <enum value="modified-availability" >Environmental: Modified Availability</enum>
+                        <enum value="confidentiality-requirement" >Environmental: Confidentiality Requirement Modifier</enum>
+                        <enum value="integrity-requirement" >Environmental: Integrity Requirement Modifier</enum>
+                        <enum value="availability-requirement" >Environmental: Availability Requirement Modifier</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='access-vector']/@value">
+                        <enum value="network">Network</enum>
+                        <enum value="adjacent">Adjacent</enum>
+                        <enum value="local">Local</enum>
+                        <enum value="physical">Physical</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='access-complexity']/@value">
+                        <enum value="high">High</enum>
+                        <enum value="low">Low</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name=('privileges-required', 'confidentiality-impact', 'integrity-impact', 'availability-impact')]/@value">
+                        <enum value="none">None</enum>
+                        <enum value="low">Low</enum>
+                        <enum value="high">High</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='user-interaction']/@value">
+                        <enum value="none">None</enum>
+                        <enum value="required">Required</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='scope']/@value">
+                        <enum value="unchanged">Unchanged</enum>
+                        <enum value="changed">Changed</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='exploit-code-maturity']/@value">
+                        <enum value="not-defined">Not Defined</enum>
+                        <enum value="unproven">Unproven</enum>
+                        <enum value="proof-of-concept">Proof-of-Concept</enum>
+                        <enum value="functional">Functional</enum>
+                        <enum value="high">High</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='remediation-level']/@value">
+                        <enum value="not-defined">Not Defined</enum>
+                        <enum value="official-fix">Official Fix</enum>
+                        <enum value="temporary-fix">Temporary Fix</enum>
+                        <enum value="workaround">Workaround</enum>
+                        <enum value="unavailable">Unavailable</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='report-confidence']/@value">
+                        <enum value="not-defined">Not Defined</enum>
+                        <enum value="unknown">Unknown</enum>
+                        <enum value="reasonable">Reasonable</enum>
+                        <enum value="confirmed">Confirmed</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name=('confidentiality-requirement', 'integrity-requirement', 'availability-requirement')]/@value">
+                        <enum value="not-defined">Not Defined</enum>
+                        <enum value="low">Low</enum>
+                        <enum value="medium">Medium</enum>
+                        <enum value="high">High</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='modified-attack-vector']/@value">
+                        <enum value="not-defined">Not Defined</enum>
+                        <enum value="network">Network</enum>
+                        <enum value="adjacent">Adjacent</enum>
+                        <enum value="local">Local</enum>
+                        <enum value="physical">Physical</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='modified-attack-complexity']/@value">
+                        <enum value="not-defined">Not Defined</enum>
+                        <enum value="high">High</enum>
+                        <enum value="low">Low</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name=('modified-privileges-required', 'modified-confidentiality', 'modified-integrity', 'modified-availability')]/@value">
+                        <enum value="not-defined">Not Defined</enum>
+                        <enum value="none">None</enum>
+                        <enum value="low">Low</enum>
+                        <enum value="high">High</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='modified-user-interaction']/@value">
+                        <enum value="not-defined">Not Defined</enum>
+                        <enum value="none">None</enum>
+                        <enum value="required">Required</enum>
+                    </allowed-values>
+                    <allowed-values target="(.)[@system=('http://www.first.org/cvss/v3.0', 'http://www.first.org/cvss/v3.1') and @name='modified-scope']/@value">
+                        <enum value="not-defined">Not Defined</enum>
+                        <enum value="unchanged">Unchanged</enum>
+                        <enum value="changed">Changed</enum>
+                    </allowed-values>
+                </constraint>
+            </define-assembly>
+        </model>
+    </define-assembly>
+
+    <define-assembly name="response" scope="local">
+        <formal-name>Risk Response</formal-name>
+        <description>Describes either recommended or an actual plan for addressing the risk.</description>
+        <define-flag name="uuid" required="yes" as-type="uuid">
+            <formal-name>Remediation Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this remediation elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>risk response</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <define-flag name="lifecycle" as-type="token" required="yes">
+            <formal-name>Remediation Intent</formal-name>
+            <description>Identifies whether this is a recommendation, such as from an assessor or tool, or an actual plan accepted by the system owner.</description>
+            <constraint>
+                <allowed-values allow-other="yes">
+                    <enum value="recommendation">Recommended Remediation</enum>
+                    <enum value="planned">The actions intended to resolve the risk.</enum>
+                    <enum value="completed">This remediation activities were performed to address the risk.</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+        <model>
+            <define-field name="title" min-occurs="1" max-occurs="1" as-type="markup-line">
+                <formal-name>Response Title</formal-name>
+                <description>The title for this response activity.</description>
+            </define-field>
+            <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                <formal-name>Response Description</formal-name>
+                <description>A human-readable description of this response plan.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="origin" max-occurs="unbounded">
+                <group-as name="origins" in-json="ARRAY"/>
+                <remarks>
+                    <p>Used to identify the individual and/or tool that generated this recommended or planned response.</p>
+                </remarks>
+            </assembly>
+
+            <define-assembly name="required-asset" max-occurs="unbounded">
+                <!-- QUESTION: Do we need to identify a set of remediation assets similar to assessment-assets -->
+                <formal-name>Required Asset</formal-name>
+                <description>Identifies an asset required to achieve remediation.</description>
+                <group-as name="required-assets" in-json="ARRAY"/>
+                <define-flag name="uuid" required="yes" as-type="uuid">
+                    <formal-name>Required Universally Unique Identifier</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this required asset elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>asset</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+                <model>
+                    <assembly ref="subject-reference" min-occurs="0" max-occurs="unbounded">
+                        <use-name>subject</use-name>
+                        <group-as name="subjects" in-json="ARRAY"/>
+                        <remarks>
+                            <p>Identifies an asset associated with this requirement, such as a party, system component, or inventory-item.</p>
+                        </remarks>
+                    </assembly>
+                    <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
+                        <formal-name>Title for Required Asset</formal-name>
+                        <description>The title for this required asset.</description>
+                    </define-field>
+                    <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                        <formal-name>Description of Required Asset</formal-name>
+                        <description>A human-readable description of this required asset.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                    </assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                </model>
+            </define-assembly>
+            <assembly ref="task" min-occurs="0" max-occurs="unbounded">
+                <group-as name="tasks" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+        <constraint>
+            <allowed-values target="prop/@name" allow-other="yes">
+                <enum value="type"></enum>
+            </allowed-values>
+            <allowed-values target="prop[@name='type']/@value" allow-other="yes">
+                <enum value="avoid">The risk will be eliminated.</enum>
+                <enum value="mitigate">The risk will be reduced.</enum>
+                <enum value="transfer">The risk will be transferred to another organization or entity.</enum>
+                <enum value="accept">The risk will continue to exist without further efforts to address it. (Sometimes referred to as "Operationally required")</enum>
+                <enum value="share">The risk will be partially transferred to another organization or entity.</enum>
+                <enum value="contingency">Plans will be made to address the risk impact if the risk occurs. (This is a form of mitigation.)</enum>
+                <enum value="none">No response, such as when the identified risk is found to be a false positive.</enum>
+            </allowed-values>
+        </constraint>
+    </define-assembly>
+
+    <define-flag name="objective-id" as-type="token" scope="local">
+        <!-- This is an id to sync with control syntax -->
+        <formal-name>Objective ID</formal-name>
+        <description>Points to an assessment objective.</description>
+    </define-flag>
+
+    <define-assembly name="assessment-part"> <!--scope="local"-->
+        <!-- QUESTION: Is it confusing to use part here, given the control meaning of part? -->
+        <formal-name>Assessment Part</formal-name>
+        <description>A partition of an assessment plan or results or a child of another part.</description>
+        <use-name>part</use-name>
+        <define-flag name="uuid" as-type="uuid">
+            <!-- CHANGE: from uuiid to uuid -->
+            <formal-name>Part Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this part elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>part</code> can be used to reference the data item locally or globally (e.g., in an ported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <define-flag name="name" as-type="token" required="yes">
+            <formal-name>Part Name</formal-name>
+            <description>A textual label that uniquely identifies the part's semantic type.</description>
+            <constraint>
+                <allowed-values allow-other="yes">
+                    <!-- QUESTION: Should this be in sync with control part? Should these be defined here or should they be defined in the context of use? -->
+                    <enum value="asset">An assessment asset.</enum>
+                    <enum value="method">An assessment method.</enum>
+                    <enum value="objective">Describes a set of control objectives.</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+        <define-flag name="ns" as-type="uri">
+            <!-- CHANGED: data type to uri -->
+            <formal-name>Part Namespace</formal-name>
+            <description>A namespace qualifying the part's name. This allows different organizations to associate distinct semantics with the same name.</description>
+            <remarks>
+                <p>Provides a means to segment the value space for the <code>name</code>, so that different organizations and individuals can assert control over the allowed names and associated text used in a part. This allows the semantics associated with a given name to be defined on an organization-by-organization basis.</p>
+                <p>An organization MUST use a URI that they have control over. e.g., a domain registered to the organization in a URI, a registered uniform resource names (URN) namespace.</p>
+                <p>When a <code>ns</code> is not provided, its value should be assumed to be <code>http://csrc.nist.gov/ns/oscal</code> and the name should be a name defined by the associated OSCAL model.</p>
+            </remarks>
+        </define-flag>
+        <define-flag name="class" as-type="token">
+            <formal-name>Part Class</formal-name>
+            <description>A textual label that provides a sub-type or characterization of the part's <code>name</code>. This can be used to further distinguish or discriminate between the semantics of multiple parts of the same control with the same <code>name</code> and <code>ns</code>.</description>
+            <remarks>
+                <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
+                <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
+            </remarks>
+        </define-flag>
+        <model>
+            <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line" >
+                <formal-name>Part Title</formal-name>
+                <description>A name given to the part, which may be used by a tool for display and navigation.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <define-field name="prose" as-type="markup-multiline" in-xml="UNWRAPPED" min-occurs="0">
+                <!-- QUESTION: Is this the right name? -->
+                <formal-name>Part Text</formal-name>
+                <description>Permits multiple paragraphs, lists, tables etc.</description>
+            </define-field>
+            <assembly ref="assessment-part" max-occurs="unbounded">
+                <group-as name="parts" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <!-- <any/> -->
+        </model>
+        <constraint>
+            <allowed-values target=".[@name='objective']/prop/@name" allow-other="yes">
+                <enum value="method">The assessment method to use. This typically appears on parts with the name "objective".</enum>
+            </allowed-values>
+            <has-cardinality target=".[@name='objective']/prop[@name='method']" min-occurs="1"/>
+            <allowed-values target=".[@name='objective']/prop[@name='method']/@value">
+                <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
+                <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
+                <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
+            </allowed-values>
+        </constraint>
+        <remarks>
+            <p>A <code>part</code> provides for logical partitioning of prose, and can be thought of as a grouping structure (e.g., section). A <code>part</code> can have child parts allowing for arbitrary nesting of prose content (e.g., statement hierarchy). A <code>part</code> can contain <code>prop</code> objects that allow for enriching prose text with structured name/value information.</p>
+            <p>A <code>part</code> can be assigned an optional <code>id</code>, which allows for internal and external references to the textual concept contained within a <code>part</code>. A <code>id</code> provides a means for an OSCAL profile, or a higher layer OSCAL model to reference a specific part within a <code>catalog</code>. For example, an <code>id</code> can be used to reference or to make modifications to a control statement in a profile.</p>
+            <p>Use of <code>part</code> and <code>prop</code> provides for a wide degree of extensibility within the OSCAL catalog model. The optional <code>ns</code> provides a means to qualify a part's <code>name</code>, allowing for organization-specific vocabularies to be defined with clear semantics. Any organization that extends OSCAL in this way should consistently assign a <code>ns</code> value that represents the organization, making a given namespace qualified <code>name</code> unique to that organization. This allows the combination of <code>ns</code> and <code>name</code> to always be unique and unambiguous, even when mixed with extensions from other organizations. Each organization is responsible for governance of their own extensions, and is strongly encouraged to publish their extensions as standards to their user community. If no <code>ns</code> is provided, the name is expected to be in the "OSCAL" namespace.</p>
+            <p>To ensure a <code>ns</code> is unique to an organization and naming conflicts are avoided, a URI containing a DNS or other globally defined organization name should be used. For example, if FedRAMP and DoD both extend OSCAL, FedRAMP will use the <code>ns</code> "https://fedramp.gov", while DoD will use the <code>ns</code> "https://defense.gov" for any organization specific <code>name</code>.</p>
+            <p>Tools that process OSCAL content are not required to interpret unrecognized OSCAL extensions; however, OSCAL compliant tools should not modify or remove unrecognized extensions, unless there is a compelling reason to do so, such as data sensitivity.</p>
+        </remarks>
+    </define-assembly>
 
 </METASCHEMA>

--- a/src/metaschema/oscal_assessment-results_metaschema.xml
+++ b/src/metaschema/oscal_assessment-results_metaschema.xml
@@ -1,346 +1,346 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../build/metaschema/toolchains/xslt-M4/validate/metaschema-composition-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
-  <schema-name>OSCAL Assessment Results Model</schema-name>
-  <schema-version>1.0.1</schema-version>
-  <short-name>oscal-ar</short-name>
-  <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
-  <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
-  <remarks>
-    <p>The OSCAL assessment results format is used to describe the information typically provided by an assessor following an assessment.</p>
-    <p>The root of the OSCAL assessment results format is <code>assessment-results</code>.
-    </p>
-  </remarks>
-  <!-- IMPORT STATEMENTS -->
-  <import href="oscal_metadata_metaschema.xml"/>
-  <import href="oscal_assessment-common_metaschema.xml"/>
-  <!-- TOP LEVEL ASSEMBLY -->
-  <define-assembly name="assessment-results">
-    <formal-name>Security Assessment Results (SAR)</formal-name>
-    <description>Security assessment results, such as those provided by a FedRAMP assessor in the FedRAMP Security Assessment Report.</description>
-    <root-name>assessment-results</root-name>
-    <define-flag name="uuid" required="yes" as-type="uuid">
-      <formal-name>Assessment Results Universally Unique Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this assessment results instance in <a href="/concepts/identifier-use/#ar-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>assessment result</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <model>
-      <assembly ref="metadata" min-occurs="1" max-occurs="1"/>
-      <assembly ref="import-ap" min-occurs="1" max-occurs="1">
-        <remarks>
-          <p>Used by the SAR to import information about the original plan for assessing the system.</p>
-        </remarks>
-      </assembly>
-      <define-assembly name="local-definitions">
-        <!-- CHANGE: added "local-definitions" -->
-        <formal-name>Local Definitions</formal-name>
-        <description>Used to define data objects that are used in the assessment plan, that do not appear in the referenced SSP.</description>
+    xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
+    <schema-name>OSCAL Assessment Results Model</schema-name>
+    <schema-version>1.0.1</schema-version>
+    <short-name>oscal-ar</short-name>
+    <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
+    <remarks>
+        <p>The OSCAL assessment results format is used to describe the information typically provided by an assessor following an assessment.</p>
+        <p>The root of the OSCAL assessment results format is <code>assessment-results</code>.
+        </p>
+    </remarks>
+    <!-- IMPORT STATEMENTS -->
+    <import href="oscal_metadata_metaschema.xml"/>
+    <import href="oscal_assessment-common_metaschema.xml"/>
+    <!-- TOP LEVEL ASSEMBLY -->
+    <define-assembly name="assessment-results">
+        <formal-name>Security Assessment Results (SAR)</formal-name>
+        <description>Security assessment results, such as those provided by a FedRAMP assessor in the FedRAMP Security Assessment Report.</description>
+        <root-name>assessment-results</root-name>
+        <define-flag name="uuid" required="yes" as-type="uuid">
+            <formal-name>Assessment Results Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this assessment results instance in <a href="/concepts/identifier-use/#ar-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>assessment result</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
         <model>
-          <assembly ref="local-objective" min-occurs="0" max-occurs="unbounded">
-            <use-name>objectives-and-methods</use-name>
-            <group-as name="objectives-and-methods" in-json="ARRAY"/>
-          </assembly>
+            <assembly ref="metadata" min-occurs="1" max-occurs="1"/>
+            <assembly ref="import-ap" min-occurs="1" max-occurs="1">
+                <remarks>
+                    <p>Used by the SAR to import information about the original plan for assessing the system.</p>
+                </remarks>
+            </assembly>
+            <define-assembly name="local-definitions">
+                <!-- CHANGE: added "local-definitions" -->
+                <formal-name>Local Definitions</formal-name>
+                <description>Used to define data objects that are used in the assessment plan, that do not appear in the referenced SSP.</description>
+                <model>
+                    <assembly ref="local-objective" min-occurs="0" max-occurs="unbounded">
+                        <use-name>objectives-and-methods</use-name>
+                        <group-as name="objectives-and-methods" in-json="ARRAY"/>
+                    </assembly>
 
-          <!-- CHANGED: implemented new model -->
-          <assembly ref="activity" min-occurs="0" max-occurs="unbounded">
-            <use-name>activity</use-name>
-            <group-as name="activities" in-json="ARRAY"/>
-          </assembly>
-          <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                    <!-- CHANGED: implemented new model -->
+                    <assembly ref="activity" min-occurs="0" max-occurs="unbounded">
+                        <use-name>activity</use-name>
+                        <group-as name="activities" in-json="ARRAY"/>
+                    </assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                </model>
+            </define-assembly>
+            <assembly ref="result" min-occurs="1" max-occurs="unbounded">
+                <!-- CHANGED: "results" to "result" -->
+                <use-name>result</use-name>
+                <!-- CHANGED: "results_group" to "results" -->
+                <group-as name="results" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="back-matter" min-occurs="0" max-occurs="1"/>
         </model>
-      </define-assembly>
-      <assembly ref="result" min-occurs="1" max-occurs="unbounded">
-        <!-- CHANGED: "results" to "result" -->
-        <use-name>result</use-name>
-        <!-- CHANGED: "results_group" to "results" -->
-        <group-as name="results" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="back-matter" min-occurs="0" max-occurs="1"/>
-    </model>
-  </define-assembly>
+    </define-assembly>
 
-  <!-- ===============================  -->
-  <!-- ========= NEW CONTENT =========  -->
-  <!-- ===============================  -->
+    <!-- ===============================    -->
+    <!-- ========= NEW CONTENT =========    -->
+    <!-- ===============================    -->
 
 
-  <!-- ===============================  -->
-  <!-- ======= END NEW CONTENT =======  -->
-  <!-- ===============================  -->
+    <!-- ===============================    -->
+    <!-- ======= END NEW CONTENT =======    -->
+    <!-- ===============================    -->
 
-  <!-- ********** RESULTS Assembly ********** -->
-  <define-assembly name="result">
-    <formal-name>Assessment Result</formal-name>
-    <description>Used by the assessment results and POA&amp;M. In the assessment results, this identifies all of the assessment observations and findings, initial and residual risks, deviations, and disposition. In the POA&amp;M, this identifies initial and residual risks, deviations, and disposition.</description>
-    <define-flag name="uuid" required="yes" as-type="uuid">
-      <formal-name>Results Universally Unique Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this set of results in <a href="/concepts/identifier-use/#ar-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>assessment result</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <model>
-      <define-field name="title" min-occurs="1" max-occurs="1" as-type="markup-line">
-        <formal-name>Results Title</formal-name>
-        <description>The title for this set of results.</description>
-      </define-field>
-      <!-- CHANGE: Added WITH_WRAPPER to description -->
-      <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-        <formal-name>Results Description</formal-name>
-        <description>A human-readable description of this set of test results.</description>
-      </define-field>
-
-      <define-field name="start" as-type="dateTime-with-timezone" min-occurs="1" max-occurs="1">
-        <formal-name>start field</formal-name>
-        <description>Date/time stamp identifying the start of the evidence collection reflected in these results.</description>
-      </define-field>
-      <define-field name="end" as-type="dateTime-with-timezone" max-occurs="1">
-        <formal-name>end field</formal-name>
-        <description>Date/time stamp identifying the end of the evidence collection reflected in these results. In a continuous motoring scenario, this may contain the same value as start if appropriate.</description>
-      </define-field>
-
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <define-assembly name="local-definitions">
-        <!-- CHANGE: added "local-definitions" -->
-        <formal-name>Local Definitions</formal-name>
-        <description>Used to define data objects that are used in the assessment plan, that do not appear in the referenced SSP.</description>
+    <!-- ********** RESULTS Assembly ********** -->
+    <define-assembly name="result">
+        <formal-name>Assessment Result</formal-name>
+        <description>Used by the assessment results and POA&amp;M. In the assessment results, this identifies all of the assessment observations and findings, initial and residual risks, deviations, and disposition. In the POA&amp;M, this identifies initial and residual risks, deviations, and disposition.</description>
+        <define-flag name="uuid" required="yes" as-type="uuid">
+            <formal-name>Results Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this set of results in <a href="/concepts/identifier-use/#ar-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>assessment result</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
         <model>
-          <assembly ref="system-component" min-occurs="0" max-occurs="unbounded">
-            <use-name>component</use-name>
-            <group-as name="components" in-json="ARRAY"/>
-            <remarks>
-              <p>Used to add any components, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
-            </remarks>
-          </assembly>
-          <assembly ref="inventory-item" min-occurs="0" max-occurs="unbounded">
-            <group-as name="inventory-items" in-json="ARRAY"/>
-            <remarks>
-              <p>Used to add any inventory-items, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
-            </remarks>
-          </assembly>
-          <assembly ref="system-user" min-occurs="0" max-occurs="unbounded">
-            <use-name>user</use-name>
-            <group-as name="users" in-json="ARRAY"/>
-            <remarks>
-              <p>Used to add any users, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
-            </remarks>
-          </assembly>
+            <define-field name="title" min-occurs="1" max-occurs="1" as-type="markup-line">
+                <formal-name>Results Title</formal-name>
+                <description>The title for this set of results.</description>
+            </define-field>
+            <!-- CHANGE: Added WITH_WRAPPER to description -->
+            <define-field name="description" min-occurs="1" max-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                <formal-name>Results Description</formal-name>
+                <description>A human-readable description of this set of test results.</description>
+            </define-field>
 
-          <assembly ref="assessment-assets" min-occurs="0" max-occurs="1">
-            <!-- To augment the assessment plan -->
-            <remarks>
-              <p>This needs to be defined in the results if an assessment platform used is different from the one described in the assessment plan. Else the platform(s) defined in the plan may be referenced within the results.</p>
-            </remarks>
-          </assembly>
+            <define-field name="start" as-type="dateTime-with-timezone" min-occurs="1" max-occurs="1">
+                <formal-name>start field</formal-name>
+                <description>Date/time stamp identifying the start of the evidence collection reflected in these results.</description>
+            </define-field>
+            <define-field name="end" as-type="dateTime-with-timezone" max-occurs="1">
+                <formal-name>end field</formal-name>
+                <description>Date/time stamp identifying the end of the evidence collection reflected in these results. In a continuous motoring scenario, this may contain the same value as start if appropriate.</description>
+            </define-field>
 
-          <assembly ref="task" min-occurs="0" max-occurs="unbounded">
-            <use-name>assessment-task</use-name>
-            <group-as name="tasks" in-json="ARRAY"/>
-          </assembly>
-        </model>
-        <constraint>
-          <is-unique id="unique-ar-local-definitions-component" target="component">
-            <key-field target="@uuid"/>
-            <remarks>
-              <p>Since multiple <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
-            </remarks>
-          </is-unique>
-          <is-unique id="unique-ar-local-definitions-user" target="user">
-            <key-field target="@uuid"/>
-            <remarks>
-              <p>A given <code>uuid</code> must be assigned only once to a user.</p>
-            </remarks>
-          </is-unique>
-        </constraint>
-      </define-assembly>
-      <!-- CHANGED: "objectives" to "reviewed-controls" -->
-      <assembly ref="reviewed-controls" min-occurs="1" max-occurs="1">
-        <remarks>
-          <p>The Assessment Results <code>control-selection</code> ignores any control selection in the Assessment Plan and re-selects controls from the baseline identified by the SSP.</p>
-          <p>The Assessment Results <code>control-objective-selection</code> ignores any control objective selection in the Assessment Plan and re-selects control objectives from the baseline identified by the SSP.</p>
-          <p>Any additional control objectives defined in the Assessment Plan <code>local-definitions</code> do not need to be re-defined in the Assessment Results <code>local-definitions</code>; however, if they were explicitly referenced with an Assessment Plan <code>control-objective-selection</code>, they need to be selected again in the Assessment Results <code>control-objective-selection</code>.</p>
-        </remarks>
-      </assembly>
-
-      <define-assembly name="attestation" max-occurs="unbounded">
-        <formal-name>Attestation Statements</formal-name>
-        <description>A set of textual statements, typically written by the assessor.</description>
-        <group-as name="attestations" in-json="ARRAY"/>
-        <model>
-          <assembly ref="responsible-party" max-occurs="unbounded">
-            <group-as name="responsible-parties" in-json="ARRAY"/>
-          </assembly>
-          <assembly ref="assessment-part" min-occurs="1" max-occurs="unbounded">
-            <!-- TODO: defined allowed parts: authorization-statement -->
-            <use-name>part</use-name>
-            <group-as name="parts" in-json="ARRAY"/>
-          </assembly>
-        </model>
-        <constraint>
-          <is-unique id="unique-ar-attestation-responsible-party" target="responsible-party">
-            <key-field target="@role-id"/>
-            <remarks>
-              <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-            </remarks>
-          </is-unique>
-        </constraint>
-      </define-assembly>
-      <!-- CHANGED: removed "schedule" and replaced with "assessment-log" -->
-      <define-assembly name="assessment-log">
-        <formal-name>Assessment Log</formal-name>
-        <description>A log of all assessment-related actions taken.</description>
-        <model>
-          <define-assembly name="entry" min-occurs="1" max-occurs="unbounded">
-            <formal-name>Assessment Log Entry</formal-name>
-            <!-- TODO: improve this description -->
-            <description>Identifies the result of an action and/or task that occurred as part of executing an assessment plan or an assessment event that occurred in producing the assessment results.</description>
-            <group-as name="entries" in-json="ARRAY"/>
-            <define-flag name="uuid" required="yes" as-type="uuid">
-              <formal-name>Assessment Log Entry Universally Unique Identifier</formal-name>
-              <!-- Identifier Declaration -->
-              <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference an assessment event in <a href="/concepts/identifier-use/#ar-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>assessment log entry</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <model>
-              <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
-                <formal-name>Action Title</formal-name>
-                <description>The title for this event.</description>
-              </define-field>
-              <!-- CHANGE: Added WITH_WRAPPER to description -->
-              <define-field name="description" min-occurs="0" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-                <formal-name>Action Description</formal-name>
-                <description>A human-readable description of this event.</description>
-              </define-field>
-              <define-field name="start" as-type="dateTime-with-timezone" min-occurs="1" max-occurs="1">
-                <formal-name>Start</formal-name>
-                <description>Identifies the start date and time of an event.</description>
-              </define-field>
-              <define-field name="end" as-type="dateTime-with-timezone" max-occurs="1">
-                <formal-name>End</formal-name>
-                <description>Identifies the end date and time of an event. If the event is a point in time, the start and end will be the same date and time.</description>
-              </define-field>
-              <assembly ref="property" max-occurs="unbounded">
+            <assembly ref="property" max-occurs="unbounded">
                 <group-as name="props" in-json="ARRAY"/>
-              </assembly>
-              <assembly ref="link" max-occurs="unbounded">
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
                 <group-as name="links" in-json="ARRAY"/>
-              </assembly>
-              <assembly ref="logged-by" max-occurs="unbounded">
-                <group-as name="logged-by" in-json="ARRAY"/>
-              </assembly>
-              <!-- CHANGED: Added "related-task" -->
-              <assembly ref="related-task" max-occurs="unbounded">
-                <group-as name="related-tasks" in-json="ARRAY"/>
-              </assembly>
-              <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-            </model>
-          </define-assembly>
+            </assembly>
+            <define-assembly name="local-definitions">
+                <!-- CHANGE: added "local-definitions" -->
+                <formal-name>Local Definitions</formal-name>
+                <description>Used to define data objects that are used in the assessment plan, that do not appear in the referenced SSP.</description>
+                <model>
+                    <assembly ref="system-component" min-occurs="0" max-occurs="unbounded">
+                        <use-name>component</use-name>
+                        <group-as name="components" in-json="ARRAY"/>
+                        <remarks>
+                            <p>Used to add any components, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
+                        </remarks>
+                    </assembly>
+                    <assembly ref="inventory-item" min-occurs="0" max-occurs="unbounded">
+                        <group-as name="inventory-items" in-json="ARRAY"/>
+                        <remarks>
+                            <p>Used to add any inventory-items, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
+                        </remarks>
+                    </assembly>
+                    <assembly ref="system-user" min-occurs="0" max-occurs="unbounded">
+                        <use-name>user</use-name>
+                        <group-as name="users" in-json="ARRAY"/>
+                        <remarks>
+                            <p>Used to add any users, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
+                        </remarks>
+                    </assembly>
+
+                    <assembly ref="assessment-assets" min-occurs="0" max-occurs="1">
+                        <!-- To augment the assessment plan -->
+                        <remarks>
+                            <p>This needs to be defined in the results if an assessment platform used is different from the one described in the assessment plan. Else the platform(s) defined in the plan may be referenced within the results.</p>
+                        </remarks>
+                    </assembly>
+
+                    <assembly ref="task" min-occurs="0" max-occurs="unbounded">
+                        <use-name>assessment-task</use-name>
+                        <group-as name="tasks" in-json="ARRAY"/>
+                    </assembly>
+                </model>
+                <constraint>
+                    <is-unique id="unique-ar-local-definitions-component" target="component">
+                        <key-field target="@uuid"/>
+                        <remarks>
+                            <p>Since multiple <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
+                        </remarks>
+                    </is-unique>
+                    <is-unique id="unique-ar-local-definitions-user" target="user">
+                        <key-field target="@uuid"/>
+                        <remarks>
+                            <p>A given <code>uuid</code> must be assigned only once to a user.</p>
+                        </remarks>
+                    </is-unique>
+                </constraint>
+            </define-assembly>
+            <!-- CHANGED: "objectives" to "reviewed-controls" -->
+            <assembly ref="reviewed-controls" min-occurs="1" max-occurs="1">
+                <remarks>
+                    <p>The Assessment Results <code>control-selection</code> ignores any control selection in the Assessment Plan and re-selects controls from the baseline identified by the SSP.</p>
+                    <p>The Assessment Results <code>control-objective-selection</code> ignores any control objective selection in the Assessment Plan and re-selects control objectives from the baseline identified by the SSP.</p>
+                    <p>Any additional control objectives defined in the Assessment Plan <code>local-definitions</code> do not need to be re-defined in the Assessment Results <code>local-definitions</code>; however, if they were explicitly referenced with an Assessment Plan <code>control-objective-selection</code>, they need to be selected again in the Assessment Results <code>control-objective-selection</code>.</p>
+                </remarks>
+            </assembly>
+
+            <define-assembly name="attestation" max-occurs="unbounded">
+                <formal-name>Attestation Statements</formal-name>
+                <description>A set of textual statements, typically written by the assessor.</description>
+                <group-as name="attestations" in-json="ARRAY"/>
+                <model>
+                    <assembly ref="responsible-party" max-occurs="unbounded">
+                        <group-as name="responsible-parties" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="assessment-part" min-occurs="1" max-occurs="unbounded">
+                        <!-- TODO: defined allowed parts: authorization-statement -->
+                        <use-name>part</use-name>
+                        <group-as name="parts" in-json="ARRAY"/>
+                    </assembly>
+                </model>
+                <constraint>
+                    <is-unique id="unique-ar-attestation-responsible-party" target="responsible-party">
+                        <key-field target="@role-id"/>
+                        <remarks>
+                            <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                        </remarks>
+                    </is-unique>
+                </constraint>
+            </define-assembly>
+            <!-- CHANGED: removed "schedule" and replaced with "assessment-log" -->
+            <define-assembly name="assessment-log">
+                <formal-name>Assessment Log</formal-name>
+                <description>A log of all assessment-related actions taken.</description>
+                <model>
+                    <define-assembly name="entry" min-occurs="1" max-occurs="unbounded">
+                        <formal-name>Assessment Log Entry</formal-name>
+                        <!-- TODO: improve this description -->
+                        <description>Identifies the result of an action and/or task that occurred as part of executing an assessment plan or an assessment event that occurred in producing the assessment results.</description>
+                        <group-as name="entries" in-json="ARRAY"/>
+                        <define-flag name="uuid" required="yes" as-type="uuid">
+                            <formal-name>Assessment Log Entry Universally Unique Identifier</formal-name>
+                            <!-- Identifier Declaration -->
+                            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference an assessment event in <a href="/concepts/identifier-use/#ar-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>assessment log entry</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                        </define-flag>
+                        <model>
+                            <define-field name="title" min-occurs="0" max-occurs="1" as-type="markup-line">
+                                <formal-name>Action Title</formal-name>
+                                <description>The title for this event.</description>
+                            </define-field>
+                            <!-- CHANGE: Added WITH_WRAPPER to description -->
+                            <define-field name="description" min-occurs="0" max-occurs="1" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                                <formal-name>Action Description</formal-name>
+                                <description>A human-readable description of this event.</description>
+                            </define-field>
+                            <define-field name="start" as-type="dateTime-with-timezone" min-occurs="1" max-occurs="1">
+                                <formal-name>Start</formal-name>
+                                <description>Identifies the start date and time of an event.</description>
+                            </define-field>
+                            <define-field name="end" as-type="dateTime-with-timezone" max-occurs="1">
+                                <formal-name>End</formal-name>
+                                <description>Identifies the end date and time of an event. If the event is a point in time, the start and end will be the same date and time.</description>
+                            </define-field>
+                            <assembly ref="property" max-occurs="unbounded">
+                                <group-as name="props" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="link" max-occurs="unbounded">
+                                <group-as name="links" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="logged-by" max-occurs="unbounded">
+                                <group-as name="logged-by" in-json="ARRAY"/>
+                            </assembly>
+                            <!-- CHANGED: Added "related-task" -->
+                            <assembly ref="related-task" max-occurs="unbounded">
+                                <group-as name="related-tasks" in-json="ARRAY"/>
+                            </assembly>
+                            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+                        </model>
+                    </define-assembly>
+                </model>
+            </define-assembly>
+
+            <!-- CHANGE: move "observation" from finding -->
+            <assembly ref="observation" min-occurs="0" max-occurs="unbounded">
+                <group-as name="observations" in-json="ARRAY"/>
+            </assembly>
+
+            <!-- CHANGE: move "risk" from finding -->
+            <assembly ref="risk" max-occurs="unbounded">
+                <group-as name="risks" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="finding" max-occurs="unbounded">
+                <group-as name="findings" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
         </model>
-      </define-assembly>
+    </define-assembly>
 
-      <!-- CHANGE: move "observation" from finding -->
-      <assembly ref="observation" min-occurs="0" max-occurs="unbounded">
-        <group-as name="observations" in-json="ARRAY"/>
-      </assembly>
-
-      <!-- CHANGE: move "risk" from finding -->
-      <assembly ref="risk" max-occurs="unbounded">
-        <group-as name="risks" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="finding" max-occurs="unbounded">
-        <group-as name="findings" in-json="ARRAY"/>
-      </assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-    </model>
-  </define-assembly>
-
-  <define-assembly name="finding">
-    <formal-name>Finding</formal-name>
-    <description>Describes an individual finding.</description>
-    <define-flag name="uuid" required="yes" as-type="uuid">
-      <formal-name>Finding Universally Unique Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this finding in <a href="/concepts/identifier-use/#ar-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>finding</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <model>
-      <define-field name="title" min-occurs="1" as-type="markup-line">
-        <formal-name>Finding Title</formal-name>
-        <description>The title for this finding.</description>
-      </define-field>
-      <!-- CHANGE: Added WITH_WRAPPER to description -->
-      <define-field name="description" min-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
-        <formal-name>Finding Description</formal-name>
-        <description>A human-readable description of this finding.</description>
-      </define-field>
-
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-
-      <assembly ref="origin" max-occurs="unbounded">
-        <group-as name="origins" in-json="ARRAY"/>
-        <remarks>
-          <p>Used to identify the individual and/or tool generated this finding.</p>
-        </remarks>
-      </assembly>
-      <assembly ref="finding-target" min-occurs="1">
-        <use-name>target</use-name>
-      </assembly>
-      <define-field name="implementation-statement-uuid" as-type="uuid" min-occurs="0" max-occurs="1">
-        <formal-name>Implementation Statement UUID</formal-name>
-        <!-- Identifier Reference -->
-        <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the implementation statement in the SSP to which this finding is related.</description>
-      </define-field>
-      <!-- CHANGED: replaced embedded observation with references -->
-      <define-assembly name="related-observation" max-occurs="unbounded">
-        <formal-name>Related Observation</formal-name>
-        <description>Relates the finding to a set of referenced observations that were used to determine the finding.</description>
-        <group-as name="related-observations" in-json="ARRAY"/>
-        <define-flag name="observation-uuid" as-type="uuid" required="yes">
-          <formal-name>Observation Universally Unique Identifier Reference</formal-name>
-          <!-- Identifier Reference -->
-          <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an observation defined in the list of observations.</description>
+    <define-assembly name="finding">
+        <formal-name>Finding</formal-name>
+        <description>Describes an individual finding.</description>
+        <define-flag name="uuid" required="yes" as-type="uuid">
+            <formal-name>Finding Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this finding in <a href="/concepts/identifier-use/#ar-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>finding</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
         </define-flag>
-      </define-assembly>
-      <!-- CHANGED: replaced "risk" with new "assciated-risk" -->
-      <define-assembly name="associated-risk" max-occurs="unbounded">
-        <formal-name>Associated Risk</formal-name>
-        <description>Relates the finding to a set of referenced risks that were used to determine the finding.</description>
-        <group-as name="related-risks" in-json="ARRAY"/>
-        <define-flag name="risk-uuid" as-type="uuid" required="yes">
-          <formal-name>Risk Universally Unique Identifier Reference</formal-name>
-          <!-- Identifier Reference -->
-          <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a risk defined in the list of risks.</description>
-        </define-flag>
-      </define-assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-    </model>
-  </define-assembly>
+        <model>
+            <define-field name="title" min-occurs="1" as-type="markup-line">
+                <formal-name>Finding Title</formal-name>
+                <description>The title for this finding.</description>
+            </define-field>
+            <!-- CHANGE: Added WITH_WRAPPER to description -->
+            <define-field name="description" min-occurs="1" in-xml="WITH_WRAPPER" as-type="markup-multiline">
+                <formal-name>Finding Description</formal-name>
+                <description>A human-readable description of this finding.</description>
+            </define-field>
 
-  <!-- Assessment Plan Import -->
-  <define-assembly name="import-ap">
-    <formal-name>Import Assessment Plan</formal-name>
-    <description>Used by assessment-results to import information about the original plan for assessing the system.</description>
-    <define-flag name="href" required="yes" as-type="uri-reference">
-      <formal-name>Assessment Plan Reference</formal-name>
-      <description>A resolvable URL reference to the assessment plan governing the assessment activities.</description>
-      <remarks>
-        <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code>
-          <code>resource</code> in the same document.</p>
-        <!-- TODO: Add a link to "within the scope of the containing OSCAL document" to point to documentation of identification scopes" -->
-        <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is within the scope of the containing OSCAL document.</p>
-        <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URI pointing to the location of the referenced resource. A relative URI will be resolved relative to the location of the document containing the link.</p>
-      </remarks>
-    </define-flag>
-    <model>
-      <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-    </model>
-  </define-assembly>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+
+            <assembly ref="origin" max-occurs="unbounded">
+                <group-as name="origins" in-json="ARRAY"/>
+                <remarks>
+                    <p>Used to identify the individual and/or tool generated this finding.</p>
+                </remarks>
+            </assembly>
+            <assembly ref="finding-target" min-occurs="1">
+                <use-name>target</use-name>
+            </assembly>
+            <define-field name="implementation-statement-uuid" as-type="uuid" min-occurs="0" max-occurs="1">
+                <formal-name>Implementation Statement UUID</formal-name>
+                <!-- Identifier Reference -->
+                <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the implementation statement in the SSP to which this finding is related.</description>
+            </define-field>
+            <!-- CHANGED: replaced embedded observation with references -->
+            <define-assembly name="related-observation" max-occurs="unbounded">
+                <formal-name>Related Observation</formal-name>
+                <description>Relates the finding to a set of referenced observations that were used to determine the finding.</description>
+                <group-as name="related-observations" in-json="ARRAY"/>
+                <define-flag name="observation-uuid" as-type="uuid" required="yes">
+                    <formal-name>Observation Universally Unique Identifier Reference</formal-name>
+                    <!-- Identifier Reference -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an observation defined in the list of observations.</description>
+                </define-flag>
+            </define-assembly>
+            <!-- CHANGED: replaced "risk" with new "assciated-risk" -->
+            <define-assembly name="associated-risk" max-occurs="unbounded">
+                <formal-name>Associated Risk</formal-name>
+                <description>Relates the finding to a set of referenced risks that were used to determine the finding.</description>
+                <group-as name="related-risks" in-json="ARRAY"/>
+                <define-flag name="risk-uuid" as-type="uuid" required="yes">
+                    <formal-name>Risk Universally Unique Identifier Reference</formal-name>
+                    <!-- Identifier Reference -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a risk defined in the list of risks.</description>
+                </define-flag>
+            </define-assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+    </define-assembly>
+
+    <!-- Assessment Plan Import -->
+    <define-assembly name="import-ap">
+        <formal-name>Import Assessment Plan</formal-name>
+        <description>Used by assessment-results to import information about the original plan for assessing the system.</description>
+        <define-flag name="href" required="yes" as-type="uri-reference">
+            <formal-name>Assessment Plan Reference</formal-name>
+            <description>A resolvable URL reference to the assessment plan governing the assessment activities.</description>
+            <remarks>
+                <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code>
+                    <code>resource</code> in the same document.</p>
+                <!-- TODO: Add a link to "within the scope of the containing OSCAL document" to point to documentation of identification scopes" -->
+                <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is within the scope of the containing OSCAL document.</p>
+                <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URI pointing to the location of the referenced resource. A relative URI will be resolved relative to the location of the document containing the link.</p>
+            </remarks>
+        </define-flag>
+        <model>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+    </define-assembly>
 
 </METASCHEMA>

--- a/src/metaschema/oscal_catalog_metaschema.xml
+++ b/src/metaschema/oscal_catalog_metaschema.xml
@@ -6,245 +6,245 @@
    <!ENTITY allowed-values-control-group-property-name SYSTEM "shared-constraints/allowed-values-control-group-property-name.ent">
 ]>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns:meta="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
-      xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
-      <schema-name>OSCAL Control Catalog Model</schema-name>
-      <schema-version>1.0.1</schema-version>
-      <short-name>oscal-catalog</short-name>
-      <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
-      <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
-      <remarks>
-            <p>The OSCAL Control Catalog format can be used to describe a collection of security controls and related control enhancements, along with contextualizing documentation and metadata. The root of the Control Catalog format is <code>catalog</code>.
-            </p>
-      </remarks>
-      <import href="oscal_control-common_metaschema.xml"/>
-      <import href="oscal_metadata_metaschema.xml"/>
-      <define-assembly name="catalog">
-            <formal-name>Catalog</formal-name>
-            <description>A collection of controls.</description>
-            <root-name>catalog</root-name>
-            <define-flag name="uuid" as-type="uuid" required="yes">
-                  <formal-name>Catalog Universally Unique Identifier</formal-name>
-                  <description>A globally unique identifier with cross-instance scope for this catalog instance. This UUID should be changed when this document is revised.</description>
-            </define-flag>
+    xmlns:meta="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
+    <schema-name>OSCAL Control Catalog Model</schema-name>
+    <schema-version>1.0.1</schema-version>
+    <short-name>oscal-catalog</short-name>
+    <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
+    <remarks>
+        <p>The OSCAL Control Catalog format can be used to describe a collection of security controls and related control enhancements, along with contextualizing documentation and metadata. The root of the Control Catalog format is <code>catalog</code>.
+        </p>
+    </remarks>
+    <import href="oscal_control-common_metaschema.xml"/>
+    <import href="oscal_metadata_metaschema.xml"/>
+    <define-assembly name="catalog">
+        <formal-name>Catalog</formal-name>
+        <description>A collection of controls.</description>
+        <root-name>catalog</root-name>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Catalog Universally Unique Identifier</formal-name>
+            <description>A globally unique identifier with cross-instance scope for this catalog instance. This UUID should be changed when this document is revised.</description>
+        </define-flag>
 
-            <model>
-                  <assembly ref="metadata" min-occurs="1"/>
-                  <assembly ref="parameter" max-occurs="unbounded">
-                        <!-- CHANGED: "parameters" to "params" -->
-                        <group-as name="params" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="control" max-occurs="unbounded">
-                        <group-as name="controls" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="group" max-occurs="unbounded">
-                        <group-as name="groups" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="back-matter">
-                        <remarks>
-                              <p>Back matter including references and resources.</p>
-                        </remarks>
-                  </assembly>
-            </model>
-            <constraint>
-                  <allowed-values target="metadata/prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                        <enum value="resolution-tool">The tool used to produce a resolved profile.</enum>
-                  </allowed-values>
-                  <allowed-values target="metadata/link/@rel">
-                        <enum value="source-profile">The tool used to produce a resolved profile.</enum>
-                  </allowed-values>
-            </constraint>
+        <model>
+            <assembly ref="metadata" min-occurs="1"/>
+            <assembly ref="parameter" max-occurs="unbounded">
+                <!-- CHANGED: "parameters" to "params" -->
+                <group-as name="params" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="control" max-occurs="unbounded">
+                <group-as name="controls" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="group" max-occurs="unbounded">
+                <group-as name="groups" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="back-matter">
+                <remarks>
+                    <p>Back matter including references and resources.</p>
+                </remarks>
+            </assembly>
+        </model>
+        <constraint>
+            <allowed-values target="metadata/prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                <enum value="resolution-tool">The tool used to produce a resolved profile.</enum>
+            </allowed-values>
+            <allowed-values target="metadata/link/@rel">
+                <enum value="source-profile">The tool used to produce a resolved profile.</enum>
+            </allowed-values>
+        </constraint>
+        <remarks>
+            <p>Catalogs may use one or more <code>group</code> objects to subdivide the control contents of a catalog.</p>
+            <p>An OSCAL catalog model provides a structured representation of control information.</p>
+        </remarks>
+        <example>
+            <description>A small catalog with a single control</description>
+            <catalog xmlns="http://csrc.nist.gov/ns/oscal/example" id="simple-example" model-version="0.99">
+                <title>A Miniature Catalog</title>
+                <control id="single">
+                    <title>A Single Control</title>
+                </control>
+            </catalog>
+        </example>
+    </define-assembly>
+    <define-assembly name="group">
+        <formal-name>Control Group</formal-name>
+        <description>A group of controls, or of groups of controls.</description>
+        <define-flag name="id" as-type="token">
+            <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
+            <formal-name>Group Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined group elsewhere in <a href="/concepts/identifier-use/#catalog-identifiers">in this and other OSCAL instances (e.g., profiles)</a>. This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same group across revisions of the document.</description>
+        </define-flag>
+        <define-flag name="class" as-type="token">
+            <formal-name>Group Class</formal-name>
+            <description>A textual label that provides a sub-type or characterization of the group.</description>
             <remarks>
-                  <p>Catalogs may use one or more <code>group</code> objects to subdivide the control contents of a catalog.</p>
-                  <p>An OSCAL catalog model provides a structured representation of control information.</p>
+                <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
+                <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
             </remarks>
-            <example>
-                  <description>A small catalog with a single control</description>
-                  <catalog xmlns="http://csrc.nist.gov/ns/oscal/example" id="simple-example" model-version="0.99">
-                        <title>A Miniature Catalog</title>
-                        <control id="single">
-                              <title>A Single Control</title>
-                        </control>
-                  </catalog>
-            </example>
-      </define-assembly>
-      <define-assembly name="group">
-            <formal-name>Control Group</formal-name>
-            <description>A group of controls, or of groups of controls.</description>
-            <define-flag name="id" as-type="token">
-                  <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
-                  <formal-name>Group Identifier</formal-name>
-                  <!-- Identifier Declaration -->
-                  <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined group elsewhere in <a href="/concepts/identifier-use/#catalog-identifiers">in this and other OSCAL instances (e.g., profiles)</a>. This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same group across revisions of the document.</description>
-            </define-flag>
-            <define-flag name="class" as-type="token">
-                  <formal-name>Group Class</formal-name>
-                  <description>A textual label that provides a sub-type or characterization of the group.</description>
-                  <remarks>
-                        <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
-                        <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
-                  </remarks>
-            </define-flag>
-            <model>
-                  <define-field name="title" as-type="markup-line" min-occurs="1">
-                        <formal-name>Group Title</formal-name>
-                        <description>A name given to the group, which may be used by a tool for display and navigation.</description>
-                  </define-field>
-                  <assembly ref="parameter" max-occurs="unbounded">
-                        <!-- CHANGED: "parameters" to "params" -->
-                        <group-as name="params" in-json="ARRAY"/>
-                  </assembly>
+        </define-flag>
+        <model>
+            <define-field name="title" as-type="markup-line" min-occurs="1">
+                <formal-name>Group Title</formal-name>
+                <description>A name given to the group, which may be used by a tool for display and navigation.</description>
+            </define-field>
+            <assembly ref="parameter" max-occurs="unbounded">
+                <!-- CHANGED: "parameters" to "params" -->
+                <group-as name="params" in-json="ARRAY"/>
+            </assembly>
 
-                  <assembly ref="property" max-occurs="unbounded">
-                        <group-as name="props" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="link" max-occurs="unbounded">
-                        <group-as name="links" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="part" max-occurs="unbounded">
-                        <group-as name="parts" in-json="ARRAY"/>
-                  </assembly>
-                  <choice>
-                        <assembly ref="group" max-occurs="unbounded">
-                              <group-as name="groups" in-json="ARRAY"/>
-                        </assembly>
-                        <assembly ref="control" max-occurs="unbounded">
-                              <group-as name="controls" in-json="ARRAY"/>
-                        </assembly>
-                  </choice>
-                  <!--<any/>-->
-            </model>
-            <constraint>
-                  <!-- CHANGE: added allowed values for a property/@name -->
-                  <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-            &allowed-values-control-group-property-name;
-                  </allowed-values>
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                        <enum value="overview">An introduction to a control or a group of controls.</enum>
-                  </allowed-values>
-            </constraint>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="part" max-occurs="unbounded">
+                <group-as name="parts" in-json="ARRAY"/>
+            </assembly>
+            <choice>
+                <assembly ref="group" max-occurs="unbounded">
+                    <group-as name="groups" in-json="ARRAY"/>
+                </assembly>
+                <assembly ref="control" max-occurs="unbounded">
+                    <group-as name="controls" in-json="ARRAY"/>
+                </assembly>
+            </choice>
+            <!--<any/>-->
+        </model>
+        <constraint>
+            <!-- CHANGE: added allowed values for a property/@name -->
+            <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+        &allowed-values-control-group-property-name;
+            </allowed-values>
+            <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                <enum value="overview">An introduction to a control or a group of controls.</enum>
+            </allowed-values>
+        </constraint>
+        <remarks>
+            <p>Catalogs can use a <code>group</code> to collect related controls into a single grouping. That can be useful to group controls into a family or other logical grouping.</p>
+            <p>A <code>group</code> may have its own properties, statements, parameters, and references, which are inherited by all members of that group.</p>
+        </remarks>
+        <example>
+            <group xmlns="http://csrc.nist.gov/ns/oscal/example" id="xyz">
+                <title>My Group</title>
+                <prop name="required" value="some value"/>
+                <control id="xyz1">
+                    <title>Control</title>
+                </control>
+            </group>
+        </example>
+    </define-assembly>
+    <define-assembly name="control">
+        <formal-name>Control</formal-name>
+        <description>A structured information object representing a security or privacy control. Each security or privacy control within the Catalog is defined by a distinct control instance.</description>
+        <define-flag name="id" as-type="token" required="yes">
+            <!-- This is an id because the idenfier is managed externally. -->
+            <formal-name>Control Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#instance">instance</a> scope that can be used to reference this control elsewhere <a href="/concepts/identifier-use/#catalog-identifiers">in this and other OSCAL instances (e.g., profiles)</a>. This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same control across revisions of the document.</description>
+        </define-flag>
+        <define-flag name="class" as-type="token">
+            <formal-name>Control Class</formal-name>
+            <description>A textual label that provides a sub-type or characterization of the control.</description>
             <remarks>
-                  <p>Catalogs can use a <code>group</code> to collect related controls into a single grouping. That can be useful to group controls into a family or other logical grouping.</p>
-                  <p>A <code>group</code> may have its own properties, statements, parameters, and references, which are inherited by all members of that group.</p>
+                <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
+                <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
             </remarks>
-            <example>
-                  <group xmlns="http://csrc.nist.gov/ns/oscal/example" id="xyz">
-                        <title>My Group</title>
-                        <prop name="required" value="some value"/>
-                        <control id="xyz1">
-                              <title>Control</title>
-                        </control>
-                  </group>
-            </example>
-      </define-assembly>
-      <define-assembly name="control">
-            <formal-name>Control</formal-name>
-            <description>A structured information object representing a security or privacy control. Each security or privacy control within the Catalog is defined by a distinct control instance.</description>
-            <define-flag name="id" as-type="token" required="yes">
-                  <!-- This is an id because the idenfier is managed externally. -->
-                  <formal-name>Control Identifier</formal-name>
-                  <!-- Identifier Declaration -->
-                  <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#instance">instance</a> scope that can be used to reference this control elsewhere <a href="/concepts/identifier-use/#catalog-identifiers">in this and other OSCAL instances (e.g., profiles)</a>. This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same control across revisions of the document.</description>
-            </define-flag>
-            <define-flag name="class" as-type="token">
-                  <formal-name>Control Class</formal-name>
-                  <description>A textual label that provides a sub-type or characterization of the control.</description>
-                  <remarks>
-                        <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
-                        <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
-                  </remarks>
-            </define-flag>
-            <model>
-                  <define-field name="title" as-type="markup-line" min-occurs="1">
-                        <formal-name>Control Title</formal-name>
-                        <description>A name given to the control, which may be used by a tool for display and navigation.</description>
-                  </define-field>
-                  <assembly ref="parameter" max-occurs="unbounded">
-                        <!-- CHANGED: "parameters" to "params" -->
-                        <group-as name="params" in-json="ARRAY"/>
-                  </assembly>
-                  <!-- TODO: Need to be able to add valid values in context -->
-                  <assembly ref="property" max-occurs="unbounded">
-                        <group-as name="props" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="link" max-occurs="unbounded">
-                        <group-as name="links" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="part" max-occurs="unbounded">
-                        <group-as name="parts" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="control" max-occurs="unbounded">
-                        <group-as name="controls" in-json="ARRAY"/>
-                  </assembly>
-                  <!--<assembly named="ref-list"/>-->
-                  <!-- <any/> -->
-            </model>
-            <constraint>
-                  <expect id="catalog-control-require-statement-when-not-withdrawn" target="." test="prop[@name='status']/@value='withdrawn' or part[@name='statement']" />
-                  <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-            &allowed-values-control-group-property-name;
-                        <enum value="status">The status of a <code>control</code>. For example, a value of 'withdrawn' can indicate that the <code>control</code> has been withdrawn and should no longer be used.</enum>
-                  </allowed-values>
-                  <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name='status']/@value">
-                        <enum value="withdrawn">The control is no longer used.</enum>
-                  </allowed-values>
-                  <allowed-values target="link/@rel" allow-other="yes">
-                        <enum value="reference">The link cites an external resource related to this control.</enum>
-                        <enum value="related">The link identifies another control with bearing to this control.</enum>
-                        <enum value="required">The link identifies another control that must be present if this control is present.</enum>
-                        <enum value="incorporated-into">The link identifies other control content where this control content is now addressed.</enum>
-                        <enum value="moved-to">The containing control definition was moved to the referenced control.</enum>
-                  </allowed-values>
-                  
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                        <enum value="overview">An introduction to a control or a group of controls.</enum>
-                        <enum value="statement">A set of control implementation requirements.</enum>
-                        <enum value="guidance">Additional information to consider when selecting, implementing, assessing, and monitoring a control.</enum>
-                        <enum value="assessment" deprecated="1.0.1">**(deprecated)** Use 'assessment-method' instead.</enum>
-                        <enum value="assessment-method" deprecated="1.0.1">The part describes a method-based assessment over a set of assessment objects.</enum>
-                  </allowed-values>
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name='statement']//part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                        <enum value="item">An individual item within a control statement.</enum>
-                        <remarks>
-                              <p>Nested statement parts are "item" parts.</p>
-                        </remarks>
-                  </allowed-values>
-                  <allowed-values target=".//part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                        <enum value="objective" deprecated="1.0.1">**(deprecated)** Use 'assessment-objective' instead.</enum>
-                        <enum value="assessment-objective">The part describes a set of assessment objectives.</enum>
-                        <remarks>
-                              <p>Objectives can be nested.</p>
-                        </remarks>
-                  </allowed-values>
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                        <enum value="objects" deprecated="1.0.1">**(deprecated)** Use 'assessment-objects' instead.</enum>
-                        <enum value="assessment-objects">Provides a listing of assessment objects.</enum>
-                        <remarks>
-                              <p>Assessment objects appear on assessment methods.</p>
-                        </remarks>
-                  </allowed-values>
-                  
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                        <enum value="method" deprecated="1.0.1">**(deprecated)** Use 'method' in the 'http://csrc.nist.gov/ns/rmf' namespace. The assessment method to use. This typically appears on parts with the name "assessment".</enum>
-                  </allowed-values>
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/rmf')]/@name">
-                        <enum value="method">The assessment method to use. This typically appears on parts with the name "assessment".</enum>
-                  </allowed-values>
-                  <expect level="WARNING" target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]" test="prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']"/>
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']/@value">
-                        <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
-                        <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
-                        <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
-                  </allowed-values>
-            </constraint>
-            <remarks>
-                  <p>Controls may be grouped using <code>group</code>, and controls may be partitioned using <code>part</code> or further enhanced (extended) using <code>control</code>.</p>
-                  <p>A control must have a part with the name "statement", which represents the textual narrative of the control. This "statement" part must occur only once, but may have nested parts to allow for multiple paragraphs or sections of text.</p>
-            </remarks>
-            <example>
-                  <control xmlns="http://csrc.nist.gov/ns/oscal/example" id="x">
-                        <title>Control 1</title>
-                  </control>
-            </example>
-      </define-assembly>
+        </define-flag>
+        <model>
+            <define-field name="title" as-type="markup-line" min-occurs="1">
+                <formal-name>Control Title</formal-name>
+                <description>A name given to the control, which may be used by a tool for display and navigation.</description>
+            </define-field>
+            <assembly ref="parameter" max-occurs="unbounded">
+                <!-- CHANGED: "parameters" to "params" -->
+                <group-as name="params" in-json="ARRAY"/>
+            </assembly>
+            <!-- TODO: Need to be able to add valid values in context -->
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="part" max-occurs="unbounded">
+                <group-as name="parts" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="control" max-occurs="unbounded">
+                <group-as name="controls" in-json="ARRAY"/>
+            </assembly>
+            <!--<assembly named="ref-list"/>-->
+            <!-- <any/> -->
+        </model>
+        <constraint>
+            <expect id="catalog-control-require-statement-when-not-withdrawn" target="." test="prop[@name='status']/@value='withdrawn' or part[@name='statement']" />
+            <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+        &allowed-values-control-group-property-name;
+                <enum value="status">The status of a <code>control</code>. For example, a value of 'withdrawn' can indicate that the <code>control</code> has been withdrawn and should no longer be used.</enum>
+            </allowed-values>
+            <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name='status']/@value">
+                <enum value="withdrawn">The control is no longer used.</enum>
+            </allowed-values>
+            <allowed-values target="link/@rel" allow-other="yes">
+                <enum value="reference">The link cites an external resource related to this control.</enum>
+                <enum value="related">The link identifies another control with bearing to this control.</enum>
+                <enum value="required">The link identifies another control that must be present if this control is present.</enum>
+                <enum value="incorporated-into">The link identifies other control content where this control content is now addressed.</enum>
+                <enum value="moved-to">The containing control definition was moved to the referenced control.</enum>
+            </allowed-values>
+            
+            <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                <enum value="overview">An introduction to a control or a group of controls.</enum>
+                <enum value="statement">A set of control implementation requirements.</enum>
+                <enum value="guidance">Additional information to consider when selecting, implementing, assessing, and monitoring a control.</enum>
+                <enum value="assessment" deprecated="1.0.1">**(deprecated)** Use 'assessment-method' instead.</enum>
+                <enum value="assessment-method" deprecated="1.0.1">The part describes a method-based assessment over a set of assessment objects.</enum>
+            </allowed-values>
+            <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name='statement']//part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                <enum value="item">An individual item within a control statement.</enum>
+                <remarks>
+                    <p>Nested statement parts are "item" parts.</p>
+                </remarks>
+            </allowed-values>
+            <allowed-values target=".//part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                <enum value="objective" deprecated="1.0.1">**(deprecated)** Use 'assessment-objective' instead.</enum>
+                <enum value="assessment-objective">The part describes a set of assessment objectives.</enum>
+                <remarks>
+                    <p>Objectives can be nested.</p>
+                </remarks>
+            </allowed-values>
+            <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                <enum value="objects" deprecated="1.0.1">**(deprecated)** Use 'assessment-objects' instead.</enum>
+                <enum value="assessment-objects">Provides a listing of assessment objects.</enum>
+                <remarks>
+                    <p>Assessment objects appear on assessment methods.</p>
+                </remarks>
+            </allowed-values>
+
+            <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                <enum value="method" deprecated="1.0.1">**(deprecated)** Use 'method' in the 'http://csrc.nist.gov/ns/rmf' namespace. The assessment method to use. This typically appears on parts with the name "assessment".</enum>
+            </allowed-values>
+            <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/rmf')]/@name">
+                <enum value="method">The assessment method to use. This typically appears on parts with the name "assessment".</enum>
+            </allowed-values>
+            <expect level="WARNING" target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]" test="prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']"/>
+            <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']/@value">
+                <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
+                <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
+                <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
+            </allowed-values>
+        </constraint>
+        <remarks>
+            <p>Controls may be grouped using <code>group</code>, and controls may be partitioned using <code>part</code> or further enhanced (extended) using <code>control</code>.</p>
+            <p>A control must have a part with the name "statement", which represents the textual narrative of the control. This "statement" part must occur only once, but may have nested parts to allow for multiple paragraphs or sections of text.</p>
+        </remarks>
+        <example>
+            <control xmlns="http://csrc.nist.gov/ns/oscal/example" id="x">
+                <title>Control 1</title>
+            </control>
+        </example>
+    </define-assembly>
 </METASCHEMA>

--- a/src/metaschema/oscal_complete_metaschema.xml
+++ b/src/metaschema/oscal_complete_metaschema.xml
@@ -6,19 +6,19 @@
    <!ENTITY allowed-values-control-group-property-name SYSTEM "./shared-constraints/allowed-values-control-group-property-name.ent">
 ]>
 <METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
-      <schema-name>OSCAL Unified Model of Models</schema-name>
-      <schema-version>1.0.1</schema-version>
-      <short-name>oscal-complete</short-name>
-      <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
-      <json-base-uri>http://csrc.nist.gov/ns/oscal/1.0</json-base-uri>
-      <remarks>
-            <p>This format represents a combination of all of the OSCAL models.</p>
-      </remarks>
-      <import href="oscal_catalog_metaschema.xml"/>
-      <import href="oscal_profile_metaschema.xml"/>
-      <import href="oscal_component_metaschema.xml"/>
-      <import href="oscal_ssp_metaschema.xml"/>
-      <import href="oscal_assessment-plan_metaschema.xml"/>
-      <import href="oscal_assessment-results_metaschema.xml"/>
-      <import href="oscal_poam_metaschema.xml"/>
+    <schema-name>OSCAL Unified Model of Models</schema-name>
+    <schema-version>1.0.1</schema-version>
+    <short-name>oscal-complete</short-name>
+    <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal/1.0</json-base-uri>
+    <remarks>
+        <p>This format represents a combination of all of the OSCAL models.</p>
+    </remarks>
+    <import href="oscal_catalog_metaschema.xml"/>
+    <import href="oscal_profile_metaschema.xml"/>
+    <import href="oscal_component_metaschema.xml"/>
+    <import href="oscal_ssp_metaschema.xml"/>
+    <import href="oscal_assessment-plan_metaschema.xml"/>
+    <import href="oscal_assessment-results_metaschema.xml"/>
+    <import href="oscal_poam_metaschema.xml"/>
 </METASCHEMA>

--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -1,439 +1,439 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../build/metaschema/toolchains/xslt-M4/validate/metaschema-composition-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <!DOCTYPE METASCHEMA [
-  <!ENTITY allowed-values-responsible-roles-operations SYSTEM "./shared-constraints/allowed-values-responsible-roles-operations.ent">
-  <!ENTITY allowed-values-responsible-roles-component-production SYSTEM "./shared-constraints/allowed-values-responsible-roles-component-production.ent">
-  <!ENTITY allowed-values-property-name-asset-type-values SYSTEM "./shared-constraints/allowed-values-property-name-asset-type-values.ent">
-  <!ENTITY allowed-values-component_component_property-name SYSTEM "./shared-constraints/allowed-values-component_component_property-name.ent">
-  <!ENTITY allowed-values-component_component_software SYSTEM "./shared-constraints/allowed-values-component_component_software.ent">
-  <!ENTITY allowed-values-component_component_service SYSTEM "./shared-constraints/allowed-values-component_component_service.ent">
-  <!ENTITY allowed-values-component_inventory-item_property-name SYSTEM "./shared-constraints/allowed-values-component_inventory-item_property-name.ent">
-  <!ENTITY allowed-values-component_component_link-rel SYSTEM "./shared-constraints/allowed-values-component_component_link-rel.ent">
-  <!ENTITY allowed-values-component-type SYSTEM "./shared-constraints/allowed-values-component-type.ent">
+    <!ENTITY allowed-values-responsible-roles-operations SYSTEM "./shared-constraints/allowed-values-responsible-roles-operations.ent">
+    <!ENTITY allowed-values-responsible-roles-component-production SYSTEM "./shared-constraints/allowed-values-responsible-roles-component-production.ent">
+    <!ENTITY allowed-values-property-name-asset-type-values SYSTEM "./shared-constraints/allowed-values-property-name-asset-type-values.ent">
+    <!ENTITY allowed-values-component_component_property-name SYSTEM "./shared-constraints/allowed-values-component_component_property-name.ent">
+    <!ENTITY allowed-values-component_component_software SYSTEM "./shared-constraints/allowed-values-component_component_software.ent">
+    <!ENTITY allowed-values-component_component_service SYSTEM "./shared-constraints/allowed-values-component_component_service.ent">
+    <!ENTITY allowed-values-component_inventory-item_property-name SYSTEM "./shared-constraints/allowed-values-component_inventory-item_property-name.ent">
+    <!ENTITY allowed-values-component_component_link-rel SYSTEM "./shared-constraints/allowed-values-component_component_link-rel.ent">
+    <!ENTITY allowed-values-component-type SYSTEM "./shared-constraints/allowed-values-component-type.ent">
 ]>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
-  <schema-name>OSCAL Component Definition Model</schema-name>
-  <schema-version>1.0.1</schema-version>
-  <short-name>oscal-component-definition</short-name>
-  <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
-  <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
-  <remarks>
-    <p>The OSCAL Component Definition Model can be used to describe the implementation of controls in a <code>component</code> or a set of components grouped as a <code>capability</code>. A component can be either a <em>technical component</em>, or a <em>documentary component</em>. A technical component is a component that is implemented in hardware (physical or virtual) or software. A documentary component is a component implemented in a document, such as a process, procedure, or policy.</p>
-    <p>The root of the OSCAL Implementation Component format is <code>component-definition</code>.
-    </p>
-    <p>NOTE: This documentation is a work in progress. As a result, documentation for many of the information elements is missing or incomplete.</p>
-  </remarks>
+    xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
+    <schema-name>OSCAL Component Definition Model</schema-name>
+    <schema-version>1.0.1</schema-version>
+    <short-name>oscal-component-definition</short-name>
+    <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
+    <remarks>
+        <p>The OSCAL Component Definition Model can be used to describe the implementation of controls in a <code>component</code> or a set of components grouped as a <code>capability</code>. A component can be either a <em>technical component</em>, or a <em>documentary component</em>. A technical component is a component that is implemented in hardware (physical or virtual) or software. A documentary component is a component implemented in a document, such as a process, procedure, or policy.</p>
+        <p>The root of the OSCAL Implementation Component format is <code>component-definition</code>.
+        </p>
+        <p>NOTE: This documentation is a work in progress. As a result, documentation for many of the information elements is missing or incomplete.</p>
+    </remarks>
 
-  <import href="oscal_implementation-common_metaschema.xml"/>
+    <import href="oscal_implementation-common_metaschema.xml"/>
 
-  <define-assembly name="component-definition">
-    <formal-name>Component Definition</formal-name>
-    <description>A collection of component descriptions, which may optionally be grouped by capability.</description>
-    <root-name>component-definition</root-name>
-    <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>Component Definition Universally Unique Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this component definition elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>component definition</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <model>
-      <assembly ref="metadata" min-occurs="1"/>
-      <assembly ref="import-component-definition" max-occurs="unbounded">
-        <group-as name="import-component-definitions" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="defined-component" max-occurs="unbounded">
-        <use-name>component</use-name>
-        <group-as name="components" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="capability" max-occurs="unbounded">
-        <group-as name="capabilities" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="back-matter"/>
-    </model>
-    <constraint>
-      <index name="index-system-component-uuid" target="component">
-        <key-field target="@uuid"/>
-        <remarks>
-          <p>Since multiple <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
-        </remarks>
-      </index>
-      <is-unique id="unique-component-definition-capability" target="capability">
-        <key-field target="@uuid"/>
-        <remarks>
-          <p>A given <code>component</code> must not be referenced more than once within the same <code>capability</code>.</p>
-        </remarks>
-      </is-unique>
-    </constraint>
-  </define-assembly>
+    <define-assembly name="component-definition">
+        <formal-name>Component Definition</formal-name>
+        <description>A collection of component descriptions, which may optionally be grouped by capability.</description>
+        <root-name>component-definition</root-name>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Component Definition Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this component definition elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>component definition</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <model>
+            <assembly ref="metadata" min-occurs="1"/>
+            <assembly ref="import-component-definition" max-occurs="unbounded">
+                <group-as name="import-component-definitions" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="defined-component" max-occurs="unbounded">
+                <use-name>component</use-name>
+                <group-as name="components" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="capability" max-occurs="unbounded">
+                <group-as name="capabilities" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="back-matter"/>
+        </model>
+        <constraint>
+            <index name="index-system-component-uuid" target="component">
+                <key-field target="@uuid"/>
+                <remarks>
+                    <p>Since multiple <code>component</code> entries can be provided, each component must have a unique <code>uuid</code>.</p>
+                </remarks>
+            </index>
+            <is-unique id="unique-component-definition-capability" target="capability">
+                <key-field target="@uuid"/>
+                <remarks>
+                    <p>A given <code>component</code> must not be referenced more than once within the same <code>capability</code>.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
 
-  <define-assembly name="import-component-definition">
-    <formal-name>Import Component Definition</formal-name>
-    <description>Loads a component definition from another resource.</description>
-    <define-flag name="href" as-type="uri-reference" required="yes">
-      <formal-name>Hyperlink Reference</formal-name>
-      <description>A link to a resource that defines a set of components and/or capabilities to import into this collection.</description>
-    </define-flag>
-  </define-assembly>
+    <define-assembly name="import-component-definition">
+        <formal-name>Import Component Definition</formal-name>
+        <description>Loads a component definition from another resource.</description>
+        <define-flag name="href" as-type="uri-reference" required="yes">
+            <formal-name>Hyperlink Reference</formal-name>
+            <description>A link to a resource that defines a set of components and/or capabilities to import into this collection.</description>
+        </define-flag>
+    </define-assembly>
 
-  <define-assembly name="defined-component">
-    <formal-name>Component</formal-name>
-    <description>A defined component that can be part of an implemented system.</description>
-    <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>Component Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this component elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>component</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <flag ref="defined-component-type" required="yes">
-      <use-name>type</use-name>
-    </flag>
-    <model>
-      <define-field name="title" as-type="markup-line" min-occurs="1">
-        <formal-name>Component Title</formal-name>
-        <description>A human readable name for the component.</description>
-      </define-field>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Component Description</formal-name>
-        <description>A description of the component, including information about its function.</description>
-      </define-field>
-      <define-field name="purpose" as-type="markup-line">
-        <formal-name>Purpose</formal-name>
-        <description>A summary of the technological or business purpose of the component.</description>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="responsible-role" max-occurs="unbounded">
-        <group-as name="responsible-roles" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="protocol" max-occurs="unbounded">
-        <group-as name="protocols" in-json="ARRAY"/>
-        <remarks>
-          <p>Used for <code>service</code> components to define the protocols supported by the service.</p>
-        </remarks>
-      </assembly>
+    <define-assembly name="defined-component">
+        <formal-name>Component</formal-name>
+        <description>A defined component that can be part of an implemented system.</description>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Component Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this component elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>component</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <flag ref="defined-component-type" required="yes">
+            <use-name>type</use-name>
+        </flag>
+        <model>
+            <define-field name="title" as-type="markup-line" min-occurs="1">
+                <formal-name>Component Title</formal-name>
+                <description>A human readable name for the component.</description>
+            </define-field>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Component Description</formal-name>
+                <description>A description of the component, including information about its function.</description>
+            </define-field>
+            <define-field name="purpose" as-type="markup-line">
+                <formal-name>Purpose</formal-name>
+                <description>A summary of the technological or business purpose of the component.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="responsible-role" max-occurs="unbounded">
+                <group-as name="responsible-roles" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="protocol" max-occurs="unbounded">
+                <group-as name="protocols" in-json="ARRAY"/>
+                <remarks>
+                    <p>Used for <code>service</code> components to define the protocols supported by the service.</p>
+                </remarks>
+            </assembly>
 
-      <assembly ref="control-implementation" max-occurs="unbounded">
-        <group-as name="control-implementations" in-json="ARRAY"/>
-      </assembly>
-      <!--
-         <assembly ref="configuration" max-occurs="unbounded">
-           <group-as name="configurations" in-json="BY_KEY" />
-         </assembly>
-         <assembly ref="artifact" max-occurs="unbounded">
-           <group-as name="artifacts" in-json="BY_KEY" />
-         </assembly>
+            <assembly ref="control-implementation" max-occurs="unbounded">
+                <group-as name="control-implementations" in-json="ARRAY"/>
+            </assembly>
+            <!--
+                 <assembly ref="configuration" max-occurs="unbounded">
+                     <group-as name="configurations" in-json="BY_KEY" />
+                 </assembly>
+                 <assembly ref="artifact" max-occurs="unbounded">
+                     <group-as name="artifacts" in-json="BY_KEY" />
+                 </assembly>
 -->
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <allowed-values target="prop/@name" allow-other="yes">
-        <!-- ========================================================================================================== -->
-        <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
-        <!-- CHANGED (BJR): Done -->
-        <!-- ========================================================================================================== -->
-            &allowed-values-component_component_property-name;
-            &allowed-values-component_inventory-item_property-name;
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <allowed-values target="prop/@name" allow-other="yes">
+                <!-- ========================================================================================================== -->
+                <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
+                <!-- CHANGED (BJR): Done -->
+                <!-- ========================================================================================================== -->
+                        &allowed-values-component_component_property-name;
+                        &allowed-values-component_inventory-item_property-name;
 
-                    <!-- CHANGE: @name="date-released" changed to @name="release-date" -->
-      </allowed-values>
+                                        <!-- CHANGE: @name="date-released" changed to @name="release-date" -->
+            </allowed-values>
 
-      <allowed-values target="link/@rel" allow-other="yes">
-        <!-- ========================================================================================================== -->
-        <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
-        <!-- CHANGED (BJR): Done -->
-        <!-- ========================================================================================================== -->
-            &allowed-values-component_component_link-rel;
-        <enum value="uses-network">This component uses the network provided by the identified network component.</enum>
-      </allowed-values>
+            <allowed-values target="link/@rel" allow-other="yes">
+                <!-- ========================================================================================================== -->
+                <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
+                <!-- CHANGED (BJR): Done -->
+                <!-- ========================================================================================================== -->
+                        &allowed-values-component_component_link-rel;
+                <enum value="uses-network">This component uses the network provided by the identified network component.</enum>
+            </allowed-values>
 
-      <allowed-values target="responsible-role/@role-id|control-implementation/implemented-requirement/responsible-role/@role-id|control-implementation/implemented-requirement/statement/responsible-role/@role-id" allow-other="yes">
-        <!-- ========================================================================================================== -->
-        <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
-        <!-- CHANGED (BJR): Done -->
-        <!-- ========================================================================================================== -->
-            &allowed-values-responsible-roles-operations;
-            &allowed-values-responsible-roles-component-production;
-      </allowed-values>
+            <allowed-values target="responsible-role/@role-id|control-implementation/implemented-requirement/responsible-role/@role-id|control-implementation/implemented-requirement/statement/responsible-role/@role-id" allow-other="yes">
+                <!-- ========================================================================================================== -->
+                <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
+                <!-- CHANGED (BJR): Done -->
+                <!-- ========================================================================================================== -->
+                        &allowed-values-responsible-roles-operations;
+                        &allowed-values-responsible-roles-component-production;
+            </allowed-values>
 
-      <allowed-values target="prop[@name='asset-type']/@value">
-            &allowed-values-property-name-asset-type-values;
-      </allowed-values>
+            <allowed-values target="prop[@name='asset-type']/@value">
+                        &allowed-values-property-name-asset-type-values;
+            </allowed-values>
 
-      <!-- ========================================================================================================== -->
-      <!-- = TODO: The following was copied from implementation-common as-is and should probably be setup with  = -->
-      <!-- =       shared constraints; however, the values are highly static (yes/no, internal/external). -->
-      <!-- =       Can be changed later with no breaking impact. -->
-      <allowed-values target="prop[@name='allows-authenticated-scan']/@value">
-        <enum value="yes">The component allows an authenticated scan.</enum>
-        <enum value="no">The component does not allow an authenticated scan.</enum>
-      </allowed-values>
+            <!-- ========================================================================================================== -->
+            <!-- = TODO: The following was copied from implementation-common as-is and should probably be setup with    = -->
+            <!-- =             shared constraints; however, the values are highly static (yes/no, internal/external). -->
+            <!-- =             Can be changed later with no breaking impact. -->
+            <allowed-values target="prop[@name='allows-authenticated-scan']/@value">
+                <enum value="yes">The component allows an authenticated scan.</enum>
+                <enum value="no">The component does not allow an authenticated scan.</enum>
+            </allowed-values>
 
-      <allowed-values target="prop[@name='virtual']/@value">
-        <enum value="yes">The component is virtualized.</enum>
-        <enum value="no">The component is not virtualized.</enum>
-      </allowed-values>
+            <allowed-values target="prop[@name='virtual']/@value">
+                <enum value="yes">The component is virtualized.</enum>
+                <enum value="no">The component is not virtualized.</enum>
+            </allowed-values>
 
-      <allowed-values target="prop[@name='public']/@value">
-        <enum value="yes">The component is publicly accessible.</enum>
-        <enum value="no">The component is not publicly accessible.</enum>
-      </allowed-values>
+            <allowed-values target="prop[@name='public']/@value">
+                <enum value="yes">The component is publicly accessible.</enum>
+                <enum value="no">The component is not publicly accessible.</enum>
+            </allowed-values>
 
-      <allowed-values target="prop[@name='implementation-point']/@value">
-        <enum value="internal">The component is implemented within the system boundary.</enum>
-        <enum value="external">The component is implemented outside the system boundary.</enum>
-      </allowed-values>
-      <!-- ========================================================================================================== -->
+            <allowed-values target="prop[@name='implementation-point']/@value">
+                <enum value="internal">The component is implemented within the system boundary.</enum>
+                <enum value="external">The component is implemented outside the system boundary.</enum>
+            </allowed-values>
+            <!-- ========================================================================================================== -->
 
-      <index-has-key name="index-metadata-location-uuid" target="prop[@name='physical-location']">
-        <key-field target="@value"/>
-      </index-has-key>
+            <index-has-key name="index-metadata-location-uuid" target="prop[@name='physical-location']">
+                <key-field target="@value"/>
+            </index-has-key>
 
-      <matches target="prop[@name='inherited-uuid']/@value" datatype="uuid" />
-      <matches target="prop[@name='release-date']/@value" datatype="date"/>
+            <matches target="prop[@name='inherited-uuid']/@value" datatype="uuid" />
+            <matches target="prop[@name='release-date']/@value" datatype="date"/>
 
-      <!-- ========================================================================================================== -->
-      <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
-      <!-- CHANGED (BJR): Done -->
-      <!-- ========================================================================================================== -->
+            <!-- ========================================================================================================== -->
+            <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
+            <!-- CHANGED (BJR): Done -->
+            <!-- ========================================================================================================== -->
 
-      <!-- ========================================================================================================== -->
-      <!-- = SOFTWARE: type='software' constraints                        = -->
-      <!-- ========================================================================================================== -->
-      <allowed-values target="(.)[@type='software']/prop/@name" allow-other="yes">
-            &allowed-values-component_component_software;
-      </allowed-values>
+            <!-- ========================================================================================================== -->
+            <!-- = SOFTWARE: type='software' constraints                                                = -->
+            <!-- ========================================================================================================== -->
+            <allowed-values target="(.)[@type='software']/prop/@name" allow-other="yes">
+                        &allowed-values-component_component_software;
+            </allowed-values>
 
-      <!-- ========================================================================================================== -->
-      <!-- = SERVICE: type='service' constraints                        = -->
-      <!-- ========================================================================================================== -->
-      <allowed-values target="(.)[@type='service']/link/@rel" allow-other="yes">
-            &allowed-values-component_component_service;
-      </allowed-values>
+            <!-- ========================================================================================================== -->
+            <!-- = SERVICE: type='service' constraints                                                = -->
+            <!-- ========================================================================================================== -->
+            <allowed-values target="(.)[@type='service']/link/@rel" allow-other="yes">
+                        &allowed-values-component_component_service;
+            </allowed-values>
 
-      <expect target="." test="not(exists((.)[not(@type='service')]/protocol))"/>
+            <expect target="." test="not(exists((.)[not(@type='service')]/protocol))"/>
 
-      <!-- ========================================================================================================== -->
-      <!-- = TODO: Consider whether INTERCONNECTION constraints are appropriate here.      = -->
-      <!-- =       I'm not sure I see a use case for this, but doesn't break to add later. = -->
-      <!-- =       If interconnection is not appropriate for component-defintion, we'll need different = -->
-      <!-- =           component-type lists for the two models.                                        = -->
-      <!-- ========================================================================================================== -->
-      <is-unique id="unique-defined-component-responsible-role" target="responsible-role">
-        <key-field target="@role-id"/>
+            <!-- ========================================================================================================== -->
+            <!-- = TODO: Consider whether INTERCONNECTION constraints are appropriate here.            = -->
+            <!-- =             I'm not sure I see a use case for this, but doesn't break to add later. = -->
+            <!-- =             If interconnection is not appropriate for component-defintion, we'll need different = -->
+            <!-- =                     component-type lists for the two models.                                                                                = -->
+            <!-- ========================================================================================================== -->
+            <is-unique id="unique-defined-component-responsible-role" target="responsible-role">
+                <key-field target="@role-id"/>
+                <remarks>
+                    <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
         <remarks>
-          <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+            <p>Components may be products, services, APIs, policies, processes, plans, guidance, standards, or other tangible items that enable security and/or privacy.</p>
+            <p>The <code>type</code> indicates which of these component types is represented.</p>
+            <p>A group of components may be aggregated into a <code>capability</code>. For example, an account management capability that consists of an account management process, and a Lightweight Directory Access Protocol (LDAP) software implementation.</p>
+            <p>Capabilities are expressed by combining one or more components.</p>
         </remarks>
-      </is-unique>
-    </constraint>
-    <remarks>
-      <p>Components may be products, services, APIs, policies, processes, plans, guidance, standards, or other tangible items that enable security and/or privacy.</p>
-      <p>The <code>type</code> indicates which of these component types is represented.</p>
-      <p>A group of components may be aggregated into a <code>capability</code>. For example, an account management capability that consists of an account management process, and a Lightweight Directory Access Protocol (LDAP) software implementation.</p>
-      <p>Capabilities are expressed by combining one or more components.</p>
-    </remarks>
-  </define-assembly>
+    </define-assembly>
 
-  <define-flag name="defined-component-type" as-type="string">
-    <formal-name>Component Type</formal-name>
-    <description>A category describing the purpose of the component.</description>
-    <constraint>
-      <allowed-values allow-other="yes">
-            &allowed-values-component-type;
-      </allowed-values>
-    </constraint>
-  </define-flag>
-
-  <define-assembly name="capability">
-    <formal-name>Capability</formal-name>
-    <description>A grouping of other components and/or capabilities.</description>
-    <define-flag required="yes" name="uuid" as-type="uuid">
-      <formal-name>Capability Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this capability elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>capability</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+    <define-flag name="defined-component-type" as-type="string">
+        <formal-name>Component Type</formal-name>
+        <description>A category describing the purpose of the component.</description>
+        <constraint>
+            <allowed-values allow-other="yes">
+                        &allowed-values-component-type;
+            </allowed-values>
+        </constraint>
     </define-flag>
-    <define-flag name="name" as-type="string" required="yes">
-      <formal-name>Capability Name</formal-name>
-      <description>The capability's human-readable name.</description>
-    </define-flag>
-    <model>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Capability Description</formal-name>
-        <description>A summary of the capability.</description>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="incorporates-component" max-occurs="unbounded">
-        <group-as name="incorporates-components" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="control-implementation" max-occurs="unbounded">
-        <group-as name="control-implementations" in-json="ARRAY"/>
-      </assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <is-unique id="unique-component-definition-capability-incorporates-component" target="incorporates-component">
-        <key-field target="@component-uuid"></key-field>
-        <remarks>
-          <p>A given <code>component</code> must not be referenced more than once within the same <code>capability</code>.</p>
-        </remarks>
-      </is-unique>
-    </constraint>
-  </define-assembly>
-  <define-assembly name="incorporates-component">
-    <formal-name>Incorporates Component</formal-name>
-    <!-- TODO: needs a description -->
-    <description>TBD</description>
-    <define-flag required="yes" name="component-uuid" as-type="uuid">
-      <formal-name>Component Reference</formal-name>
-      <!-- Identifier Reference -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a <code>component</code>.</description>
-    </define-flag>
-    <model>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Component Description</formal-name>
-        <description>A description of the component, including information about its function.</description>
-      </define-field>
-    </model>
-  </define-assembly>
 
-  <define-assembly name="control-implementation" scope="local">
-    <formal-name>Control Implementation Set</formal-name>
-    <description>Defines how the component or capability supports a set of controls.</description>
-    <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>Control Implementation Set Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference a set of implemented controls elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>control implementation set</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <flag ref="source" required="yes">
-      <remarks>
-        <p>A URL reference to the source catalog or profile for which this component is implementing controls for.</p>
-      </remarks>
-    </flag>
-    <model>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Control Implementation Description</formal-name>
-        <description>A description of how the specified set of controls are implemented for the containing component or capability.</description>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="set-parameter" max-occurs="unbounded">
-        <group-as name="set-parameters" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="implemented-requirement" min-occurs="1" max-occurs="unbounded">
-        <group-as name="implemented-requirements" in-json="ARRAY"/>
-      </assembly>
-    </model>
-    <constraint>
-      <is-unique id="unique-component-definition-control-implementation-set-parameter" target="set-parameter">
-        <key-field target="@param-id"/>
+    <define-assembly name="capability">
+        <formal-name>Capability</formal-name>
+        <description>A grouping of other components and/or capabilities.</description>
+        <define-flag required="yes" name="uuid" as-type="uuid">
+            <formal-name>Capability Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this capability elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>capability</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <define-flag name="name" as-type="string" required="yes">
+            <formal-name>Capability Name</formal-name>
+            <description>The capability's human-readable name.</description>
+        </define-flag>
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Capability Description</formal-name>
+                <description>A summary of the capability.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="incorporates-component" max-occurs="unbounded">
+                <group-as name="incorporates-components" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="control-implementation" max-occurs="unbounded">
+                <group-as name="control-implementations" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <is-unique id="unique-component-definition-capability-incorporates-component" target="incorporates-component">
+                <key-field target="@component-uuid"></key-field>
+                <remarks>
+                    <p>A given <code>component</code> must not be referenced more than once within the same <code>capability</code>.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
+    <define-assembly name="incorporates-component">
+        <formal-name>Incorporates Component</formal-name>
+        <!-- TODO: needs a description -->
+        <description>TBD</description>
+        <define-flag required="yes" name="component-uuid" as-type="uuid">
+            <formal-name>Component Reference</formal-name>
+            <!-- Identifier Reference -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a <code>component</code>.</description>
+        </define-flag>
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Component Description</formal-name>
+                <description>A description of the component, including information about its function.</description>
+            </define-field>
+        </model>
+    </define-assembly>
+
+    <define-assembly name="control-implementation" scope="local">
+        <formal-name>Control Implementation Set</formal-name>
+        <description>Defines how the component or capability supports a set of controls.</description>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Control Implementation Set Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference a set of implemented controls elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>control implementation set</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <flag ref="source" required="yes">
+            <remarks>
+                <p>A URL reference to the source catalog or profile for which this component is implementing controls for.</p>
+            </remarks>
+        </flag>
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Control Implementation Description</formal-name>
+                <description>A description of how the specified set of controls are implemented for the containing component or capability.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="set-parameter" max-occurs="unbounded">
+                <group-as name="set-parameters" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="implemented-requirement" min-occurs="1" max-occurs="unbounded">
+                <group-as name="implemented-requirements" in-json="ARRAY"/>
+            </assembly>
+        </model>
+        <constraint>
+            <is-unique id="unique-component-definition-control-implementation-set-parameter" target="set-parameter">
+                <key-field target="@param-id"/>
+                <remarks>
+                    <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
         <remarks>
-          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+            <p>Use of <code>set-parameter</code> in this context, sets the parameter for all related controls referenced in an <code>implemented-requirement</code>. If the same parameter is also set in a specific <code>implemented-requirement</code>, then the new value will override this value.</p>
         </remarks>
-      </is-unique>
-    </constraint>
-    <remarks>
-      <p>Use of <code>set-parameter</code> in this context, sets the parameter for all related controls referenced in an <code>implemented-requirement</code>. If the same parameter is also set in a specific <code>implemented-requirement</code>, then the new value will override this value.</p>
-    </remarks>
-  </define-assembly>
-  <define-assembly name="implemented-requirement" scope="local">
-    <formal-name>Control Implementation</formal-name>
-    <description>Describes how the containing component or capability implements an individual control.</description>
-    <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>Control Implementation Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference a specific control implementation elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>control implementation</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <flag ref="control-id" required="yes"/>
-    <model>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Control Implementation Description</formal-name>
-        <description>A description of how the specified control is implemented for the containing component or capability.</description>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="set-parameter" max-occurs="unbounded">
-        <group-as name="set-parameters" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="responsible-role" max-occurs="unbounded">
-        <group-as name="responsible-roles" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="statement" max-occurs="unbounded">
-        <group-as name="statements" in-json="ARRAY"/>
-      </assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <is-unique id="unique-component-definition-implemented-requirement-set-parameter" target="set-parameter">
-        <key-field target="@param-id"/>
-        <remarks>
-          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
-        </remarks>
-      </is-unique>
-      <is-unique id="unique-component-definition-implemented-requirement-responsible-role" target="responsible-role">
-        <key-field target="@role-id"/>
-        <remarks>
-          <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-        </remarks>
-      </is-unique>
-      <is-unique id="unique-component-definition-implemented-requirement-statement" target="statement">
-        <key-field target="@statement-id"/>
-        <remarks>
-          <p>Since <code>statement</code> entries can be referenced using the statement's statement-id, each statement must be referenced only once.</p>
-        </remarks>
-      </is-unique>
-    </constraint>
-  </define-assembly>
-  <define-assembly name="statement" scope="local">
-    <formal-name>Control Statement Implementation</formal-name>
-    <description>Identifies which statements within a control are addressed.</description>
-    <flag ref="statement-id" required="yes">
-      <remarks>
-        <p>A reference to the specific implemented statement associated with a control.</p>
-      </remarks>
-    </flag>
-    <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>Control Statement Reference Universally Unique Identifier</formal-name>
-      <!-- Identifier Reference -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this control statement elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The <em>UUID</em> of the <code>control statement</code> in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).</description>
-    </define-flag>
-    <model>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Statement Implementation Description</formal-name>
-        <description>A summary of how the containing control statement is implemented by the component or capability.</description>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="responsible-role" max-occurs="unbounded">
-        <group-as name="responsible-roles" in-json="ARRAY"/>
-      </assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <is-unique id="unique-component-definition-statement-responsible-role" target="responsible-role">
-        <key-field target="@role-id"/>
-        <remarks>
-          <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-        </remarks>
-      </is-unique>
-    </constraint>
-  </define-assembly>
+    </define-assembly>
+    <define-assembly name="implemented-requirement" scope="local">
+        <formal-name>Control Implementation</formal-name>
+        <description>Describes how the containing component or capability implements an individual control.</description>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Control Implementation Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference a specific control implementation elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>control implementation</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <flag ref="control-id" required="yes"/>
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Control Implementation Description</formal-name>
+                <description>A description of how the specified control is implemented for the containing component or capability.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="set-parameter" max-occurs="unbounded">
+                <group-as name="set-parameters" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="responsible-role" max-occurs="unbounded">
+                <group-as name="responsible-roles" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="statement" max-occurs="unbounded">
+                <group-as name="statements" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <is-unique id="unique-component-definition-implemented-requirement-set-parameter" target="set-parameter">
+                <key-field target="@param-id"/>
+                <remarks>
+                    <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+                </remarks>
+            </is-unique>
+            <is-unique id="unique-component-definition-implemented-requirement-responsible-role" target="responsible-role">
+                <key-field target="@role-id"/>
+                <remarks>
+                    <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+            <is-unique id="unique-component-definition-implemented-requirement-statement" target="statement">
+                <key-field target="@statement-id"/>
+                <remarks>
+                    <p>Since <code>statement</code> entries can be referenced using the statement's statement-id, each statement must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
+    <define-assembly name="statement" scope="local">
+        <formal-name>Control Statement Implementation</formal-name>
+        <description>Identifies which statements within a control are addressed.</description>
+        <flag ref="statement-id" required="yes">
+            <remarks>
+                <p>A reference to the specific implemented statement associated with a control.</p>
+            </remarks>
+        </flag>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Control Statement Reference Universally Unique Identifier</formal-name>
+            <!-- Identifier Reference -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this control statement elsewhere in <a href="/concepts/identifier-use/#component-definition-identifiers">this or other OSCAL instances</a>. The <em>UUID</em> of the <code>control statement</code> in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).</description>
+        </define-flag>
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Statement Implementation Description</formal-name>
+                <description>A summary of how the containing control statement is implemented by the component or capability.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="responsible-role" max-occurs="unbounded">
+                <group-as name="responsible-roles" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <is-unique id="unique-component-definition-statement-responsible-role" target="responsible-role">
+                <key-field target="@role-id"/>
+                <remarks>
+                    <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
 </METASCHEMA>

--- a/src/metaschema/oscal_control-common_metaschema.xml
+++ b/src/metaschema/oscal_control-common_metaschema.xml
@@ -73,6 +73,15 @@
                         <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
             &allowed-values-control-group-property-name;
                         </allowed-values>
+                        <allowed-values target=".[@name='assessment']/prop/@name" allow-other="yes">
+                                <enum value="method">The assessment method to use. This typically appears on parts with the name "assessment".</enum>
+                        </allowed-values>
+                        <has-cardinality target=".[@name='assessment']/prop[@name='method']" min-occurs="1"/>
+                        <allowed-values target=".[@name='assessment']/prop[@name='method']/@value">
+                                <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
+                                <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
+                                <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
+                        </allowed-values>
                 </constraint>
                 <remarks>
                         <p>A <code>part</code> provides for logical partitioning of prose, and can be thought of as a grouping structure (e.g., section). A <code>part</code> can have child parts allowing for arbitrary nesting of prose content (e.g., statement hierarchy). A <code>part</code> can contain <code>prop</code> objects that allow for enriching prose text with structured name/value information.</p>

--- a/src/metaschema/oscal_control-common_metaschema.xml
+++ b/src/metaschema/oscal_control-common_metaschema.xml
@@ -6,275 +6,275 @@
    <!ENTITY allowed-values-control-group-property-name SYSTEM "./shared-constraints/allowed-values-control-group-property-name.ent">
 ]>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd" abstract="yes">
-        <schema-name>OSCAL Control Catalog Format -- Common Models</schema-name>
-        <schema-version>1.0.1</schema-version>
-        <short-name>oscal-catalog-common</short-name>
-        <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
-        <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
-        <import href="oscal_metadata_metaschema.xml"/>
-        <!-- ######################################## -->
-        <!-- # Part Assembly and related constructs # -->
-        <!-- ######################################## -->
-        <define-assembly name="part">
-                <formal-name>Part</formal-name>
-                <description>A partition of a control's definition or a child of another part.</description>
-                <define-flag name="id" as-type="token">
-                        <!-- This is an id because the idenfier is intended to be human-readable. -->
-                        <formal-name>Part Identifier</formal-name>
-                        <!-- Identifier Declaration -->
-                        <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined part elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. When referenced from another OSCAL instance, this identifier must be referenced in the context of the containing resource (e.g., import-profile). This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-                </define-flag>
-                <define-flag name="name" as-type="token" required="yes">
-                        <formal-name>Part Name</formal-name>
-                        <description>A textual label that uniquely identifies the part's semantic type.</description>
-                </define-flag>
-                <define-flag name="ns" as-type="uri">
-                        <!-- CHANGED: data type to uri -->
-                        <formal-name>Part Namespace</formal-name>
-                        <description>A namespace qualifying the part's name. This allows different organizations to associate distinct semantics with the same name.</description>
-                        <remarks>
-                                <p>Provides a means to segment the value space for the <code>name</code>, so that different organizations and individuals can assert control over the allowed names and associated text used in a part. This allows the semantics associated with a given name to be defined on an organization-by-organization basis.</p>
-                                <p>An organization MUST use a URI that they have control over. e.g., a domain registered to the organization in a URI, a registered uniform resource names (URN) namespace.</p>
-                                <p>When a <code>ns</code> is not provided, its value should be assumed to be <code>http://csrc.nist.gov/ns/oscal</code> and the name should be a name defined by the associated OSCAL model.</p>
-                        </remarks>
-                </define-flag>
-                <define-flag name="class" as-type="token">
-                        <formal-name>Part Class</formal-name>
-                        <description>A textual label that provides a sub-type or characterization of the part's <code>name</code>. This can be used to further distinguish or discriminate between the semantics of multiple parts of the same control with the same <code>name</code> and <code>ns</code>.
-                        </description>
-                        <remarks>
-                                <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
-                                <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
-                        </remarks>
-                </define-flag>
-                <model>
-                        <define-field name="title" as-type="markup-line">
-                                <formal-name>Part Title</formal-name>
-                                <description>A name given to the part, which may be used by a tool for display and navigation.</description>
-                        </define-field>
-                        <assembly ref="property" max-occurs="unbounded">
-                                <group-as name="props" in-json="ARRAY"/>
-                        </assembly>
-                        <define-field name="prose" as-type="markup-multiline" in-xml="UNWRAPPED">
-                                <formal-name>Part Text</formal-name>
-                                <description>Permits multiple paragraphs, lists, tables etc.</description>
-                        </define-field>
-                        <assembly ref="part" max-occurs="unbounded">
-                                <group-as name="parts" in-json="ARRAY"/>
-                        </assembly>
-                        <assembly ref="link" max-occurs="unbounded">
-                                <group-as name="links" in-json="ARRAY"/>
-                        </assembly>
-                        <!-- <any/> -->
-                </model>
-                <constraint>
-                        <!-- CHANGE: added allowed values for a property/@name -->
-                        <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-            &allowed-values-control-group-property-name;
-                        </allowed-values>
-<!--                        <allowed-values target=".[@name='assessment']/prop/@name" allow-other="yes">
-                                <enum value="method">The assessment method to use. This typically appears on parts with the name "assessment".</enum>
-                        </allowed-values>
-                        <has-cardinality target=".[@name='assessment']/prop[@name='method']" min-occurs="1"/>
-                        <allowed-values target=".[@name='assessment']/prop[@name='method']/@value">
-                                <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
-                                <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
-                                <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
-                        </allowed-values>
--->                </constraint>
-                <remarks>
-                        <p>A <code>part</code> provides for logical partitioning of prose, and can be thought of as a grouping structure (e.g., section). A <code>part</code> can have child parts allowing for arbitrary nesting of prose content (e.g., statement hierarchy). A <code>part</code> can contain <code>prop</code> objects that allow for enriching prose text with structured name/value information.</p>
-                        <p>A <code>part</code> can be assigned an optional <code>id</code>, which allows for internal and external references to the textual concept contained within a <code>part</code>. A <code>id</code> provides a means for an OSCAL profile, or a higher layer OSCAL model to reference a specific part within a <code>catalog</code>. For example, an <code>id</code> can be used to reference or to make modifications to a control statement in a profile.</p>
-                        <p>Use of <code>part</code> and <code>prop</code> provides for a wide degree of extensibility within the OSCAL catalog model. The optional <code>ns</code> provides a means to qualify a part's <code>name</code>, allowing for organization-specific vocabularies to be defined with clear semantics. Any organization that extends OSCAL in this way should consistently assign a <code>ns</code> value that represents the organization, making a given namespace qualified <code>name</code> unique to that organization. This allows the combination of <code>ns</code> and <code>name</code> to always be unique and unambiguous, even when mixed with extensions from other organizations. Each organization is responsible for governance of their own extensions, and is strongly encouraged to publish their extensions as standards to their user community. If no <code>ns</code> is provided, the name is expected to be in the "OSCAL" namespace.</p>
-                        <p>To ensure a <code>ns</code> is unique to an organization and naming conflicts are avoided, a URI containing a DNS or other globally defined organization name should be used. For example, if FedRAMP and DoD both extend OSCAL, FedRAMP will use the <code>ns</code> "https://fedramp.gov", while DoD will use the <code>ns</code> "https://defense.gov" for any organization specific <code>name</code>.
-                        </p>
-                        <p>Tools that process OSCAL content are not required to interpret unrecognized OSCAL extensions; however, OSCAL compliant tools should not modify or remove unrecognized extensions, unless there is a compelling reason to do so, such as data sensitivity.</p>
-                </remarks>
-                <example>
-                        <description>Multiple Parts with Different Organization-Specific Names</description>
-                        <o:part xmlns:o="http://csrc.nist.gov/ns/oscal/example" name="statement" id="statement-A">
-                                <o:part ns="https://fedramp.gov" name="status" id="statement-A-FedRAMP">Something FedRAMP Cares About</o:part>
-                                <o:part ns="https://defense.gov" name="status" id="statement-A-DoD">Something DoD Cares About</o:part>
-                        </o:part>
-                </example>
-        </define-assembly>
-
-        <!-- ############################################# -->
-        <!-- # Parameter Assembly and related constructs # -->
-        <!-- ############################################# -->
-        <define-assembly name="parameter">
-                <formal-name>Parameter</formal-name>
-                <description>Parameters provide a mechanism for the dynamic assignment of value(s) in a control.</description>
-                <!-- It is worth it abbreviate "param" in XML, while keeping "parameters" in JSON. -->
-                <use-name>param</use-name>
-                <define-flag name="id" as-type="token" required="yes">
-                        <!-- This is an id because the idenfier is intended to be human-readable. -->
-                        <formal-name>Parameter Identifier</formal-name>
-                        <!-- Identifier Declaration -->
-                        <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined parameter elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. When referenced from another OSCAL instance, this identifier must be referenced in the context of the containing resource (e.g., import-profile). This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-                </define-flag>
-                <!-- TODO: What is the semantics of class here? -->
-                <define-flag name="class" as-type="token">
-                        <formal-name>Parameter Class</formal-name>
-                        <description>A textual label that provides a characterization of the parameter.</description>
-                        <remarks>
-                                <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
-                        </remarks>
-                </define-flag>
-                <define-flag name="depends-on" as-type="token" deprecated="1.0.1">
-                        <formal-name>Depends on</formal-name>
-                        <description>**(deprecated)** Another parameter invoking this one. This construct has been deprecated and should not be used.</description>
-                </define-flag>
-                <model>
-                        <assembly ref="property" max-occurs="unbounded">
-                                <group-as name="props" in-json="ARRAY"/>
-                        </assembly>
-                        <!-- CHANGE: relative order in sequence -->
-                        <assembly ref="link" max-occurs="unbounded">
-                                <group-as name="links" in-json="ARRAY"/>
-                        </assembly>
-                        <define-field name="label" as-type="markup-line">
-                                <formal-name>Parameter Label</formal-name>
-                                <description>A short, placeholder name for the parameter, which can be used as a substitute for a <code>value</code> if no value is assigned.</description>
-                                <remarks>
-                                        <p>The label value should be suitable for inline display in a rendered catalog.</p>
-                                </remarks>
-                        </define-field>
-                        <define-field name="usage" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-                                <formal-name>Parameter Usage Description</formal-name>
-                                <description>Describes the purpose and use of a parameter</description>
-                        </define-field>
-                        <assembly ref="parameter-constraint" max-occurs="unbounded">
-                                <use-name>constraint</use-name>
-                                <group-as name="constraints" in-json="ARRAY"/>
-                        </assembly>
-                        <assembly ref="parameter-guideline" max-occurs="unbounded">
-                                <use-name>guideline</use-name>
-                                <!-- CHANGED from "guidance" to "guidelines" -->
-                                <group-as name="guidelines" in-json="ARRAY"/>
-                        </assembly>
-                        <choice>
-                                <field ref="parameter-value" max-occurs="unbounded">
-                                        <!-- CHANGED cardinality to allow for multiple values -->
-                                        <use-name>value</use-name>
-                                        <group-as name="values" in-json="ARRAY"/>
-                                        <remarks>
-                                                <p>A set of values provided in a catalog can be redefined at any higher layer of OSCAL (e.g., Profile).</p>
-                                        </remarks>
-                                </field>
-                                <assembly ref="parameter-selection">
-                                        <use-name>select</use-name>
-                                        <remarks>
-                                                <p>A set of parameter value choices, that may be picked from to set the parameter value.</p>
-                                        </remarks>
-                                </assembly>
-                        </choice>
-                        <field ref="remarks" in-xml="WITH_WRAPPER"/>
-                        <!-- <any/> -->
-                </model>
-                <constraint>
-                        <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                                &allowed-values-control-group-property-name;
-                                <enum value="alt-label">An alternate to the value provided by the parameter's label. This will typically be qualified by a class.</enum>
-                        </allowed-values>
-                        <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/rmf')]/@name">
-                                <enum value="aggregates">The parent parameter provides an aggregation of 2 or more other parameters, each described by this property.</enum>
-                        </allowed-values>
-                        <expect target="." test="not(exists(@depends-on))">
-                                <message>depends-on is deprecated</message>
-                        </expect>
-                </constraint>
-                <remarks>
-                        <p>In a catalog, a parameter is typically used as a placeholder for the future assignment of a parameter value, although the OSCAL model allows for the direct assignment of a value if desired by the control author. The <code>value</code> may be optionally used to specify one or more values. If no value is provided, then it is expected that the value will be provided at the Profile or Implementation layer.</p>
-                        <p>A parameter can include a variety of metadata options that support the future solicitation of one or more values. A <code>label</code> provides a textual placeholder that can be used in a tool to solicit parameter value input, or to display in catalog documentation. The <code>desc</code> provides a short description of what the parameter is used for, which can be used in tooling to help a user understand how to use the parameter. A <code>constraint</code> can be used to provide criteria for the allowed values. A <code>guideline</code> provides a recommendation for the use of a parameter.</p>
-                </remarks>
-        </define-assembly>
-
-        <define-assembly name="parameter-constraint">
-                <!-- CHANGED from field to assembly to allow for future extension -->
-                <formal-name>Constraint</formal-name>
-                <description>A formal or informal expression of a constraint or test</description>
-                <model>
-                        <!-- CHANGED: renamed "detail" to "description" -->
-                        <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-                                <formal-name>Constraint Description</formal-name>
-                                <description>A textual summary of the constraint to be applied.</description>
-                        </define-field>
-                        <!-- CHANGED from flag to assembly to allow for future extension -->
-                        <define-assembly name="test" max-occurs="unbounded">
-                                <formal-name>Constraint Test</formal-name>
-                                <description>A test expression which is expected to be evaluated by a tool.</description>
-                                <group-as name="tests" in-json="ARRAY"/>
-                                <model>
-                                        <define-field name="expression" as-type="string" min-occurs="1">
-                                                <formal-name>Constraint test</formal-name>
-                                                <description>A formal (executable) expression of a constraint</description>
-                                        </define-field>
-                                        <field ref="remarks" in-xml="WITH_WRAPPER"/>
-                                </model>
-                        </define-assembly>
-                </model>
-        </define-assembly>
-        <define-assembly name="parameter-guideline">
-                <formal-name>Guideline</formal-name>
-                <description>A prose statement that provides a recommendation for the use of a parameter.</description>
-                <model>
-                        <define-field name="prose" as-type="markup-multiline" in-xml="UNWRAPPED" min-occurs="1">
-                                <formal-name>Guideline Text</formal-name>
-                                <description>Prose permits multiple paragraphs, lists, tables etc.</description>
-                        </define-field>
-                        <!-- <any/> -->
-                </model>
-        </define-assembly>
-
-        <define-field name="parameter-value">
-                <!-- CHANGED type from "markup-line" to "string" since this is intended to be a scalar value -->
-                <formal-name>Parameter Value</formal-name>
-                <description>A parameter value or set of values.</description>
-        </define-field>
-
-        <define-assembly name="parameter-selection">
-                <formal-name>Selection</formal-name>
-                <description>Presenting a choice among alternatives</description>
-                <define-flag name="how-many" as-type="token">
-                        <formal-name>Parameter Cardinality</formal-name>
-                        <description>Describes the number of selections that must occur. Without this setting, only one value should be assumed to be permitted.</description>
-                        <constraint>
-                                <allowed-values allow-other="no">
-                                        <enum value="one">Only one value is permitted.</enum>
-                                        <enum value="one-or-more">One or more values are permitted.</enum>
-                                </allowed-values>
-                        </constraint>
-                </define-flag>
-                <model>
-                        <define-field name="parameter-choice" as-type="markup-line" max-occurs="unbounded">
-                                <formal-name>Choice</formal-name>
-                                <description>A value selection among several such options</description>
-                                <use-name>choice</use-name>
-                                <json-value-key>value</json-value-key>
-                                <!-- CHANGED "alternatives" to "choices" -->
-                                <group-as name="choice" in-json="ARRAY"/>
-                        </define-field>
-                        <!-- <any/> -->
-                </model>
-                <remarks>
-                        <p>A set of parameter value choices, that may be picked from to set the parameter value.</p>
-                </remarks>
-        </define-assembly>
-        <!-- ############################## -->
-        <!-- # Control-related constructs # -->
-        <!-- ############################## -->
-        <define-flag name="control-id" as-type="token">
-                <formal-name>Control Identifier Reference</formal-name>
-                <!-- Identifier Reference -->
-                <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a> identifier reference to a control with a corresponding <code>id</code> value. When referencing an externally defined <code>control</code>, the <code>Control Identifier Reference</code> must be used in the context of the external / imported OSCAL instance (e.g., uri-reference).</description>
+    xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd" abstract="yes">
+    <schema-name>OSCAL Control Catalog Format -- Common Models</schema-name>
+    <schema-version>1.0.1</schema-version>
+    <short-name>oscal-catalog-common</short-name>
+    <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
+    <import href="oscal_metadata_metaschema.xml"/>
+    <!-- ######################################## -->
+    <!-- # Part Assembly and related constructs # -->
+    <!-- ######################################## -->
+    <define-assembly name="part">
+        <formal-name>Part</formal-name>
+        <description>A partition of a control's definition or a child of another part.</description>
+        <define-flag name="id" as-type="token">
+            <!-- This is an id because the idenfier is intended to be human-readable. -->
+            <formal-name>Part Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined part elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. When referenced from another OSCAL instance, this identifier must be referenced in the context of the containing resource (e.g., import-profile). This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
         </define-flag>
-        <define-assembly name="include-all">
-                <formal-name>Include All</formal-name>
-                <description>Include all controls from the imported catalog or profile resources.</description>
+        <define-flag name="name" as-type="token" required="yes">
+            <formal-name>Part Name</formal-name>
+            <description>A textual label that uniquely identifies the part's semantic type.</description>
+        </define-flag>
+        <define-flag name="ns" as-type="uri">
+            <!-- CHANGED: data type to uri -->
+            <formal-name>Part Namespace</formal-name>
+            <description>A namespace qualifying the part's name. This allows different organizations to associate distinct semantics with the same name.</description>
+            <remarks>
+                <p>Provides a means to segment the value space for the <code>name</code>, so that different organizations and individuals can assert control over the allowed names and associated text used in a part. This allows the semantics associated with a given name to be defined on an organization-by-organization basis.</p>
+                <p>An organization MUST use a URI that they have control over. e.g., a domain registered to the organization in a URI, a registered uniform resource names (URN) namespace.</p>
+                <p>When a <code>ns</code> is not provided, its value should be assumed to be <code>http://csrc.nist.gov/ns/oscal</code> and the name should be a name defined by the associated OSCAL model.</p>
+            </remarks>
+        </define-flag>
+        <define-flag name="class" as-type="token">
+            <formal-name>Part Class</formal-name>
+            <description>A textual label that provides a sub-type or characterization of the part's <code>name</code>. This can be used to further distinguish or discriminate between the semantics of multiple parts of the same control with the same <code>name</code> and <code>ns</code>.
+            </description>
+            <remarks>
+                <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
+                <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
+            </remarks>
+        </define-flag>
+        <model>
+            <define-field name="title" as-type="markup-line">
+                <formal-name>Part Title</formal-name>
+                <description>A name given to the part, which may be used by a tool for display and navigation.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <define-field name="prose" as-type="markup-multiline" in-xml="UNWRAPPED">
+                <formal-name>Part Text</formal-name>
+                <description>Permits multiple paragraphs, lists, tables etc.</description>
+            </define-field>
+            <assembly ref="part" max-occurs="unbounded">
+                <group-as name="parts" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <!-- <any/> -->
+        </model>
+        <constraint>
+            <!-- CHANGE: added allowed values for a property/@name -->
+            <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+        &allowed-values-control-group-property-name;
+            </allowed-values>
+<!--            <allowed-values target=".[@name='assessment']/prop/@name" allow-other="yes">
+                <enum value="method">The assessment method to use. This typically appears on parts with the name "assessment".</enum>
+            </allowed-values>
+            <has-cardinality target=".[@name='assessment']/prop[@name='method']" min-occurs="1"/>
+            <allowed-values target=".[@name='assessment']/prop[@name='method']/@value">
+                <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
+                <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
+                <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
+            </allowed-values>
+-->        </constraint>
+        <remarks>
+            <p>A <code>part</code> provides for logical partitioning of prose, and can be thought of as a grouping structure (e.g., section). A <code>part</code> can have child parts allowing for arbitrary nesting of prose content (e.g., statement hierarchy). A <code>part</code> can contain <code>prop</code> objects that allow for enriching prose text with structured name/value information.</p>
+            <p>A <code>part</code> can be assigned an optional <code>id</code>, which allows for internal and external references to the textual concept contained within a <code>part</code>. A <code>id</code> provides a means for an OSCAL profile, or a higher layer OSCAL model to reference a specific part within a <code>catalog</code>. For example, an <code>id</code> can be used to reference or to make modifications to a control statement in a profile.</p>
+            <p>Use of <code>part</code> and <code>prop</code> provides for a wide degree of extensibility within the OSCAL catalog model. The optional <code>ns</code> provides a means to qualify a part's <code>name</code>, allowing for organization-specific vocabularies to be defined with clear semantics. Any organization that extends OSCAL in this way should consistently assign a <code>ns</code> value that represents the organization, making a given namespace qualified <code>name</code> unique to that organization. This allows the combination of <code>ns</code> and <code>name</code> to always be unique and unambiguous, even when mixed with extensions from other organizations. Each organization is responsible for governance of their own extensions, and is strongly encouraged to publish their extensions as standards to their user community. If no <code>ns</code> is provided, the name is expected to be in the "OSCAL" namespace.</p>
+            <p>To ensure a <code>ns</code> is unique to an organization and naming conflicts are avoided, a URI containing a DNS or other globally defined organization name should be used. For example, if FedRAMP and DoD both extend OSCAL, FedRAMP will use the <code>ns</code> "https://fedramp.gov", while DoD will use the <code>ns</code> "https://defense.gov" for any organization specific <code>name</code>.
+            </p>
+            <p>Tools that process OSCAL content are not required to interpret unrecognized OSCAL extensions; however, OSCAL compliant tools should not modify or remove unrecognized extensions, unless there is a compelling reason to do so, such as data sensitivity.</p>
+        </remarks>
+        <example>
+            <description>Multiple Parts with Different Organization-Specific Names</description>
+            <o:part xmlns:o="http://csrc.nist.gov/ns/oscal/example" name="statement" id="statement-A">
+                <o:part ns="https://fedramp.gov" name="status" id="statement-A-FedRAMP">Something FedRAMP Cares About</o:part>
+                <o:part ns="https://defense.gov" name="status" id="statement-A-DoD">Something DoD Cares About</o:part>
+            </o:part>
+        </example>
+    </define-assembly>
+
+    <!-- ############################################# -->
+    <!-- # Parameter Assembly and related constructs # -->
+    <!-- ############################################# -->
+    <define-assembly name="parameter">
+        <formal-name>Parameter</formal-name>
+        <description>Parameters provide a mechanism for the dynamic assignment of value(s) in a control.</description>
+        <!-- It is worth it abbreviate "param" in XML, while keeping "parameters" in JSON. -->
+        <use-name>param</use-name>
+        <define-flag name="id" as-type="token" required="yes">
+            <!-- This is an id because the idenfier is intended to be human-readable. -->
+            <formal-name>Parameter Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined parameter elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. When referenced from another OSCAL instance, this identifier must be referenced in the context of the containing resource (e.g., import-profile). This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <!-- TODO: What is the semantics of class here? -->
+        <define-flag name="class" as-type="token">
+            <formal-name>Parameter Class</formal-name>
+            <description>A textual label that provides a characterization of the parameter.</description>
+            <remarks>
+                <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
+            </remarks>
+        </define-flag>
+        <define-flag name="depends-on" as-type="token" deprecated="1.0.1">
+            <formal-name>Depends on</formal-name>
+            <description>**(deprecated)** Another parameter invoking this one. This construct has been deprecated and should not be used.</description>
+        </define-flag>
+        <model>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <!-- CHANGE: relative order in sequence -->
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <define-field name="label" as-type="markup-line">
+                <formal-name>Parameter Label</formal-name>
+                <description>A short, placeholder name for the parameter, which can be used as a substitute for a <code>value</code> if no value is assigned.</description>
                 <remarks>
-                        <p>This element provides an alternative to calling controls individually from a catalog.</p>
+                    <p>The label value should be suitable for inline display in a rendered catalog.</p>
                 </remarks>
-        </define-assembly>
+            </define-field>
+            <define-field name="usage" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                <formal-name>Parameter Usage Description</formal-name>
+                <description>Describes the purpose and use of a parameter</description>
+            </define-field>
+            <assembly ref="parameter-constraint" max-occurs="unbounded">
+                <use-name>constraint</use-name>
+                <group-as name="constraints" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="parameter-guideline" max-occurs="unbounded">
+                <use-name>guideline</use-name>
+                <!-- CHANGED from "guidance" to "guidelines" -->
+                <group-as name="guidelines" in-json="ARRAY"/>
+            </assembly>
+            <choice>
+                <field ref="parameter-value" max-occurs="unbounded">
+                    <!-- CHANGED cardinality to allow for multiple values -->
+                    <use-name>value</use-name>
+                    <group-as name="values" in-json="ARRAY"/>
+                    <remarks>
+                        <p>A set of values provided in a catalog can be redefined at any higher layer of OSCAL (e.g., Profile).</p>
+                    </remarks>
+                </field>
+                <assembly ref="parameter-selection">
+                    <use-name>select</use-name>
+                    <remarks>
+                        <p>A set of parameter value choices, that may be picked from to set the parameter value.</p>
+                    </remarks>
+                </assembly>
+            </choice>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+            <!-- <any/> -->
+        </model>
+        <constraint>
+            <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                &allowed-values-control-group-property-name;
+                <enum value="alt-label">An alternate to the value provided by the parameter's label. This will typically be qualified by a class.</enum>
+            </allowed-values>
+            <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/rmf')]/@name">
+                <enum value="aggregates">The parent parameter provides an aggregation of 2 or more other parameters, each described by this property.</enum>
+            </allowed-values>
+            <expect target="." test="not(exists(@depends-on))">
+                <message>depends-on is deprecated</message>
+            </expect>
+        </constraint>
+        <remarks>
+            <p>In a catalog, a parameter is typically used as a placeholder for the future assignment of a parameter value, although the OSCAL model allows for the direct assignment of a value if desired by the control author. The <code>value</code> may be optionally used to specify one or more values. If no value is provided, then it is expected that the value will be provided at the Profile or Implementation layer.</p>
+            <p>A parameter can include a variety of metadata options that support the future solicitation of one or more values. A <code>label</code> provides a textual placeholder that can be used in a tool to solicit parameter value input, or to display in catalog documentation. The <code>desc</code> provides a short description of what the parameter is used for, which can be used in tooling to help a user understand how to use the parameter. A <code>constraint</code> can be used to provide criteria for the allowed values. A <code>guideline</code> provides a recommendation for the use of a parameter.</p>
+        </remarks>
+    </define-assembly>
+
+    <define-assembly name="parameter-constraint">
+        <!-- CHANGED from field to assembly to allow for future extension -->
+        <formal-name>Constraint</formal-name>
+        <description>A formal or informal expression of a constraint or test</description>
+        <model>
+            <!-- CHANGED: renamed "detail" to "description" -->
+            <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                <formal-name>Constraint Description</formal-name>
+                <description>A textual summary of the constraint to be applied.</description>
+            </define-field>
+            <!-- CHANGED from flag to assembly to allow for future extension -->
+            <define-assembly name="test" max-occurs="unbounded">
+                <formal-name>Constraint Test</formal-name>
+                <description>A test expression which is expected to be evaluated by a tool.</description>
+                <group-as name="tests" in-json="ARRAY"/>
+                <model>
+                    <define-field name="expression" as-type="string" min-occurs="1">
+                        <formal-name>Constraint test</formal-name>
+                        <description>A formal (executable) expression of a constraint</description>
+                    </define-field>
+                    <field ref="remarks" in-xml="WITH_WRAPPER"/>
+                </model>
+            </define-assembly>
+        </model>
+    </define-assembly>
+    <define-assembly name="parameter-guideline">
+        <formal-name>Guideline</formal-name>
+        <description>A prose statement that provides a recommendation for the use of a parameter.</description>
+        <model>
+            <define-field name="prose" as-type="markup-multiline" in-xml="UNWRAPPED" min-occurs="1">
+                <formal-name>Guideline Text</formal-name>
+                <description>Prose permits multiple paragraphs, lists, tables etc.</description>
+            </define-field>
+            <!-- <any/> -->
+        </model>
+    </define-assembly>
+
+    <define-field name="parameter-value">
+        <!-- CHANGED type from "markup-line" to "string" since this is intended to be a scalar value -->
+        <formal-name>Parameter Value</formal-name>
+        <description>A parameter value or set of values.</description>
+    </define-field>
+
+    <define-assembly name="parameter-selection">
+        <formal-name>Selection</formal-name>
+        <description>Presenting a choice among alternatives</description>
+        <define-flag name="how-many" as-type="token">
+            <formal-name>Parameter Cardinality</formal-name>
+            <description>Describes the number of selections that must occur. Without this setting, only one value should be assumed to be permitted.</description>
+            <constraint>
+                <allowed-values allow-other="no">
+                    <enum value="one">Only one value is permitted.</enum>
+                    <enum value="one-or-more">One or more values are permitted.</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+        <model>
+            <define-field name="parameter-choice" as-type="markup-line" max-occurs="unbounded">
+                <formal-name>Choice</formal-name>
+                <description>A value selection among several such options</description>
+                <use-name>choice</use-name>
+                <json-value-key>value</json-value-key>
+                <!-- CHANGED "alternatives" to "choices" -->
+                <group-as name="choice" in-json="ARRAY"/>
+            </define-field>
+            <!-- <any/> -->
+        </model>
+        <remarks>
+            <p>A set of parameter value choices, that may be picked from to set the parameter value.</p>
+        </remarks>
+    </define-assembly>
+    <!-- ############################## -->
+    <!-- # Control-related constructs # -->
+    <!-- ############################## -->
+    <define-flag name="control-id" as-type="token">
+        <formal-name>Control Identifier Reference</formal-name>
+        <!-- Identifier Reference -->
+        <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a> identifier reference to a control with a corresponding <code>id</code> value. When referencing an externally defined <code>control</code>, the <code>Control Identifier Reference</code> must be used in the context of the external / imported OSCAL instance (e.g., uri-reference).</description>
+    </define-flag>
+    <define-assembly name="include-all">
+        <formal-name>Include All</formal-name>
+        <description>Include all controls from the imported catalog or profile resources.</description>
+        <remarks>
+            <p>This element provides an alternative to calling controls individually from a catalog.</p>
+        </remarks>
+    </define-assembly>
 </METASCHEMA>

--- a/src/metaschema/oscal_control-common_metaschema.xml
+++ b/src/metaschema/oscal_control-common_metaschema.xml
@@ -73,7 +73,7 @@
                         <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
             &allowed-values-control-group-property-name;
                         </allowed-values>
-                        <allowed-values target=".[@name='assessment']/prop/@name" allow-other="yes">
+<!--                        <allowed-values target=".[@name='assessment']/prop/@name" allow-other="yes">
                                 <enum value="method">The assessment method to use. This typically appears on parts with the name "assessment".</enum>
                         </allowed-values>
                         <has-cardinality target=".[@name='assessment']/prop[@name='method']" min-occurs="1"/>
@@ -82,7 +82,7 @@
                                 <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
                                 <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
                         </allowed-values>
-                </constraint>
+-->                </constraint>
                 <remarks>
                         <p>A <code>part</code> provides for logical partitioning of prose, and can be thought of as a grouping structure (e.g., section). A <code>part</code> can have child parts allowing for arbitrary nesting of prose content (e.g., statement hierarchy). A <code>part</code> can contain <code>prop</code> objects that allow for enriching prose text with structured name/value information.</p>
                         <p>A <code>part</code> can be assigned an optional <code>id</code>, which allows for internal and external references to the textual concept contained within a <code>part</code>. A <code>id</code> provides a means for an OSCAL profile, or a higher layer OSCAL model to reference a specific part within a <code>catalog</code>. For example, an <code>id</code> can be used to reference or to make modifications to a control statement in a profile.</p>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -1,694 +1,694 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../build/metaschema/toolchains/xslt-M4/validate/metaschema-composition-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <!DOCTYPE METASCHEMA [
-      <!ENTITY allowed-values-responsible-roles-operations SYSTEM "./shared-constraints/allowed-values-responsible-roles-operations.ent">
-      <!ENTITY allowed-values-responsible-roles-component-production SYSTEM "./shared-constraints/allowed-values-responsible-roles-component-production.ent">
-      <!ENTITY allowed-values-property-name-asset-type-values SYSTEM "./shared-constraints/allowed-values-property-name-asset-type-values.ent">
-      <!ENTITY allowed-values-component_component_property-name SYSTEM "./shared-constraints/allowed-values-component_component_property-name.ent">
-      <!ENTITY allowed-values-component_component_software SYSTEM "./shared-constraints/allowed-values-component_component_software.ent">
-      <!ENTITY allowed-values-component_component_service SYSTEM "./shared-constraints/allowed-values-component_component_service.ent">
-      <!ENTITY allowed-values-component_inventory-item_property-name SYSTEM "./shared-constraints/allowed-values-component_inventory-item_property-name.ent">
-      <!ENTITY allowed-values-component_component_link-rel SYSTEM "./shared-constraints/allowed-values-component_component_link-rel.ent">
-      <!ENTITY allowed-values-component-type SYSTEM "./shared-constraints/allowed-values-component-type.ent">
+    <!ENTITY allowed-values-responsible-roles-operations SYSTEM "./shared-constraints/allowed-values-responsible-roles-operations.ent">
+    <!ENTITY allowed-values-responsible-roles-component-production SYSTEM "./shared-constraints/allowed-values-responsible-roles-component-production.ent">
+    <!ENTITY allowed-values-property-name-asset-type-values SYSTEM "./shared-constraints/allowed-values-property-name-asset-type-values.ent">
+    <!ENTITY allowed-values-component_component_property-name SYSTEM "./shared-constraints/allowed-values-component_component_property-name.ent">
+    <!ENTITY allowed-values-component_component_software SYSTEM "./shared-constraints/allowed-values-component_component_software.ent">
+    <!ENTITY allowed-values-component_component_service SYSTEM "./shared-constraints/allowed-values-component_component_service.ent">
+    <!ENTITY allowed-values-component_inventory-item_property-name SYSTEM "./shared-constraints/allowed-values-component_inventory-item_property-name.ent">
+    <!ENTITY allowed-values-component_component_link-rel SYSTEM "./shared-constraints/allowed-values-component_component_link-rel.ent">
+    <!ENTITY allowed-values-component-type SYSTEM "./shared-constraints/allowed-values-component-type.ent">
 ]>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd" abstract="yes">
-      <schema-name>OSCAL Implementation Common Information</schema-name>
-      <schema-version>1.0.1</schema-version>
-      <short-name>oscal-implementation-common</short-name>
-      <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
-      <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
+    xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd" abstract="yes">
+    <schema-name>OSCAL Implementation Common Information</schema-name>
+    <schema-version>1.0.1</schema-version>
+    <short-name>oscal-implementation-common</short-name>
+    <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
 
-      <import href="oscal_metadata_metaschema.xml"/>
-      <import href="oscal_control-common_metaschema.xml"/>
-      
-      <!-- ################################################## -->
-      <!-- # The System Component and supporting constructs # -->
-      <!-- ################################################## -->
-      <define-assembly name="system-component">
-            <formal-name>Component</formal-name>
-            <description>A defined component that can be part of an implemented system.</description>
-            <define-flag name="uuid" as-type="uuid" required="yes">
-                  <formal-name>Component Identifier</formal-name>
-                  <!-- Identifier Declaration -->
-                  <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this component elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>component</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <flag ref="system-component-type" required="yes">
-                  <!-- CHANGED: "component-type" to "type" -->
-                  <use-name>type</use-name>
-            </flag>
-            <model>
-                  <define-field name="title" as-type="markup-line" min-occurs="1">
-                        <formal-name>Component Title</formal-name>
-                        <description>A human readable name for the system component.</description>
-                  </define-field>
-                  <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-                        <formal-name>Component Description</formal-name>
-                        <description>A description of the component, including information about its function.</description>
-                  </define-field>
-                  <define-field name="purpose" as-type="markup-line">
-                        <formal-name>Purpose</formal-name>
-                        <description>A summary of the technological or business purpose of the component.</description>
-                  </define-field>
-                  <assembly ref="property" max-occurs="unbounded">
-                        <group-as name="props" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="link" max-occurs="unbounded">
-                        <group-as name="links" in-json="ARRAY"/>
-                  </assembly>
-                  <define-assembly name="status" min-occurs="1">
-                        <formal-name>Status</formal-name>
-                        <description>Describes the operational status of the system component.</description>
-                        <define-flag name="state" as-type="token" required="yes">
-                              <formal-name>State</formal-name>
-                              <description>The operational status.</description>
-                              <constraint>
-                                    <allowed-values>
-                                          <enum value="under-development">The component is being designed, developed, or implemented.</enum>
-                                          <enum value="operational">The component is currently operational and is available for use in the system.</enum>
-                                          <enum value="disposition">The component is no longer operational.</enum>
-                                          <enum value="other">Some other state.</enum>
-                                    </allowed-values>
-                              </constraint>
-                        </define-flag>
-                        <model>
-                              <field ref="remarks" in-xml="WITH_WRAPPER"/>
-                        </model>
-                  </define-assembly>
-                  <assembly ref="responsible-role" max-occurs="unbounded">
-                        <group-as name="responsible-roles" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="protocol" max-occurs="unbounded">
-                        <group-as name="protocols" in-json="ARRAY"/>
-                        <remarks>
-                              <p>Used for <code>service</code> components to define the protocols supported by the service.</p>
-                        </remarks>
-                  </assembly>
-                  <field ref="remarks" in-xml="WITH_WRAPPER"/>
-            </model>
-            <constraint>
-                  <allowed-values target="prop/@name" allow-other="yes">
-                        <!-- names related to inherited component -->
-                        <enum value="implementation-point">Relative placement of component ('internal' or 'external') to the system.</enum>
-                        <enum value="leveraged-authorization-uuid">UUID of the related leveraged-authorization assembly in this SSP.</enum>
-                        <enum value="inherited-uuid">UUID of the component as it was assigned in the leveraged system's SSP.</enum>
+    <import href="oscal_metadata_metaschema.xml"/>
+    <import href="oscal_control-common_metaschema.xml"/>
 
-                        <!-- ========================================================================================================== -->
-                        <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
-                        <!-- CHANGED (BJR): Done -->
-                        <!-- ========================================================================================================== -->
-                        &allowed-values-component_inventory-item_property-name;
-
-                        &allowed-values-component_component_property-name;
-                  </allowed-values>
-
-                  <allowed-values target="link/@rel" allow-other="yes">
-                        <!-- ========================================================================================================== -->
-                        <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
-                        <!-- CHANGED (BJR): Done -->
-                        <!-- ========================================================================================================== -->
-            &allowed-values-component_component_link-rel;
-                        <enum value="uses-network">This component uses the network provided by the identified network component.</enum>
-                  </allowed-values>
-
-                  <allowed-values target="responsible-role/@role-id" allow-other="yes">
-                        <!-- ========================================================================================================== -->
-                        <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
-                        <!-- ========================================================================================================== -->
-            &allowed-values-responsible-roles-operations;
-            &allowed-values-responsible-roles-component-production;
-                  </allowed-values>
-
-                  <allowed-values target="prop[@name='asset-type']/@value">
-            &allowed-values-property-name-asset-type-values;
-                  </allowed-values>
-
-                  <allowed-values target="prop[@name='allows-authenticated-scan']/@value">
-                        <enum value="yes">The component allows an authenticated scan.</enum>
-                        <enum value="no">The component does not allow an authenticated scan.</enum>
-                  </allowed-values>
-
-                  <allowed-values target="prop[@name='public']/@value">
-                        <enum value="yes">The component is publicly accessible.</enum>
-                        <enum value="no">The component is not publicly accessible.</enum>
-                  </allowed-values>
-
-                  <allowed-values target="prop[@name='virtual']/@value">
-                        <enum value="yes">The component is virtualized.</enum>
-                        <enum value="no">The component is not virtualized.</enum>
-                  </allowed-values>
-
-                  <allowed-values target="prop[@name='implementation-point']/@value">
-                        <enum value="internal">The component is implemented within the system boundary.</enum>
-                        <enum value="external">The component is implemented outside the system boundary.</enum>
-                  </allowed-values>
-
-                  <index-has-key name="index-metadata-location-uuid" target="prop[@name='physical-location']">
-                        <key-field target="@value"/>
-                  </index-has-key>
-
-                  <matches target="prop[@name='inherited-uuid']/@value" datatype="uuid" />
-                  <matches target="prop[@name='release-date']/@value" datatype="date"/>
-
-                  <!-- ========================================================================================================== -->
-                  <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
-                  <!-- ========================================================================================================== -->
-
-                  <allowed-values target="(.)[@type=('software', 'hardware', 'service')]/prop/@name" allow-other="yes">
-                        <enum value="vendor-name">The name of the company or organization </enum>
-                  </allowed-values>
-
-                  <!-- TODO: Add ipv4-subnet property for type='network' - add pattern constraint -->
-                  <!-- TODO: Add ipv6-subnet property for type='network' - add pattern constraint -->
-
-                  <!-- ========================================================================================================== -->
-                  <!-- = VALIDATION: type='validation' constraints                        = -->
-                  <!-- ========================================================================================================== -->
-                  <allowed-values target="(.)[@type='validation']/link/@rel" allow-other="yes">
-                        <enum value="validation-details">A link to an online information provided by the authorizing body.</enum>
-                  </allowed-values>
-
-                  <!-- ========================================================================================================== -->
-                  <!-- = SOFTWARE: type='software' constraints                        = -->
-                  <!-- ========================================================================================================== -->
-                  <allowed-values target="(.)[@type='software']/prop/@name" allow-other="yes">
-            &allowed-values-component_component_software;
-                  </allowed-values>
-
-                  <!-- ========================================================================================================== -->
-                  <!-- = SERVICE: type='service' constraints                        = -->
-                  <!-- ========================================================================================================== -->
-                  <allowed-values target="(.)[@type='service']/link/@rel" allow-other="yes">
-            &allowed-values-component_component_service;
-                  </allowed-values>
-
-                  <expect target="." test="not(exists((.)[not(@type='service')]/protocol))"/>
-
-                  <!-- ========================================================================================================== -->
-                  <!-- = INTERCONNECTION: type='interconnection' constraints                        = -->
-                  <!-- ========================================================================================================== -->
-                  <allowed-values target="(.)[@type='interconnection']/prop/@name" allow-other="yes">
-                        <enum value="isa-title">Title of the Interconnection Security Agreement (ISA).</enum>
-                        <enum value="isa-date">Date of the Interconnection Security Agreement (ISA).</enum>
-                        <enum value="isa-remote-system-name">The name of the remote interconnected system.</enum>
-                        <enum value="ipv4-address">An Internet Protocol Version 4 interconnection address</enum>
-                        <enum value="ipv6-address">An Internet Protocol Version 6 interconnection address</enum>
-                        <enum value="direction">An Internet Protocol Version 6 interconnection address</enum>
-                  </allowed-values>
-                  <allowed-values target="prop[@name=('ipv4-address','ipv6-address')]/@class" allow-other="yes">
-                        <enum value="local">The identified IP address is for this system.</enum>
-                        <enum value="remote">The identified IP address is for the remote system to which this system is connected.</enum>
-                  </allowed-values>
-                  <allowed-values target="(.)[@type='interconnection']/link/@rel" allow-other="yes">
-                        <!-- CHANGE: @name="agreement" changed to @name="isa-agreement" -->
-                        <enum value="isa-agreement">A link to the system interconnection agreement.</enum>
-                  </allowed-values>
-                  <allowed-values target="(.)[@type='interconnection']/responsible-role/@role-id" allow-other="yes">
-                        <enum value="isa-poc-local">Interconnection Security Agreement (ISA) point of contact (POC) for this system.</enum>
-                        <enum value="isa-poc-remote">Interconnection Security Agreement (ISA) point of contact (POC) for the remote interconnected system.</enum>
-                        <enum value="isa-authorizing-official-local">Interconnection Security Agreement (ISA) authorizing official for this system.</enum>
-                        <enum value="isa-authorizing-official-remote">Interconnection Security Agreement (ISA) authorizing official for the remote interconnected system.</enum>
-                  </allowed-values>
-                  <matches target="prop[@name='isa-date']/@value" datatype="dateTime"/>
-                  <matches target="prop[@name='ipv4-address']/@value" datatype="ip-v4-address" />
-                  <matches target="prop[@name='ipv6-address']/@value" datatype="ip-v6-address" />
-                  <allowed-values target="prop[@name='direction']/@value" allow-other="yes">
-                        <enum value="incoming">Data from the remote system flows into this system.</enum>
-                        <enum value="outgoing">Data from this system flows to the remote system.</enum>
-                  </allowed-values>
-                  <is-unique id="unique-system-component-responsible-role" target="responsible-role">
-                        <key-field target="@role-id"/>
-                        <remarks>
-                              <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-                        </remarks>
-                  </is-unique>
-            </constraint>
-            <remarks>
-                  <p>Components may be products, services, application programming interface (APIs), policies, processes, plans, guidance, standards, or other tangible items that enable security and/or privacy.</p>
-                  <p>The <code>type</code> indicates which of these component types is represented.</p>
-                  <!-- <p>A group of components may be aggregated into a <code>capability</code>. For example, an account management capability that consists of an account management process, and a Lightweight Directory Access Protocol (LDAP) software implementation.</p>
-         <p>Capabilities are expressed by combining one or more components.</p>-->
-                  <p>When defining a <code>service</code> component where are relationship to other components is known, one or more <code>link</code> entries with rel values of provided-by and used-by can be used to link to the specific component identifier(s) that provide and use the service respectively.</p>
-            </remarks>
-      </define-assembly>
-
-      <define-flag name="system-component-type" as-type="string">
-            <formal-name>Component Type</formal-name>
-            <description>A category describing the purpose of the component.</description>
-            <constraint>
-                  <allowed-values allow-other="yes">
-                        <enum value="this-system">The system as a whole.</enum>
-                        <enum value="system">An external system, which may be a leveraged system or the other side of an interconnection.</enum>
-                        &allowed-values-component-type;
-                        <enum value="network">A physical or virtual network.</enum>
-                  </allowed-values>
-            </constraint>
-      </define-flag>
-
-      <define-assembly name="protocol">
-            <formal-name>Service Protocol Information</formal-name>
-            <description>Information about the protocol used to provide a service.</description>
-            <define-flag name="uuid" as-type="uuid">
-                  <formal-name>Service Protocol Information Universally Unique Identifier</formal-name>
-                  <!-- Identifier Declaration -->
-                  <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this service protocol information elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>service protocol</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <define-flag name="name" required="yes">
-                  <formal-name>Protocol Name</formal-name>
-                  <description>The common name of the protocol, which should be the appropriate "service name" from the <a href="https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml">IANA Service Name and Transport Protocol Port Number Registry</a>.
-                  </description>
-                  <remarks>
-                        <p>The short name of the protocol (e.g., https).</p>
-                  </remarks>
-            </define-flag>
-            <model>
-                  <define-field name="title" as-type="markup-line">
-            <formal-name>Protocol Title</formal-name>
-                        <description>A human readable name for the protocol (e.g., Transport Layer Security).</description>
-                  </define-field>
-                  <assembly ref="port-range" max-occurs="unbounded">
-                        <group-as name="port-ranges" in-json="ARRAY"/>
-                  </assembly>
-            </model>
-            <constraint>
-                  <expect level="WARNING" target="." test="@uuid">
-                        <message>It is a best practice to provide a UUID.</message>
-                  </expect>
-            </constraint>
-      </define-assembly>
-      <define-assembly name="port-range">
-            <formal-name>Port Range</formal-name>
-            <description>Where applicable this is the IPv4 port range on which the service operates.</description>
-            <define-flag name="start" as-type="nonNegativeInteger">
-                  <formal-name>Start</formal-name>
-                  <description>Indicates the starting port number in a port range</description>
-                  <remarks>
-                        <p>Should be a number within a permitted range</p>
-                  </remarks>
-            </define-flag>
-            <define-flag name="end" as-type="nonNegativeInteger">
-                  <formal-name>End</formal-name>
-                  <description>Indicates the ending port number in a port range</description>
-                  <remarks>
-                        <p>Should be a number within a permitted range</p>
-                  </remarks>
-            </define-flag>
-            <define-flag name="transport" as-type="token">
-                  <formal-name>Transport</formal-name>
-                  <description>Indicates the transport type.</description>
-                  <constraint>
+    <!-- ################################################## -->
+    <!-- # The System Component and supporting constructs # -->
+    <!-- ################################################## -->
+    <define-assembly name="system-component">
+        <formal-name>Component</formal-name>
+        <description>A defined component that can be part of an implemented system.</description>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Component Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this component elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>component</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <flag ref="system-component-type" required="yes">
+            <!-- CHANGED: "component-type" to "type" -->
+            <use-name>type</use-name>
+        </flag>
+        <model>
+            <define-field name="title" as-type="markup-line" min-occurs="1">
+                <formal-name>Component Title</formal-name>
+                <description>A human readable name for the system component.</description>
+            </define-field>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Component Description</formal-name>
+                <description>A description of the component, including information about its function.</description>
+            </define-field>
+            <define-field name="purpose" as-type="markup-line">
+                <formal-name>Purpose</formal-name>
+                <description>A summary of the technological or business purpose of the component.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <define-assembly name="status" min-occurs="1">
+                <formal-name>Status</formal-name>
+                <description>Describes the operational status of the system component.</description>
+                <define-flag name="state" as-type="token" required="yes">
+                    <formal-name>State</formal-name>
+                    <description>The operational status.</description>
+                    <constraint>
                         <allowed-values>
-                              <enum value="TCP">Transmission Control Protocol</enum>
-                              <enum value="UDP">User Datagram Protocol</enum>
+                            <enum value="under-development">The component is being designed, developed, or implemented.</enum>
+                            <enum value="operational">The component is currently operational and is available for use in the system.</enum>
+                            <enum value="disposition">The component is no longer operational.</enum>
+                            <enum value="other">Some other state.</enum>
                         </allowed-values>
-                  </constraint>
-            </define-flag>
-            <remarks>
-                  <p>To be validated as a natural number (integer &gt;= 1). A single port uses the same value for start and end. Use multiple 'port-range' entries for non-contiguous ranges.</p>
-            </remarks>
-            <example>
-                  <service xmlns="http://csrc.nist.gov/ns/oscal/example" id="svc-01" name="Domain Name Service (DNS) Lookup">
-                        <protocol name="dns">
-                              <port-range start="53" end="53" transport="tcp"/>
-                        </protocol>
-                  </service>
-            </example>
-      </define-assembly>
+                    </constraint>
+                </define-flag>
+                <model>
+                    <field ref="remarks" in-xml="WITH_WRAPPER"/>
+                </model>
+            </define-assembly>
+            <assembly ref="responsible-role" max-occurs="unbounded">
+                <group-as name="responsible-roles" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="protocol" max-occurs="unbounded">
+                <group-as name="protocols" in-json="ARRAY"/>
+                <remarks>
+                    <p>Used for <code>service</code> components to define the protocols supported by the service.</p>
+                </remarks>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <allowed-values target="prop/@name" allow-other="yes">
+                <!-- names related to inherited component -->
+                <enum value="implementation-point">Relative placement of component ('internal' or 'external') to the system.</enum>
+                <enum value="leveraged-authorization-uuid">UUID of the related leveraged-authorization assembly in this SSP.</enum>
+                <enum value="inherited-uuid">UUID of the component as it was assigned in the leveraged system's SSP.</enum>
 
-      <define-assembly name="implementation-status">
-            <formal-name>Implementation Status</formal-name>
-            <description>Indicates the degree to which the a given control is implemented.</description>
-            <define-flag name="state" as-type="token" required="yes">
-                  <formal-name>Implementation State</formal-name>
-                  <description>Identifies the implementation status of the control or control objective.</description>
-                  <constraint>
-                        <allowed-values allow-other="yes">
-                              <enum value="implemented">The control is fully implemented.</enum>
-                              <enum value="partial">The control is partially implemented.</enum>
-                              <enum value="planned">There is a plan for implementing the control as explained in the remarks.</enum>
-                              <enum value="alternative">There is an alternative implementation for this control as explained in the remarks.</enum>
-                              <enum value="not-applicable">This control does not apply to this system as justified in the remarks.</enum>
-                        </allowed-values>
-                  </constraint>
-            </define-flag>
-            <model>
-                  <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
-            </model>
-      </define-assembly>
+                <!-- ========================================================================================================== -->
+                <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
+                <!-- CHANGED (BJR): Done -->
+                <!-- ========================================================================================================== -->
+                &allowed-values-component_inventory-item_property-name;
 
-      <!-- ############################################# -->
-      <!-- # The System User and supporting constructs # -->
-      <!-- ############################################# -->
-      <define-assembly name="system-user">
-            <formal-name>System User</formal-name>
-            <description>A type of user that interacts with the system based on an associated role.</description>
-            <define-flag name="uuid" as-type="uuid" required="yes">
-                  <formal-name>User Universally Unique Identifier</formal-name>
-                  <!-- Identifier Declaration -->
-                  <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this user class elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>system user</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <model>
-                  <define-field name="title" as-type="markup-line">
-                        <formal-name>User Title</formal-name>
-                        <description>A name given to the user, which may be used by a tool for display and navigation.</description>
-                  </define-field>
-                  <define-field name="short-name">
-                        <formal-name>User Short Name</formal-name>
-                        <description>A short common name, abbreviation, or acronym for the user.</description>
-                  </define-field>
-                  <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-                        <formal-name>User Description</formal-name>
-                        <description>A summary of the user's purpose within the system.</description>
-                  </define-field>
-                  <assembly ref="property" max-occurs="unbounded">
-                        <group-as name="props" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="link" max-occurs="unbounded">
-                        <group-as name="links" in-json="ARRAY"/>
-                        <!-- TODO: Model specific link relationships?  (BJR - I don't think we need this now) -->
-                  </assembly>
-                  <field ref="role-id" min-occurs="0" max-occurs="unbounded">
-                        <group-as name="role-ids" in-json="ARRAY"/>
-                  </field>
-                  <assembly ref="authorized-privilege" max-occurs="unbounded">
-                        <group-as name="authorized-privileges" in-json="ARRAY"/>
-                  </assembly>
-                  <field ref="remarks" in-xml="WITH_WRAPPER"/>
-            </model>
-            <constraint>
-                  <allowed-values target="prop/@name" allow-other="yes">
-                        <enum value="type">The type of user, such as internal, external, or general-public.</enum>
-                        <enum value="privilege-level">The user's privilege level within the system, such as privileged, non-privileged, no-logical-access.</enum>
-                  </allowed-values>
-                  <allowed-values target="prop[@name='type']/@value">
-                        <enum value="internal">A user account for a person or entity that is part of the organization who owns or operates the system.</enum>
-                        <enum value="external">A user account for a person or entity that is not part of the organization who owns or operates the system.</enum>
-                        <enum value="general-public">A user of the system considered to be outside </enum>
-                  </allowed-values>
-                  <allowed-values target="prop[@name='privilege-level']/@value">
-                        <enum value="privileged">This role has elevated access to the system, such as a group or system administrator.</enum>
-                        <enum value="non-privileged">This role has typical user-level access to the system without elevated access.</enum>
-                        <enum value="no-logical-access">This role has no access to the system, such as a manager who approves access as part of a process.</enum>
-                  </allowed-values>
-                  <allowed-values target="role-id" allow-other="yes">
-            &allowed-values-responsible-roles-operations;
-                  </allowed-values>
-            </constraint>
-            <remarks>
-                  <p>Permissible values to be determined closer to the application, such as by a receiving authority.</p>
-            </remarks>
-      </define-assembly>
-      <define-assembly name="authorized-privilege">
-            <formal-name>Privilege</formal-name>
-            <description>Identifies a specific system privilege held by the user, along with an associated description and/or rationale for the privilege.</description>
-            <model>
-                  <define-field name="title" as-type="markup-line" min-occurs="1">
-            <formal-name>Privilege Title</formal-name>
-                        <description>A human readable name for the privilege.</description>
-                  </define-field>
-                  <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-                        <formal-name>Privilege Description</formal-name>
-                        <description>A summary of the privilege's purpose within the system.</description>
-                  </define-field>
-                  <field ref="function-performed" min-occurs="1" max-occurs="unbounded">
-                        <group-as name="functions-performed" in-json="ARRAY"/>
-                  </field>
-            </model>
-      </define-assembly>
-      <define-field name="function-performed" as-type="string">
-            <formal-name>Functions Performed</formal-name>
-            <description>Describes a function performed for a given authorized privilege by this user class.</description>
-      </define-field>
-
-      <!-- ################################################ -->
-      <!-- # The Inventory Item and supporting constructs # -->
-      <!-- ################################################ -->
-      <define-assembly name="inventory-item">
-            <formal-name>Inventory Item</formal-name>
-            <description>A single managed inventory item within the system.</description>
-            <!--      <json-key flag-name="uuid"/>
--->
-            <define-flag name="uuid" as-type="uuid" required="yes">
-                  <formal-name>Inventory Item Universally Unique Identifier</formal-name>
-                  <!-- Identifier Declaration -->
-                  <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this inventory item elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>inventory item</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <!-- CHANGED: Moved to property[@name='asset-id']. -->
-            <!--      <define-flag name="asset-id">
-         <!-\- This is an id because the idenfier is assigned and managed externally. -\->
-         <formal-name>Asset Identifier</formal-name>
-         <description>Organizational asset identifier that is unique in the context of the system. This may be a reference to the identifier used in an asset tracking system or a vulnerability scanning tool.</description>
-      </define-flag>  -->
-            <model>
-                  <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-                        <formal-name>Inventory Item Description</formal-name>
-                        <description>A summary of the inventory item stating its purpose within the system.</description>
-                  </define-field>
-                  <assembly ref="property" max-occurs="unbounded">
-                        <group-as name="props" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="link" max-occurs="unbounded">
-                        <group-as name="links" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="responsible-party" max-occurs="unbounded">
-                        <group-as name="responsible-parties" in-json="ARRAY"/>
-                  </assembly>
-                  <define-assembly name="implemented-component" max-occurs="unbounded">
-                        <!-- TODO: Sync constraints with system-component; maybe remove this? (CHANGED (BJR): Dave-See Gitter for details on this. -->
-                        <formal-name>Implemented Component</formal-name>
-                        <description>The set of components that are implemented in a given system inventory item.</description>
-                        <group-as name="implemented-components" in-json="ARRAY"/>
-
-                        <define-flag required="yes" name="component-uuid" as-type="uuid">
-                              <formal-name>Component Universally Unique Identifier Reference</formal-name>
-                              <!-- Identifier Reference -->
-                              <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a <code>component</code> that is implemented as part of an inventory item.</description>
-                        </define-flag>
-
-                        <!-- CHANGED (daw): the following is not needed since it is required on the referenced component -->
-                        <!--      <!-\- CHANGED (BJR): Added component-type for alignment with system-component -\->
-      <flag ref="component-type" required="yes" />
--->
-                        <!-- The following is commented because this is not being used and can be inferred based on the type of the component -->
-                        <!--
-      <define-flag name="use">
-         <formal-name>Implementation Use Type</formal-name>
-         <description>The type of implementation</description>
-         <constraint>
-            <allowed-values allow-other="yes">
-               <enum value="runs-software">The implemented component is a 'software' component that the inventory item has installed and uses.</enum>
-               <enum value="uses-hardware">The implemented component is a 'hardware' component that the inventory item has installed and uses.</enum>
-               <enum value="enforces-policy">The implemented component is a 'policy' component that the inventory item supports and enforces.</enum>
-               <enum value="implements-process">The implemented component is a 'process' component that the inventory item supports and enforces.</enum>
+                &allowed-values-component_component_property-name;
             </allowed-values>
-         </constraint>
-      </define-flag>
--->
-                        <model>
-                              <assembly ref="property" max-occurs="unbounded">
-                                    <group-as name="props" in-json="ARRAY"/>
-                              </assembly>
-                              <assembly ref="link" max-occurs="unbounded">
-                                    <group-as name="links" in-json="ARRAY"/>
-                              </assembly>
-                              <assembly ref="responsible-party" max-occurs="unbounded">
-                                    <group-as name="responsible-parties" in-json="ARRAY"/>
-                                    <remarks>
-                                          <p>This construct is used to either: 1) associate a party or parties to a role defined on the component using the <code>responsible-role</code> construct, or 2) to define a party or parties that are responsible for a role defined within the context of the containing <code>inventory-item</code>.
-                                          </p>
-                                    </remarks>
-                              </assembly>
-                              <field ref="remarks" in-xml="WITH_WRAPPER"/>
-                        </model>
-                        <constraint>
-                              <!-- TODO: constrain component-uuid references to components defined in the document. ((BJR): Was unsure how to do this.) -->
-                              <!-- TODO: constrain link href values based on rel ((BJR): Was unsure of how to do this.) -->
 
-                              <!-- TODO: constrain property values based on name (CHANGED (BJR): Done.) -->
-                              <allowed-values target="prop/@name" allow-other="yes">
-                  &allowed-values-component_component_property-name;
-                  &allowed-values-component_inventory-item_property-name;
+            <allowed-values target="link/@rel" allow-other="yes">
+                <!-- ========================================================================================================== -->
+                <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
+                <!-- CHANGED (BJR): Done -->
+                <!-- ========================================================================================================== -->
+        &allowed-values-component_component_link-rel;
+                <enum value="uses-network">This component uses the network provided by the identified network component.</enum>
+            </allowed-values>
 
-                              </allowed-values>
-                              <!-- ensure that at least one asset-id is provided -->
-                              <has-cardinality target="prop[@name='asset-id']" min-occurs="1"/>
+            <allowed-values target="responsible-role/@role-id" allow-other="yes">
+                <!-- ========================================================================================================== -->
+                <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
+                <!-- ========================================================================================================== -->
+        &allowed-values-responsible-roles-operations;
+        &allowed-values-responsible-roles-component-production;
+            </allowed-values>
 
+            <allowed-values target="prop[@name='asset-type']/@value">
+        &allowed-values-property-name-asset-type-values;
+            </allowed-values>
 
-                              <allowed-values target="responsible-party/@role-id" allow-other="yes">
-                  &allowed-values-responsible-roles-operations;
-                              </allowed-values>
+            <allowed-values target="prop[@name='allows-authenticated-scan']/@value">
+                <enum value="yes">The component allows an authenticated scan.</enum>
+                <enum value="no">The component does not allow an authenticated scan.</enum>
+            </allowed-values>
 
-                              <!-- TODO: constrain party-id references to parties defined in the document. (BJR Unsure how to do this. )-->
+            <allowed-values target="prop[@name='public']/@value">
+                <enum value="yes">The component is publicly accessible.</enum>
+                <enum value="no">The component is not publicly accessible.</enum>
+            </allowed-values>
 
-                              <is-unique id="unique-implemented-component-responsible-party" target="responsible-party">
-                                    <key-field target="@role-id"/>
-                                    <remarks>
-                                          <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-                                    </remarks>
-                              </is-unique>
-                        </constraint>
-                  </define-assembly>
-                  <field ref="remarks" in-xml="WITH_WRAPPER"/>
-            </model>
+            <allowed-values target="prop[@name='virtual']/@value">
+                <enum value="yes">The component is virtualized.</enum>
+                <enum value="no">The component is not virtualized.</enum>
+            </allowed-values>
+
+            <allowed-values target="prop[@name='implementation-point']/@value">
+                <enum value="internal">The component is implemented within the system boundary.</enum>
+                <enum value="external">The component is implemented outside the system boundary.</enum>
+            </allowed-values>
+
+            <index-has-key name="index-metadata-location-uuid" target="prop[@name='physical-location']">
+                <key-field target="@value"/>
+            </index-has-key>
+
+            <matches target="prop[@name='inherited-uuid']/@value" datatype="uuid" />
+            <matches target="prop[@name='release-date']/@value" datatype="date"/>
+
+            <!-- ========================================================================================================== -->
+            <!-- = Changes to the following values need to be synced with component in the SSP and component metaschemas. = -->
+            <!-- ========================================================================================================== -->
+
+            <allowed-values target="(.)[@type=('software', 'hardware', 'service')]/prop/@name" allow-other="yes">
+                <enum value="vendor-name">The name of the company or organization </enum>
+            </allowed-values>
+
+            <!-- TODO: Add ipv4-subnet property for type='network' - add pattern constraint -->
+            <!-- TODO: Add ipv6-subnet property for type='network' - add pattern constraint -->
+
+            <!-- ========================================================================================================== -->
+            <!-- = VALIDATION: type='validation' constraints                = -->
+            <!-- ========================================================================================================== -->
+            <allowed-values target="(.)[@type='validation']/link/@rel" allow-other="yes">
+                <enum value="validation-details">A link to an online information provided by the authorizing body.</enum>
+            </allowed-values>
+
+            <!-- ========================================================================================================== -->
+            <!-- = SOFTWARE: type='software' constraints                = -->
+            <!-- ========================================================================================================== -->
+            <allowed-values target="(.)[@type='software']/prop/@name" allow-other="yes">
+        &allowed-values-component_component_software;
+            </allowed-values>
+
+            <!-- ========================================================================================================== -->
+            <!-- = SERVICE: type='service' constraints                = -->
+            <!-- ========================================================================================================== -->
+            <allowed-values target="(.)[@type='service']/link/@rel" allow-other="yes">
+        &allowed-values-component_component_service;
+            </allowed-values>
+
+            <expect target="." test="not(exists((.)[not(@type='service')]/protocol))"/>
+
+            <!-- ========================================================================================================== -->
+            <!-- = INTERCONNECTION: type='interconnection' constraints                = -->
+            <!-- ========================================================================================================== -->
+            <allowed-values target="(.)[@type='interconnection']/prop/@name" allow-other="yes">
+                <enum value="isa-title">Title of the Interconnection Security Agreement (ISA).</enum>
+                <enum value="isa-date">Date of the Interconnection Security Agreement (ISA).</enum>
+                <enum value="isa-remote-system-name">The name of the remote interconnected system.</enum>
+                <enum value="ipv4-address">An Internet Protocol Version 4 interconnection address</enum>
+                <enum value="ipv6-address">An Internet Protocol Version 6 interconnection address</enum>
+                <enum value="direction">An Internet Protocol Version 6 interconnection address</enum>
+            </allowed-values>
+            <allowed-values target="prop[@name=('ipv4-address','ipv6-address')]/@class" allow-other="yes">
+                <enum value="local">The identified IP address is for this system.</enum>
+                <enum value="remote">The identified IP address is for the remote system to which this system is connected.</enum>
+            </allowed-values>
+            <allowed-values target="(.)[@type='interconnection']/link/@rel" allow-other="yes">
+                <!-- CHANGE: @name="agreement" changed to @name="isa-agreement" -->
+                <enum value="isa-agreement">A link to the system interconnection agreement.</enum>
+            </allowed-values>
+            <allowed-values target="(.)[@type='interconnection']/responsible-role/@role-id" allow-other="yes">
+                <enum value="isa-poc-local">Interconnection Security Agreement (ISA) point of contact (POC) for this system.</enum>
+                <enum value="isa-poc-remote">Interconnection Security Agreement (ISA) point of contact (POC) for the remote interconnected system.</enum>
+                <enum value="isa-authorizing-official-local">Interconnection Security Agreement (ISA) authorizing official for this system.</enum>
+                <enum value="isa-authorizing-official-remote">Interconnection Security Agreement (ISA) authorizing official for the remote interconnected system.</enum>
+            </allowed-values>
+            <matches target="prop[@name='isa-date']/@value" datatype="dateTime"/>
+            <matches target="prop[@name='ipv4-address']/@value" datatype="ip-v4-address" />
+            <matches target="prop[@name='ipv6-address']/@value" datatype="ip-v6-address" />
+            <allowed-values target="prop[@name='direction']/@value" allow-other="yes">
+                <enum value="incoming">Data from the remote system flows into this system.</enum>
+                <enum value="outgoing">Data from this system flows to the remote system.</enum>
+            </allowed-values>
+            <is-unique id="unique-system-component-responsible-role" target="responsible-role">
+                <key-field target="@role-id"/>
+                <remarks>
+                    <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+        <remarks>
+            <p>Components may be products, services, application programming interface (APIs), policies, processes, plans, guidance, standards, or other tangible items that enable security and/or privacy.</p>
+            <p>The <code>type</code> indicates which of these component types is represented.</p>
+            <!-- <p>A group of components may be aggregated into a <code>capability</code>. For example, an account management capability that consists of an account management process, and a Lightweight Directory Access Protocol (LDAP) software implementation.</p>
+       <p>Capabilities are expressed by combining one or more components.</p>-->
+            <p>When defining a <code>service</code> component where are relationship to other components is known, one or more <code>link</code> entries with rel values of provided-by and used-by can be used to link to the specific component identifier(s) that provide and use the service respectively.</p>
+        </remarks>
+    </define-assembly>
+
+    <define-flag name="system-component-type" as-type="string">
+        <formal-name>Component Type</formal-name>
+        <description>A category describing the purpose of the component.</description>
+        <constraint>
+            <allowed-values allow-other="yes">
+                <enum value="this-system">The system as a whole.</enum>
+                <enum value="system">An external system, which may be a leveraged system or the other side of an interconnection.</enum>
+                &allowed-values-component-type;
+                <enum value="network">A physical or virtual network.</enum>
+            </allowed-values>
+        </constraint>
+    </define-flag>
+
+    <define-assembly name="protocol">
+        <formal-name>Service Protocol Information</formal-name>
+        <description>Information about the protocol used to provide a service.</description>
+        <define-flag name="uuid" as-type="uuid">
+            <formal-name>Service Protocol Information Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this service protocol information elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>service protocol</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <define-flag name="name" required="yes">
+            <formal-name>Protocol Name</formal-name>
+            <description>The common name of the protocol, which should be the appropriate "service name" from the <a href="https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml">IANA Service Name and Transport Protocol Port Number Registry</a>.
+            </description>
+            <remarks>
+                <p>The short name of the protocol (e.g., https).</p>
+            </remarks>
+        </define-flag>
+        <model>
+            <define-field name="title" as-type="markup-line">
+        <formal-name>Protocol Title</formal-name>
+                <description>A human readable name for the protocol (e.g., Transport Layer Security).</description>
+            </define-field>
+            <assembly ref="port-range" max-occurs="unbounded">
+                <group-as name="port-ranges" in-json="ARRAY"/>
+            </assembly>
+        </model>
+        <constraint>
+            <expect level="WARNING" target="." test="@uuid">
+                <message>It is a best practice to provide a UUID.</message>
+            </expect>
+        </constraint>
+    </define-assembly>
+    <define-assembly name="port-range">
+        <formal-name>Port Range</formal-name>
+        <description>Where applicable this is the IPv4 port range on which the service operates.</description>
+        <define-flag name="start" as-type="nonNegativeInteger">
+            <formal-name>Start</formal-name>
+            <description>Indicates the starting port number in a port range</description>
+            <remarks>
+                <p>Should be a number within a permitted range</p>
+            </remarks>
+        </define-flag>
+        <define-flag name="end" as-type="nonNegativeInteger">
+            <formal-name>End</formal-name>
+            <description>Indicates the ending port number in a port range</description>
+            <remarks>
+                <p>Should be a number within a permitted range</p>
+            </remarks>
+        </define-flag>
+        <define-flag name="transport" as-type="token">
+            <formal-name>Transport</formal-name>
+            <description>Indicates the transport type.</description>
             <constraint>
-                  <allowed-values target="prop/@name" allow-other="yes">
-                        <enum value="ipv4-address">The Internet Protocol v4 Address of the asset.</enum>
-                        <enum value="ipv6-address">The Internet Protocol v6 Address of the asset.</enum>
-                        <enum value="fqdn">The full-qualified domain name (FQDN) of the asset.</enum>
-                        <enum value="uri">A Uniform Resource Identifier (URI) for the asset.</enum>
-                        <enum value="serial-number">A serial number for the asset.</enum>
-                        <enum value="netbios-name">The NetBIOS name for the asset.</enum>
-                        <enum value="mac-address">The media access control (MAC) address for the asset.</enum>
-                        <enum value="physical-location">The physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers).</enum>
-                        <enum value="is-scanned">is the asset subjected to network scans? (yes/no)</enum>
-                        <!-- =========================================================================================== -->
-                        <!-- = The following is to support the legacy approach for inventory-items without components. = -->
-                        <!-- =========================================================================================== -->
-                        <!-- This is "model" in the context of a component -->
-                        <enum value="hardware-model">The model number of the hardware used by the asset.</enum>
-                        <!-- This is "name" in the context of a component -->
-                        <enum value="os-name">The name of the operating system used by the asset.</enum>
-                        <!-- This is "version" in the context of a component -->
-                        <enum value="os-version">The version of the operating system used by the asset.</enum>
-                        <!-- This is "name" in the context of a component -->
-                        <enum value="software-name">The software product name used by the asset.</enum>
-                        <!-- This is "version" in the context of a component -->
-                        <enum value="software-version">The software product version used by the asset.</enum>
-                        <!-- This is "patch-level" in the context of a component -->
-                        <enum value="software-patch-level">The software product patch level used by the asset.</enum>
+                <allowed-values>
+                    <enum value="TCP">Transmission Control Protocol</enum>
+                    <enum value="UDP">User Datagram Protocol</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+        <remarks>
+            <p>To be validated as a natural number (integer &gt;= 1). A single port uses the same value for start and end. Use multiple 'port-range' entries for non-contiguous ranges.</p>
+        </remarks>
+        <example>
+            <service xmlns="http://csrc.nist.gov/ns/oscal/example" id="svc-01" name="Domain Name Service (DNS) Lookup">
+                <protocol name="dns">
+                    <port-range start="53" end="53" transport="tcp"/>
+                </protocol>
+            </service>
+        </example>
+    </define-assembly>
 
-                        <!-- =========================================================================================== -->
-                        <!-- = The following is shared with system-component. = -->
-                        <!-- =========================================================================================== -->
-                        &allowed-values-component_inventory-item_property-name;
+    <define-assembly name="implementation-status">
+        <formal-name>Implementation Status</formal-name>
+        <description>Indicates the degree to which the a given control is implemented.</description>
+        <define-flag name="state" as-type="token" required="yes">
+            <formal-name>Implementation State</formal-name>
+            <description>Identifies the implementation status of the control or control objective.</description>
+            <constraint>
+                <allowed-values allow-other="yes">
+                    <enum value="implemented">The control is fully implemented.</enum>
+                    <enum value="partial">The control is partially implemented.</enum>
+                    <enum value="planned">There is a plan for implementing the control as explained in the remarks.</enum>
+                    <enum value="alternative">There is an alternative implementation for this control as explained in the remarks.</enum>
+                    <enum value="not-applicable">This control does not apply to this system as justified in the remarks.</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+        <model>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
+        </model>
+    </define-assembly>
 
-                  </allowed-values>
-                  <allowed-values target="prop[@name='asset-type']/@value">
-                        &allowed-values-property-name-asset-type-values;
-                  </allowed-values>
+    <!-- ############################################# -->
+    <!-- # The System User and supporting constructs # -->
+    <!-- ############################################# -->
+    <define-assembly name="system-user">
+        <formal-name>System User</formal-name>
+        <description>A type of user that interacts with the system based on an associated role.</description>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>User Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this user class elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>system user</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <model>
+            <define-field name="title" as-type="markup-line">
+                <formal-name>User Title</formal-name>
+                <description>A name given to the user, which may be used by a tool for display and navigation.</description>
+            </define-field>
+            <define-field name="short-name">
+                <formal-name>User Short Name</formal-name>
+                <description>A short common name, abbreviation, or acronym for the user.</description>
+            </define-field>
+            <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                <formal-name>User Description</formal-name>
+                <description>A summary of the user's purpose within the system.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+                <!-- TODO: Model specific link relationships?  (BJR - I don't think we need this now) -->
+            </assembly>
+            <field ref="role-id" min-occurs="0" max-occurs="unbounded">
+                <group-as name="role-ids" in-json="ARRAY"/>
+            </field>
+            <assembly ref="authorized-privilege" max-occurs="unbounded">
+                <group-as name="authorized-privileges" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <allowed-values target="prop/@name" allow-other="yes">
+                <enum value="type">The type of user, such as internal, external, or general-public.</enum>
+                <enum value="privilege-level">The user's privilege level within the system, such as privileged, non-privileged, no-logical-access.</enum>
+            </allowed-values>
+            <allowed-values target="prop[@name='type']/@value">
+                <enum value="internal">A user account for a person or entity that is part of the organization who owns or operates the system.</enum>
+                <enum value="external">A user account for a person or entity that is not part of the organization who owns or operates the system.</enum>
+                <enum value="general-public">A user of the system considered to be outside </enum>
+            </allowed-values>
+            <allowed-values target="prop[@name='privilege-level']/@value">
+                <enum value="privileged">This role has elevated access to the system, such as a group or system administrator.</enum>
+                <enum value="non-privileged">This role has typical user-level access to the system without elevated access.</enum>
+                <enum value="no-logical-access">This role has no access to the system, such as a manager who approves access as part of a process.</enum>
+            </allowed-values>
+            <allowed-values target="role-id" allow-other="yes">
+        &allowed-values-responsible-roles-operations;
+            </allowed-values>
+        </constraint>
+        <remarks>
+            <p>Permissible values to be determined closer to the application, such as by a receiving authority.</p>
+        </remarks>
+    </define-assembly>
+    <define-assembly name="authorized-privilege">
+        <formal-name>Privilege</formal-name>
+        <description>Identifies a specific system privilege held by the user, along with an associated description and/or rationale for the privilege.</description>
+        <model>
+            <define-field name="title" as-type="markup-line" min-occurs="1">
+        <formal-name>Privilege Title</formal-name>
+                <description>A human readable name for the privilege.</description>
+            </define-field>
+            <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                <formal-name>Privilege Description</formal-name>
+                <description>A summary of the privilege's purpose within the system.</description>
+            </define-field>
+            <field ref="function-performed" min-occurs="1" max-occurs="unbounded">
+                <group-as name="functions-performed" in-json="ARRAY"/>
+            </field>
+        </model>
+    </define-assembly>
+    <define-field name="function-performed" as-type="string">
+        <formal-name>Functions Performed</formal-name>
+        <description>Describes a function performed for a given authorized privilege by this user class.</description>
+    </define-field>
 
-                  <allowed-values target="(.)[@type=('software', 'hardware', 'service')]/prop/@name" allow-other="yes">
-                        <enum value="vendor-name">The name of the company or organization </enum>
-                  </allowed-values>
+    <!-- ################################################ -->
+    <!-- # The Inventory Item and supporting constructs # -->
+    <!-- ################################################ -->
+    <define-assembly name="inventory-item">
+        <formal-name>Inventory Item</formal-name>
+        <description>A single managed inventory item within the system.</description>
+        <!--    <json-key flag-name="uuid"/>
+-->
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Inventory Item Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this inventory item elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>inventory item</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <!-- CHANGED: Moved to property[@name='asset-id']. -->
+        <!--    <define-flag name="asset-id">
+       <!-\- This is an id because the idenfier is assigned and managed externally. -\->
+       <formal-name>Asset Identifier</formal-name>
+       <description>Organizational asset identifier that is unique in the context of the system. This may be a reference to the identifier used in an asset tracking system or a vulnerability scanning tool.</description>
+    </define-flag>  -->
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Inventory Item Description</formal-name>
+                <description>A summary of the inventory item stating its purpose within the system.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="responsible-party" max-occurs="unbounded">
+                <group-as name="responsible-parties" in-json="ARRAY"/>
+            </assembly>
+            <define-assembly name="implemented-component" max-occurs="unbounded">
+                <!-- TODO: Sync constraints with system-component; maybe remove this? (CHANGED (BJR): Dave-See Gitter for details on this. -->
+                <formal-name>Implemented Component</formal-name>
+                <description>The set of components that are implemented in a given system inventory item.</description>
+                <group-as name="implemented-components" in-json="ARRAY"/>
+
+                <define-flag required="yes" name="component-uuid" as-type="uuid">
+                    <formal-name>Component Universally Unique Identifier Reference</formal-name>
+                    <!-- Identifier Reference -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a <code>component</code> that is implemented as part of an inventory item.</description>
+                </define-flag>
+
+                <!-- CHANGED (daw): the following is not needed since it is required on the referenced component -->
+                <!--    <!-\- CHANGED (BJR): Added component-type for alignment with system-component -\->
+    <flag ref="component-type" required="yes" />
+-->
+                <!-- The following is commented because this is not being used and can be inferred based on the type of the component -->
+                <!--
+    <define-flag name="use">
+       <formal-name>Implementation Use Type</formal-name>
+       <description>The type of implementation</description>
+       <constraint>
+        <allowed-values allow-other="yes">
+           <enum value="runs-software">The implemented component is a 'software' component that the inventory item has installed and uses.</enum>
+           <enum value="uses-hardware">The implemented component is a 'hardware' component that the inventory item has installed and uses.</enum>
+           <enum value="enforces-policy">The implemented component is a 'policy' component that the inventory item supports and enforces.</enum>
+           <enum value="implements-process">The implemented component is a 'process' component that the inventory item supports and enforces.</enum>
+        </allowed-values>
+       </constraint>
+    </define-flag>
+-->
+                <model>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="responsible-party" max-occurs="unbounded">
+                        <group-as name="responsible-parties" in-json="ARRAY"/>
+                        <remarks>
+                            <p>This construct is used to either: 1) associate a party or parties to a role defined on the component using the <code>responsible-role</code> construct, or 2) to define a party or parties that are responsible for a role defined within the context of the containing <code>inventory-item</code>.
+                            </p>
+                        </remarks>
+                    </assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER"/>
+                </model>
+                <constraint>
+                    <!-- TODO: constrain component-uuid references to components defined in the document. ((BJR): Was unsure how to do this.) -->
+                    <!-- TODO: constrain link href values based on rel ((BJR): Was unsure of how to do this.) -->
+
+                    <!-- TODO: constrain property values based on name (CHANGED (BJR): Done.) -->
+                    <allowed-values target="prop/@name" allow-other="yes">
+            &allowed-values-component_component_property-name;
+            &allowed-values-component_inventory-item_property-name;
+
+                    </allowed-values>
+                    <!-- ensure that at least one asset-id is provided -->
+                    <has-cardinality target="prop[@name='asset-id']" min-occurs="1"/>
 
 
-                  <allowed-values target="prop[@name='is-scanned']/@value">
-                        <enum value="yes">The asset is included in periodic vulnerability scanning.</enum>
-                        <enum value="no">The asset is not included in periodic vulnerability scanning.</enum>
-                  </allowed-values>
-
-                  <allowed-values target="link/@rel" allow-other="yes">
-                        <enum value="baseline-template">A reference to the baseline template used to configure the asset.</enum>
-                  </allowed-values>
-                  <!-- TODO: constrain link href values based on rel ((BJR): Was unsure how to do this.) -->
-
-                  <allowed-values target="responsible-party/@role-id" allow-other="yes">
+                    <allowed-values target="responsible-party/@role-id" allow-other="yes">
             &allowed-values-responsible-roles-operations;
-            &allowed-values-responsible-roles-component-production;
-                  </allowed-values>
+                    </allowed-values>
 
-                  <index-has-key name="index-metadata-role-id" target="responsible-party">
-                        <key-field target="@role-id"></key-field>
-                  </index-has-key>
-                  <index-has-key name="index-metadata-party-uuid" target="responsible-party">
-                        <key-field target="party-uuid"></key-field>
-                  </index-has-key>
-                  <is-unique id="unique-inventory-item-responsible-party" target="responsible-party">
+                    <!-- TODO: constrain party-id references to parties defined in the document. (BJR Unsure how to do this. )-->
+
+                    <is-unique id="unique-implemented-component-responsible-party" target="responsible-party">
                         <key-field target="@role-id"/>
                         <remarks>
-                              <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                            <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
                         </remarks>
-                  </is-unique>
-            </constraint>
-      </define-assembly>
+                    </is-unique>
+                </constraint>
+            </define-assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <allowed-values target="prop/@name" allow-other="yes">
+                <enum value="ipv4-address">The Internet Protocol v4 Address of the asset.</enum>
+                <enum value="ipv6-address">The Internet Protocol v6 Address of the asset.</enum>
+                <enum value="fqdn">The full-qualified domain name (FQDN) of the asset.</enum>
+                <enum value="uri">A Uniform Resource Identifier (URI) for the asset.</enum>
+                <enum value="serial-number">A serial number for the asset.</enum>
+                <enum value="netbios-name">The NetBIOS name for the asset.</enum>
+                <enum value="mac-address">The media access control (MAC) address for the asset.</enum>
+                <enum value="physical-location">The physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers).</enum>
+                <enum value="is-scanned">is the asset subjected to network scans? (yes/no)</enum>
+                <!-- =========================================================================================== -->
+                <!-- = The following is to support the legacy approach for inventory-items without components. = -->
+                <!-- =========================================================================================== -->
+                <!-- This is "model" in the context of a component -->
+                <enum value="hardware-model">The model number of the hardware used by the asset.</enum>
+                <!-- This is "name" in the context of a component -->
+                <enum value="os-name">The name of the operating system used by the asset.</enum>
+                <!-- This is "version" in the context of a component -->
+                <enum value="os-version">The version of the operating system used by the asset.</enum>
+                <!-- This is "name" in the context of a component -->
+                <enum value="software-name">The software product name used by the asset.</enum>
+                <!-- This is "version" in the context of a component -->
+                <enum value="software-version">The software product version used by the asset.</enum>
+                <!-- This is "patch-level" in the context of a component -->
+                <enum value="software-patch-level">The software product patch level used by the asset.</enum>
+
+                <!-- =========================================================================================== -->
+                <!-- = The following is shared with system-component. = -->
+                <!-- =========================================================================================== -->
+                &allowed-values-component_inventory-item_property-name;
+
+            </allowed-values>
+            <allowed-values target="prop[@name='asset-type']/@value">
+                &allowed-values-property-name-asset-type-values;
+            </allowed-values>
+
+            <allowed-values target="(.)[@type=('software', 'hardware', 'service')]/prop/@name" allow-other="yes">
+                <enum value="vendor-name">The name of the company or organization </enum>
+            </allowed-values>
 
 
-      <define-flag name="source" as-type="uri-reference">
-            <formal-name>Source Resource Reference</formal-name>
-            <description>A reference to an OSCAL catalog or profile providing the referenced control or subcontrol definition.</description>
-      </define-flag>
-      <!--   <define-assembly name="only-statement">
-      <formal-name>Specific Statement</formal-name>
-      <description>Describes which specific statements are addressed by a requirement, by pointing to a specific requirement statement within a control.</description>
-      <json-key flag-name="statement-id"/>
-      <flag ref="statement-id" required="yes">
-         <remarks>
-            <p>A reference to the specific implemented statement.</p>
-         </remarks>
-      </flag>
-      <model>
-         <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-            <formal-name>Statement Implementation Description</formal-name>
-            <description>A description of the component, including information about its function.</description>
-         </define-field>
-         <field ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-         </field>
-         <assembly ref="property" max-occurs="unbounded">
-            <group-as name="properties" in-json="ARRAY"/>
-         </assembly>
-         <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-            <!-\- TODO: Model specific link relationships ((BJR): Was unsure how to do this.) -\->
-         </assembly>
+            <allowed-values target="prop[@name='is-scanned']/@value">
+                <enum value="yes">The asset is included in periodic vulnerability scanning.</enum>
+                <enum value="no">The asset is not included in periodic vulnerability scanning.</enum>
+            </allowed-values>
+
+            <allowed-values target="link/@rel" allow-other="yes">
+                <enum value="baseline-template">A reference to the baseline template used to configure the asset.</enum>
+            </allowed-values>
+            <!-- TODO: constrain link href values based on rel ((BJR): Was unsure how to do this.) -->
+
+            <allowed-values target="responsible-party/@role-id" allow-other="yes">
+        &allowed-values-responsible-roles-operations;
+        &allowed-values-responsible-roles-component-production;
+            </allowed-values>
+
+            <index-has-key name="index-metadata-role-id" target="responsible-party">
+                <key-field target="@role-id"></key-field>
+            </index-has-key>
+            <index-has-key name="index-metadata-party-uuid" target="responsible-party">
+                <key-field target="party-uuid"></key-field>
+            </index-has-key>
+            <is-unique id="unique-inventory-item-responsible-party" target="responsible-party">
+                <key-field target="@role-id"/>
+                <remarks>
+                    <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
+
+
+    <define-flag name="source" as-type="uri-reference">
+        <formal-name>Source Resource Reference</formal-name>
+        <description>A reference to an OSCAL catalog or profile providing the referenced control or subcontrol definition.</description>
+    </define-flag>
+    <!--   <define-assembly name="only-statement">
+    <formal-name>Specific Statement</formal-name>
+    <description>Describes which specific statements are addressed by a requirement, by pointing to a specific requirement statement within a control.</description>
+    <json-key flag-name="statement-id"/>
+    <flag ref="statement-id" required="yes">
+       <remarks>
+        <p>A reference to the specific implemented statement.</p>
+       </remarks>
+    </flag>
+    <model>
+       <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+        <formal-name>Statement Implementation Description</formal-name>
+        <description>A description of the component, including information about its function.</description>
+       </define-field>
+       <field ref="property" max-occurs="unbounded">
+        <group-as name="props" in-json="ARRAY"/>
+       </field>
+       <assembly ref="property" max-occurs="unbounded">
+        <group-as name="properties" in-json="ARRAY"/>
+       </assembly>
+       <assembly ref="link" max-occurs="unbounded">
+        <group-as name="links" in-json="ARRAY"/>
+        <!-\- TODO: Model specific link relationships ((BJR): Was unsure how to do this.) -\->
+       </assembly>
 <!-\-
-         <assembly ref="using"/>
+       <assembly ref="using"/>
 -\->
-         <!-\- TODO: Implement parameters -\->
-         <field ref="remarks" in-xml="WITH_WRAPPER"/>
-      </model>
+       <!-\- TODO: Implement parameters -\->
+       <field ref="remarks" in-xml="WITH_WRAPPER"/>
+    </model>
    </define-assembly>
 -->
-      <define-flag name="statement-id" as-type="token">
-            <formal-name>Control Statement Reference</formal-name>
-            <!-- Identifier Reference -->
-            <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a> identifier reference to a <code>control statement</code>.</description>
-      </define-flag>
-      <define-assembly name="set-parameter">
-            <formal-name>Set Parameter Value</formal-name>
-            <description>Identifies the parameter that will be set by the enclosed value.</description>
-            <flag ref="param-id" required="yes"/>
-            <model>
-                  <define-field name="parameter-value" as-type="string" min-occurs="1" max-occurs="unbounded">
-                        <!-- CHANGED type from "markup-line" to "string" since this is intended to be a scalar value -->
-                        <formal-name>Parameter Value</formal-name>
-                        <description>A parameter value or set of values.</description>
-                        <use-name>value</use-name>
-                        <group-as name="values" in-json="ARRAY"/>
-                  </define-field>
-                  <field ref="remarks" in-xml="WITH_WRAPPER"/>
-            </model>
-      </define-assembly>
+    <define-flag name="statement-id" as-type="token">
+        <formal-name>Control Statement Reference</formal-name>
+        <!-- Identifier Reference -->
+        <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a> identifier reference to a <code>control statement</code>.</description>
+    </define-flag>
+    <define-assembly name="set-parameter">
+        <formal-name>Set Parameter Value</formal-name>
+        <description>Identifies the parameter that will be set by the enclosed value.</description>
+        <flag ref="param-id" required="yes"/>
+        <model>
+            <define-field name="parameter-value" as-type="string" min-occurs="1" max-occurs="unbounded">
+                <!-- CHANGED type from "markup-line" to "string" since this is intended to be a scalar value -->
+                <formal-name>Parameter Value</formal-name>
+                <description>A parameter value or set of values.</description>
+                <use-name>value</use-name>
+                <group-as name="values" in-json="ARRAY"/>
+            </define-field>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+    </define-assembly>
 
-      <!-- ===== FIELDS ===== -->
-      <define-field name="system-id" as-type="string">
-            <!-- This is an id because the idenfier is assigned and managed by humans. -->
-            <formal-name>System Identification</formal-name>
-            <!-- Identifier Declaration -->
-            <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this system identification property elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. When referencing an externally defined <code>system identification</code>, the <code>system identification</code> must be used in the context of the external / imported OSCAL instance (e.g., uri-reference). This string should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same system across revisions of the document.</description>
-            <json-value-key>id</json-value-key>
-            <define-flag name="identifier-type" as-type="uri">
-                  <formal-name>Identification System Type</formal-name>
-                  <description>Identifies the identification system from which the provided identifier was assigned. </description>
-                  <constraint>
-                        <allowed-values allow-other="yes">
-                              <enum value="https://fedramp.gov">The identifier was assigned by FedRAMP.</enum>
-                              <enum value="https://ietf.org/rfc/rfc4122">A Universally Unique Identifier (UUID) as defined by RFC4122.</enum>
-                        </allowed-values>
-                  </constraint>
-            </define-flag>
-      </define-field>
+    <!-- ===== FIELDS ===== -->
+    <define-field name="system-id" as-type="string">
+        <!-- This is an id because the idenfier is assigned and managed by humans. -->
+        <formal-name>System Identification</formal-name>
+        <!-- Identifier Declaration -->
+        <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this system identification property elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. When referencing an externally defined <code>system identification</code>, the <code>system identification</code> must be used in the context of the external / imported OSCAL instance (e.g., uri-reference). This string should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same system across revisions of the document.</description>
+        <json-value-key>id</json-value-key>
+        <define-flag name="identifier-type" as-type="uri">
+            <formal-name>Identification System Type</formal-name>
+            <description>Identifies the identification system from which the provided identifier was assigned. </description>
+            <constraint>
+                <allowed-values allow-other="yes">
+                    <enum value="https://fedramp.gov">The identifier was assigned by FedRAMP.</enum>
+                    <enum value="https://ietf.org/rfc/rfc4122">A Universally Unique Identifier (UUID) as defined by RFC4122.</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+    </define-field>
 
-      <!-- ===== FLAGS ===== -->
-      <define-flag name="param-id" as-type="token">
-            <!-- This is an id because the idenfier is assigned and managed by humans. -->
-            <formal-name>Parameter ID</formal-name>
-            <!-- Identifier Reference -->
-            <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a> reference to a <code>parameter</code> within a control, who's catalog has been imported into the current implementation context.</description>
-            <example>
-                  <set-param xmlns="http://csrc.nist.gov/ns/oscal/example" param-id="ac-2_prm_2">
-                        <enum>System ISSO</enum>
-                  </set-param>
-            </example>
-      </define-flag>
+    <!-- ===== FLAGS ===== -->
+    <define-flag name="param-id" as-type="token">
+        <!-- This is an id because the idenfier is assigned and managed by humans. -->
+        <formal-name>Parameter ID</formal-name>
+        <!-- Identifier Reference -->
+        <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a> reference to a <code>parameter</code> within a control, who's catalog has been imported into the current implementation context.</description>
+        <example>
+            <set-param xmlns="http://csrc.nist.gov/ns/oscal/example" param-id="ac-2_prm_2">
+                <enum>System ISSO</enum>
+            </set-param>
+        </example>
+    </define-flag>
 </METASCHEMA>

--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -122,7 +122,7 @@
                               <formal-name>As-Is Structuring Directive</formal-name>
                               <description>An As-is element indicates that the controls should be structured in resolution as they are structured in their source catalogs. It does not contain any elements or attributes.</description>
                         </define-field>
-                        <define-assembly name="custom">
+                        <define-assembly name="custom" min-occurs="1">
                               <formal-name>Custom grouping</formal-name>
                               <description>A Custom element frames a structure for embedding represented controls in resolution.</description>
                               <model>

--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -4,436 +4,436 @@
    <!ENTITY allowed-values-control-group-property-name SYSTEM "./shared-constraints/allowed-values-control-group-property-name.ent">
 ]>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
-      <schema-name>OSCAL Profile Model</schema-name>
-      <schema-version>1.0.1</schema-version>
-      <short-name>oscal-profile</short-name>
-      <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
-      <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
-      <remarks>
-            <p>A profile designates a selection and configuration of controls from one or more catalogs, along with a series of operations over them. The topmost element in the OSCAL profile XML schema is <code>profile</code>.</p>
-      </remarks>
+    xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
+    <schema-name>OSCAL Profile Model</schema-name>
+    <schema-version>1.0.1</schema-version>
+    <short-name>oscal-profile</short-name>
+    <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
+    <remarks>
+        <p>A profile designates a selection and configuration of controls from one or more catalogs, along with a series of operations over them. The topmost element in the OSCAL profile XML schema is <code>profile</code>.</p>
+    </remarks>
 
-      <import href="oscal_metadata_metaschema.xml"/>
-      <import href="oscal_control-common_metaschema.xml"/>
+    <import href="oscal_metadata_metaschema.xml"/>
+    <import href="oscal_control-common_metaschema.xml"/>
 
-      <define-assembly name="profile">
-            <formal-name>Profile</formal-name>
-            <description>Each OSCAL profile is defined by a Profile element</description>
-            <root-name>profile</root-name>
-            <define-flag name="uuid" as-type="uuid" required="yes">
-                  <formal-name>Profile Universally Unique Identifier</formal-name>
-                  <!-- Identifier Declaration -->
-                  <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this profile elsewhere in <a href="/concepts/identifier-use/#profile-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>profile</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This identifier should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same profile across revisions of the document.</description>
-            </define-flag>
-            <model>
-                  <assembly ref="metadata" min-occurs="1"/>
-                  <assembly ref="import" min-occurs="1" max-occurs="unbounded">
-                        <group-as name="imports" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="merge"/>
-                  <assembly ref="modify"/>
-                  <assembly ref="back-matter"/>
-            </model>
+    <define-assembly name="profile">
+        <formal-name>Profile</formal-name>
+        <description>Each OSCAL profile is defined by a Profile element</description>
+        <root-name>profile</root-name>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Profile Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this profile elsewhere in <a href="/concepts/identifier-use/#profile-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>profile</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This identifier should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same profile across revisions of the document.</description>
+        </define-flag>
+        <model>
+            <assembly ref="metadata" min-occurs="1"/>
+            <assembly ref="import" min-occurs="1" max-occurs="unbounded">
+                <group-as name="imports" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="merge"/>
+            <assembly ref="modify"/>
+            <assembly ref="back-matter"/>
+        </model>
+        <remarks>
+            <p>An OSCAL document that describes a tailoring of controls from one or more catalogs, with possible modification of multiple controls. It provides mechanisms by which controls may be selected (<code>import</code>), merged or (re)structured (<code>merge</code>), and amended (<code>modify</code>). OSCAL profiles may select subsets of controls, set parameter values for them in application, and even adjust the representation of controls as given in and by a catalog. They may also serve as sources for further modification in and by other profiles, that import them.</p>
+            <p>See the <a href="/concepts/identifier-use/">Concepts - Identifier Use</a> page for additional information regarding this identifier's uniqueness and scope.</p>
+        </remarks>
+    </define-assembly>
+    <define-assembly name="import">
+        <formal-name>Import resource</formal-name>
+        <description>The <code>import</code> designates a catalog, profile, or other resource to be included (referenced and potentially modified) by this profile. The import also identifies which controls to select using the <code>include-all</code>, <code>include-controls</code>, and <code>exclude-controls</code> directives.</description>
+        <define-flag name="href" as-type="uri-reference" required="yes">
+            <formal-name>Catalog or Profile Reference</formal-name>
+            <description>A resolvable URL reference to the base catalog or profile that this profile is tailoring.</description>
             <remarks>
-                  <p>An OSCAL document that describes a tailoring of controls from one or more catalogs, with possible modification of multiple controls. It provides mechanisms by which controls may be selected (<code>import</code>), merged or (re)structured (<code>merge</code>), and amended (<code>modify</code>). OSCAL profiles may select subsets of controls, set parameter values for them in application, and even adjust the representation of controls as given in and by a catalog. They may also serve as sources for further modification in and by other profiles, that import them.</p>
-                  <p>See the <a href="/concepts/identifier-use/">Concepts - Identifier Use</a> page for additional information regarding this identifier's uniqueness and scope.</p>
+                <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code>
+                    <code>resource</code> in the same document.</p>
+                <!-- TODO: Add a link to "within the scope of the containing OSCAL document" to point to documentation of identification scopes" -->
+                <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is within the scope of the containing OSCAL document.</p>
+                <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URL pointing to the location of the referenced resource. A relative URL will be resolved relative to the location of the document containing the link.</p>
             </remarks>
-      </define-assembly>
-      <define-assembly name="import">
-            <formal-name>Import resource</formal-name>
-            <description>The <code>import</code> designates a catalog, profile, or other resource to be included (referenced and potentially modified) by this profile. The import also identifies which controls to select using the <code>include-all</code>, <code>include-controls</code>, and <code>exclude-controls</code> directives.</description>
-            <define-flag name="href" as-type="uri-reference" required="yes">
-                  <formal-name>Catalog or Profile Reference</formal-name>
-                  <description>A resolvable URL reference to the base catalog or profile that this profile is tailoring.</description>
-                  <remarks>
-                        <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code>
-                              <code>resource</code> in the same document.</p>
-                        <!-- TODO: Add a link to "within the scope of the containing OSCAL document" to point to documentation of identification scopes" -->
-                        <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is within the scope of the containing OSCAL document.</p>
-                        <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URL pointing to the location of the referenced resource. A relative URL will be resolved relative to the location of the document containing the link.</p>
-                  </remarks>
-            </define-flag>
-            <model>
-                  <choice>
-                        <assembly ref="include-all" min-occurs="1">
-                              <remarks>
-                                    <p>Identifies that all controls are to be included from the imported catalog or profile.</p>
-                              </remarks>
-                        </assembly>
-                        <assembly ref="select-control-by-id" min-occurs="1" max-occurs="unbounded">
-                              <use-name>include-controls</use-name>
-                              <group-as name="include-controls" in-json="ARRAY"/>
-                              <remarks>
-                                    <p>Identifies a subset of controls to import from the referenced catalog or profile by control identifier or match pattern.</p>
-                              </remarks>
-                        </assembly>
-                  </choice>
-                  <assembly ref="select-control-by-id" max-occurs="unbounded">
-                        <use-name>exclude-controls</use-name>
-                        <group-as name="exclude-controls" in-json="ARRAY"/>
-                        <remarks>
-                              <p>Identifies which controls to exclude, or eliminate, from the set of included controls by control identifier or match pattern.</p>
-                        </remarks>
-                  </assembly>
-            </model>
-            <remarks>
-                  <p>A profile must be based on an existing OSCAL catalog or another OSCAL profile. An <code>import</code> indicates such a source whose controls are to be included (referenced and modified) in a profile. This source will either be a catalog whose controls are given (<q>by value</q>), or a profile with its own control imports.</p>
-                  <p>The contents of the <code>import</code> element indicate which controls from the source will be included. Controls from the source catalog or profile may be either selected, using the <code>include-all</code> or <code>include-controls</code> directives, or de-selected (using an <code>exclude-controls</code> directive).</p>
-            </remarks>
-            <example>
-                  <import xmlns="http://csrc.nist.gov/ns/oscal/example" href="catalog.xml">
-                        <include-all/>
-                  </import>
-            </example>
-      </define-assembly>
-      <define-assembly name="merge">
-            <formal-name>Merge controls</formal-name>
-            <description>A Merge element provides structuring directives that drive how controls are organized after resolution.</description>
-            <model>
-                  <define-assembly name="combine">
-                        <formal-name>Combination rule</formal-name>
-                        <description>A Combine element defines whether and how to combine multiple (competing) versions of the same control</description>
-                        <define-flag name="method" as-type="string">
-                              <formal-name>Combination method</formal-name>
-                              <description>How clashing controls should be handled</description>
-                              <constraint>
-                                    <allowed-values>
-                                          <enum value="use-first">Use the first definition - the first control with a given ID is used; subsequent ones are discarded</enum>
-                                          <enum value="merge" deprecated="1.0.1">**(deprecated)** **(unspecified)** Merge - controls with the same ID are combined</enum>
-                                          <enum value="keep">Keep - controls with the same ID are kept, retaining the clash</enum>
-                                    </allowed-values>
-                              </constraint>
-                        </define-flag>
-                        <constraint>
-                              <expect id="expect-profile-combine-method-merge-unused" target="." test="not(exists(combine[@method='merge']))"/>
-                        </constraint>
-                        <remarks>
-                              <p>Whenever combining controls from multiple (import) pathways, an issue arises of what to do with clashing invocations (multiple competing versions of a control). </p>
-                              <p>This setting permits a profile designer to apply a rule for the resolution of such cases. In a well-designed profile, such collisions would ordinarily be avoided, but this setting can be useful for defining what to do when it occurs.</p>
-                        </remarks>
-                  </define-assembly>
-                  <choice>
-                        <define-assembly name="flat" min-occurs="1">
-                              <formal-name>Flat</formal-name>
-                              <description>Use the flat structuring method.</description>
-                        </define-assembly>
-                        <define-field name="as-is" as-type="boolean" min-occurs="1">
-                              <formal-name>As-Is Structuring Directive</formal-name>
-                              <description>An As-is element indicates that the controls should be structured in resolution as they are structured in their source catalogs. It does not contain any elements or attributes.</description>
-                        </define-field>
-                        <define-assembly name="custom" min-occurs="1">
-                              <formal-name>Custom grouping</formal-name>
-                              <description>A Custom element frames a structure for embedding represented controls in resolution.</description>
-                              <model>
-                                    <assembly ref="group" max-occurs="unbounded">
-                                          <group-as name="groups" in-json="ARRAY"/>
-                                    </assembly>
-                                    <assembly ref="insert-controls" max-occurs="unbounded">
-                                          <group-as name="insert-controls" in-json="ARRAY"/>
-                                    </assembly>
-                              </model>
-                              <remarks>
-                                    <p>The <code>custom</code> element represents a custom arrangement or organization of controls in the resolution of a catalog.</p>
-                                    <p>While the <code>as-is</code> element provides for a restitution of a control set's organization (in one or more source catalogs), this element permits the definition of an entirely different structure.</p>
-                              </remarks>
-                        </define-assembly>
-                  </choice>
-            </model>
-            <remarks>
-                  <p>The contents of the <code>merge</code> element may be used to <q>reorder</q> or <q>restructure</q> controls by indicating an order and/or structure in resolution.</p>
-                  <p>Implicitly, a <code>merge</code> element is also a filter: controls that are included in a profile, but not included (implicitly or explicitly) in the scope of a <code>merge</code> element, will not be merged into (will be dropped) in the resulting resolution.</p>
-            </remarks>
-      </define-assembly>
-      <define-assembly name="group">
-            <formal-name>Control group</formal-name>
-            <description>A group of (selected) controls or of groups of controls</description>
-            <define-flag name="id" as-type="token">
-                  <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
-                  <formal-name>Group Identifier</formal-name>
-                  <!-- Identifier Declaration -->
-                  <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined group elsewhere in <a href="/concepts/identifier-use/#profile-identifiers">this or other OSCAL instances</a>. When referenced from another OSCAL instance, this identifier must be referenced in the context of the containing resource (e.g., import-profile). This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same group across revisions of the document.</description>
-            </define-flag>
-            <define-flag name="class" as-type="token">
-                  <formal-name>Group Class</formal-name>
-                  <description>A textual label that provides a sub-type or characterization of the group.</description>
-                  <remarks>
-                        <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
-                        <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
-                  </remarks>
-            </define-flag>
-            <model>
-                  <define-field name="title" as-type="markup-line" min-occurs="1">
-                        <formal-name>Group Title</formal-name>
-                        <description>A name given to the group, which may be used by a tool for display and navigation.</description>
-                  </define-field>
-                  <assembly ref="parameter" max-occurs="unbounded">
-                        <group-as name="params" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="property" max-occurs="unbounded">
-                        <group-as name="props" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="link" max-occurs="unbounded">
-                        <group-as name="links" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="part" max-occurs="unbounded">
-                        <group-as name="parts" in-json="ARRAY"/>
-                  </assembly>
-                  <choice>
+        </define-flag>
+        <model>
+            <choice>
+                <assembly ref="include-all" min-occurs="1">
+                    <remarks>
+                        <p>Identifies that all controls are to be included from the imported catalog or profile.</p>
+                    </remarks>
+                </assembly>
+                <assembly ref="select-control-by-id" min-occurs="1" max-occurs="unbounded">
+                    <use-name>include-controls</use-name>
+                    <group-as name="include-controls" in-json="ARRAY"/>
+                    <remarks>
+                        <p>Identifies a subset of controls to import from the referenced catalog or profile by control identifier or match pattern.</p>
+                    </remarks>
+                </assembly>
+            </choice>
+            <assembly ref="select-control-by-id" max-occurs="unbounded">
+                <use-name>exclude-controls</use-name>
+                <group-as name="exclude-controls" in-json="ARRAY"/>
+                <remarks>
+                    <p>Identifies which controls to exclude, or eliminate, from the set of included controls by control identifier or match pattern.</p>
+                </remarks>
+            </assembly>
+        </model>
+        <remarks>
+            <p>A profile must be based on an existing OSCAL catalog or another OSCAL profile. An <code>import</code> indicates such a source whose controls are to be included (referenced and modified) in a profile. This source will either be a catalog whose controls are given (<q>by value</q>), or a profile with its own control imports.</p>
+            <p>The contents of the <code>import</code> element indicate which controls from the source will be included. Controls from the source catalog or profile may be either selected, using the <code>include-all</code> or <code>include-controls</code> directives, or de-selected (using an <code>exclude-controls</code> directive).</p>
+        </remarks>
+        <example>
+            <import xmlns="http://csrc.nist.gov/ns/oscal/example" href="catalog.xml">
+                <include-all/>
+            </import>
+        </example>
+    </define-assembly>
+    <define-assembly name="merge">
+        <formal-name>Merge controls</formal-name>
+        <description>A Merge element provides structuring directives that drive how controls are organized after resolution.</description>
+        <model>
+            <define-assembly name="combine">
+                <formal-name>Combination rule</formal-name>
+                <description>A Combine element defines whether and how to combine multiple (competing) versions of the same control</description>
+                <define-flag name="method" as-type="string">
+                    <formal-name>Combination method</formal-name>
+                    <description>How clashing controls should be handled</description>
+                    <constraint>
+                        <allowed-values>
+                            <enum value="use-first">Use the first definition - the first control with a given ID is used; subsequent ones are discarded</enum>
+                            <enum value="merge" deprecated="1.0.1">**(deprecated)** **(unspecified)** Merge - controls with the same ID are combined</enum>
+                            <enum value="keep">Keep - controls with the same ID are kept, retaining the clash</enum>
+                        </allowed-values>
+                    </constraint>
+                </define-flag>
+                <constraint>
+                    <expect id="expect-profile-combine-method-merge-unused" target="." test="not(exists(combine[@method='merge']))"/>
+                </constraint>
+                <remarks>
+                    <p>Whenever combining controls from multiple (import) pathways, an issue arises of what to do with clashing invocations (multiple competing versions of a control). </p>
+                    <p>This setting permits a profile designer to apply a rule for the resolution of such cases. In a well-designed profile, such collisions would ordinarily be avoided, but this setting can be useful for defining what to do when it occurs.</p>
+                </remarks>
+            </define-assembly>
+            <choice>
+                <define-assembly name="flat" min-occurs="1">
+                    <formal-name>Flat</formal-name>
+                    <description>Use the flat structuring method.</description>
+                </define-assembly>
+                <define-field name="as-is" as-type="boolean" min-occurs="1">
+                    <formal-name>As-Is Structuring Directive</formal-name>
+                    <description>An As-is element indicates that the controls should be structured in resolution as they are structured in their source catalogs. It does not contain any elements or attributes.</description>
+                </define-field>
+                <define-assembly name="custom" min-occurs="1">
+                    <formal-name>Custom grouping</formal-name>
+                    <description>A Custom element frames a structure for embedding represented controls in resolution.</description>
+                    <model>
                         <assembly ref="group" max-occurs="unbounded">
-                              <group-as name="groups" in-json="ARRAY"/>
+                            <group-as name="groups" in-json="ARRAY"/>
                         </assembly>
                         <assembly ref="insert-controls" max-occurs="unbounded">
-                              <group-as name="insert-controls" in-json="ARRAY"/>
+                            <group-as name="insert-controls" in-json="ARRAY"/>
                         </assembly>
-                  </choice>
-            </model>
+                    </model>
+                    <remarks>
+                        <p>The <code>custom</code> element represents a custom arrangement or organization of controls in the resolution of a catalog.</p>
+                        <p>While the <code>as-is</code> element provides for a restitution of a control set's organization (in one or more source catalogs), this element permits the definition of an entirely different structure.</p>
+                    </remarks>
+                </define-assembly>
+            </choice>
+        </model>
+        <remarks>
+            <p>The contents of the <code>merge</code> element may be used to <q>reorder</q> or <q>restructure</q> controls by indicating an order and/or structure in resolution.</p>
+            <p>Implicitly, a <code>merge</code> element is also a filter: controls that are included in a profile, but not included (implicitly or explicitly) in the scope of a <code>merge</code> element, will not be merged into (will be dropped) in the resulting resolution.</p>
+        </remarks>
+    </define-assembly>
+    <define-assembly name="group">
+        <formal-name>Control group</formal-name>
+        <description>A group of (selected) controls or of groups of controls</description>
+        <define-flag name="id" as-type="token">
+            <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
+            <formal-name>Group Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined group elsewhere in <a href="/concepts/identifier-use/#profile-identifiers">this or other OSCAL instances</a>. When referenced from another OSCAL instance, this identifier must be referenced in the context of the containing resource (e.g., import-profile). This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same group across revisions of the document.</description>
+        </define-flag>
+        <define-flag name="class" as-type="token">
+            <formal-name>Group Class</formal-name>
+            <description>A textual label that provides a sub-type or characterization of the group.</description>
             <remarks>
-                  <p>This construct mirrors the same construct that exists in an OSCAL catalog.</p>
+                <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
+                <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
             </remarks>
-      </define-assembly>
-      <define-assembly name="modify">
-            <formal-name>Modify controls</formal-name>
-            <description>Set parameters or amend controls in resolution</description>
-            <model>
-                  <define-assembly name="set-parameter" max-occurs="unbounded">
-                        <formal-name>Parameter Setting</formal-name>
-                        <description>A parameter setting, to be propagated to points of insertion</description>
-                        <group-as name="set-parameters" in-json="ARRAY"/>
-                        <define-flag required="yes" name="param-id" as-type="token">
-                              <!-- This is an id because the idenfier is assigned and managed by humans. -->
-                              <formal-name>Parameter ID</formal-name>
-                              <!-- Identifier Declaration -->
-                              <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined parameter elsewhere in <a href="/concepts/identifier-use/#profile-identifiers">this or other OSCAL instances</a>. When referenced from another OSCAL instance, this identifier must be referenced in the context of the containing resource (e.g., import-profile). This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-                        </define-flag>
-                        <define-flag name="class" as-type="token">
-                              <formal-name>Parameter Class</formal-name>
-                              <description>A textual label that provides a characterization of the parameter.</description>
-                              <remarks>
-                                    <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
-                              </remarks>
-                        </define-flag>
-                        <define-flag name="depends-on" as-type="token" deprecated="1.0.1">
-                              <formal-name>Depends on</formal-name>
-                              <description>**(deprecated)** Another parameter invoking this one. This construct has been deprecated and should not be used.</description>
-                        </define-flag>
-                        <model>
-                              <assembly ref="property" max-occurs="unbounded">
-                                    <group-as name="props" in-json="ARRAY"/>
-                              </assembly>
-                              <assembly ref="link" max-occurs="unbounded">
-                                    <group-as name="links" in-json="ARRAY"/>
-                              </assembly>
-                              <define-field name="label" as-type="markup-line">
-                                    <formal-name>Parameter Label</formal-name>
-                                    <description>A short, placeholder name for the parameter, which can be used as a substitute for a <code>value</code> if no value is assigned.</description>
-                                    <remarks>
-                                          <p>The label value should be suitable for inline display in a rendered catalog.</p>
-                                    </remarks>
-                              </define-field>
-                              <define-field name="usage" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-                                    <formal-name>Parameter Usage Description</formal-name>
-                                    <description>Describes the purpose and use of a parameter</description>
-                              </define-field>
-                              <assembly ref="parameter-constraint" max-occurs="unbounded">
-                                    <use-name>constraint</use-name>
-                                    <group-as name="constraints" in-json="ARRAY"/>
-                              </assembly>
-                              <assembly ref="parameter-guideline" max-occurs="unbounded">
-                                    <use-name>guideline</use-name>
-                                    <group-as name="guidelines" in-json="ARRAY"/>
-                              </assembly>
-                              <choice>
-                                    <field ref="parameter-value" max-occurs="unbounded">
-                                          <use-name>value</use-name>
-                                          <group-as name="values" in-json="ARRAY"/>
-                                          <remarks>
-                                                <p>Used to (re)define a parameter value.</p>
-                                          </remarks>
-                                    </field>
-                                    <assembly ref="parameter-selection">
-                                          <use-name>select</use-name>
-                                    </assembly>
-                              </choice>
-                        </model>
-                  </define-assembly>
-                  <assembly ref="alter" max-occurs="unbounded">
-                        <group-as name="alters" in-json="ARRAY"/>
-                  </assembly>
-            </model>
-            <constraint>
-                  <is-unique id="unique-profile-modify-set-parameter" target="set-parameter">
-                        <key-field target="@param-id"/>
-                        <remarks>
-                              <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
-                        </remarks>
-                  </is-unique>
-            </constraint>
-            
-      </define-assembly>
-      <define-assembly name="insert-controls">
-            <formal-name>Select controls</formal-name>
-            <description>Specifies which controls to use in the containing context.</description>
-            <define-flag as-type="token" name="order">
-                  <formal-name>Order</formal-name>
-                  <description>A designation of how a selection of controls in a profile is to be ordered.</description>
-                  <constraint>
-                        <allowed-values>
-                              <enum value="keep"/>
-                              <enum value="ascending"/>
-                              <enum value="descending"/>
-                        </allowed-values>
-                  </constraint>
-            </define-flag>
-            <model>
-                  <choice>
-                        <assembly ref="include-all" min-occurs="1"/>
-                        <assembly ref="select-control-by-id" min-occurs="1" max-occurs="unbounded">
-                              <use-name>include-controls</use-name>
-                              <group-as name="include-controls" in-json="ARRAY"/>
-                        </assembly>
-                  </choice>
-                  <assembly ref="select-control-by-id" max-occurs="unbounded">
-                        <use-name>exclude-controls</use-name>
-                        <group-as name="exclude-controls" in-json="ARRAY"/>
-                        <remarks>
-                              <p>Identifies which controls to exclude, or eliminate, from the set of matching includes.</p>
-                        </remarks>
-                  </assembly>
-            </model>
-            <remarks>
-                  <p>To be schema-valid, this element must contain either (but not both) a single <code>include-all</code> directive, or a sequence of <code>include-controls</code> directives.</p>
-                  <p>If this directive is not provided, then no controls are to be inserted; i.e., all controls are included explicitly.</p>
-            </remarks>
-      </define-assembly>
-      <define-assembly name="select-control-by-id" scope="local">
-            <formal-name>Call</formal-name>
-            <description>Call a control by its ID</description>
-            <flag ref="with-child-controls"/>
-            <model>
-                  <define-field name="with-id" as-type="token" max-occurs="unbounded">
-                        <formal-name>Match Controls by Identifier</formal-name>
-                        <description></description>
-                        <group-as name="with-ids" in-json="ARRAY"/>
-                  </define-field>
-                  <define-assembly name="matching" max-occurs="unbounded">
-                        <formal-name>Match Controls by Pattern</formal-name>
-                        <description>Select controls by (regular expression) match on ID</description>
-                        <group-as name="matching" in-json="ARRAY"/>
-                        <flag ref="pattern"/>
-                  </define-assembly>
-            </model>
-            <remarks>
-                  <p>If <code>with-child-controls</code> is <q>yes</q> on the call to a control, no sibling <code>call</code>elements need to be used to call any controls appearing within it. Since generally, this is how control enhancements are represented (as controls within controls), this provides a way to include controls with all their dependent controls (enhancements) without having to call them individually.</p>
-            </remarks>
-      </define-assembly>
-      <define-assembly name="alter">
-            <formal-name>Alteration</formal-name>
-            <description>An Alter element specifies changes to be made to an included control when a profile is resolved.</description>
-            <flag ref="control-id" required="yes"/>
-            <model>
-                  <assembly ref="remove" max-occurs="unbounded">
-                        <group-as name="removes" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="add" max-occurs="unbounded">
-                        <group-as name="adds" in-json="ARRAY"/>
-                  </assembly>
-            </model>
-            <remarks>
-                  <p>Use <code>@control-id</code> to indicate the scope of alteration.</p>
-                  <p>It is an error for two <code>alter</code> elements to apply to the same control. In practice, multiple alterations can be applied (together), but it creates confusion.</p>
-                  <p>At present, no provision is made for altering many controls at once (for example, to systematically remove properties or add global properties); extending this element to match multiple control IDs could provide for this.</p>
-            </remarks>
-      </define-assembly>
-      <define-assembly name="remove">
-            <formal-name>Removal</formal-name>
-            <description>Specifies objects to be removed from a control based on specific aspects of the object that must all match.</description>
-            <define-flag name="by-name" as-type="token">
-                  <formal-name>Reference by (assigned) name</formal-name>
-                  <description>Identify items to remove by matching their assigned name</description>
-            </define-flag>
-            <define-flag name="by-class" as-type="token">
-                  <formal-name>Reference by class</formal-name>
-                  <description>Identify items to remove by matching their <code>class</code>.</description>
-            </define-flag>
-            <define-flag name="by-id" as-type="token">
-                  <formal-name>Reference by ID</formal-name>
-                  <description>Identify items to remove indicated by their <code>id</code>.</description>
-            </define-flag>
-            <define-flag name="by-item-name" as-type="token">
-                  <formal-name>Item Name Reference</formal-name>
-                  <description>Identify items to remove by the name of the item's information element name, e.g. <code>title</code> or <code>prop</code></description>
-            </define-flag>
-            <define-flag name="by-ns" as-type="token">
-                  <formal-name>Item Namespace Reference</formal-name>
-                  <description>Identify items to remove by the item's <code>ns</code>, which is the namespace associated with a <code>part</code>, or <code>prop</code>.</description>
-            </define-flag>
-            <remarks>
-                  <p>Use <code>name-ref</code>, <code>class-ref</code>, <code>id-ref</code> or <code>generic-identifier</code> to indicate class tokens or ID reference, or the formal name, of the component to be removed or erased from a control, when a catalog is resolved. The control affected is indicated by the pointer on the removal's parent (containing) <code>alter</code> element.</p>
-                  <p>To change an element, use <code>remove</code> to remove the element, then <code>add</code> to add it back again with changes.</p>
-            </remarks>
-      </define-assembly>
-      <define-assembly name="add">
-            <formal-name>Addition</formal-name>
-            <description>Specifies contents to be added into controls, in resolution</description>
-            <define-flag name="position" as-type="token">
-                  <formal-name>Position</formal-name>
-                  <description>Where to add the new content with respect to the targeted element (beside it or inside it)</description>
-                  <constraint>
-                        <allowed-values>
-                              <enum value="before">Preceding the id-ref target</enum>
-                              <enum value="after">Following the id-ref target</enum>
-                              <enum value="starting">Inside the control or id-ref target, at the start</enum>
-                              <enum value="ending">Inside the control or id-ref target, at the end</enum>
-                        </allowed-values>
-                  </constraint>
-            </define-flag>
-            <define-flag name="by-id" as-type="token">
-                  <formal-name>Reference by ID</formal-name>
-                  <description>Target location of the addition.</description>
-            </define-flag>
-            <model>
-                  <define-field name="title" as-type="markup-line">
-                        <formal-name>Title Change</formal-name>
-                        <description>A name given to the control, which may be used by a tool for display and navigation.</description>
-                  </define-field>
-                  <assembly ref="parameter" max-occurs="unbounded">
-                        <!-- CHANGED: "parameters" to "params" -->
-                        <group-as name="params" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="property" max-occurs="unbounded">
+        </define-flag>
+        <model>
+            <define-field name="title" as-type="markup-line" min-occurs="1">
+                <formal-name>Group Title</formal-name>
+                <description>A name given to the group, which may be used by a tool for display and navigation.</description>
+            </define-field>
+            <assembly ref="parameter" max-occurs="unbounded">
+                <group-as name="params" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="part" max-occurs="unbounded">
+                <group-as name="parts" in-json="ARRAY"/>
+            </assembly>
+            <choice>
+                <assembly ref="group" max-occurs="unbounded">
+                    <group-as name="groups" in-json="ARRAY"/>
+                </assembly>
+                <assembly ref="insert-controls" max-occurs="unbounded">
+                    <group-as name="insert-controls" in-json="ARRAY"/>
+                </assembly>
+            </choice>
+        </model>
+        <remarks>
+            <p>This construct mirrors the same construct that exists in an OSCAL catalog.</p>
+        </remarks>
+    </define-assembly>
+    <define-assembly name="modify">
+        <formal-name>Modify controls</formal-name>
+        <description>Set parameters or amend controls in resolution</description>
+        <model>
+            <define-assembly name="set-parameter" max-occurs="unbounded">
+                <formal-name>Parameter Setting</formal-name>
+                <description>A parameter setting, to be propagated to points of insertion</description>
+                <group-as name="set-parameters" in-json="ARRAY"/>
+                <define-flag required="yes" name="param-id" as-type="token">
+                    <!-- This is an id because the idenfier is assigned and managed by humans. -->
+                    <formal-name>Parameter ID</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#locally-unique">locally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined parameter elsewhere in <a href="/concepts/identifier-use/#profile-identifiers">this or other OSCAL instances</a>. When referenced from another OSCAL instance, this identifier must be referenced in the context of the containing resource (e.g., import-profile). This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+                <define-flag name="class" as-type="token">
+                    <formal-name>Parameter Class</formal-name>
+                    <description>A textual label that provides a characterization of the parameter.</description>
+                    <remarks>
+                        <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
+                    </remarks>
+                </define-flag>
+                <define-flag name="depends-on" as-type="token" deprecated="1.0.1">
+                    <formal-name>Depends on</formal-name>
+                    <description>**(deprecated)** Another parameter invoking this one. This construct has been deprecated and should not be used.</description>
+                </define-flag>
+                <model>
+                    <assembly ref="property" max-occurs="unbounded">
                         <group-as name="props" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="link" max-occurs="unbounded">
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
                         <group-as name="links" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="part" max-occurs="unbounded">
-                        <group-as name="parts" in-json="ARRAY"/>
-                  </assembly>
-            </model>
+                    </assembly>
+                    <define-field name="label" as-type="markup-line">
+                        <formal-name>Parameter Label</formal-name>
+                        <description>A short, placeholder name for the parameter, which can be used as a substitute for a <code>value</code> if no value is assigned.</description>
+                        <remarks>
+                            <p>The label value should be suitable for inline display in a rendered catalog.</p>
+                        </remarks>
+                    </define-field>
+                    <define-field name="usage" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                        <formal-name>Parameter Usage Description</formal-name>
+                        <description>Describes the purpose and use of a parameter</description>
+                    </define-field>
+                    <assembly ref="parameter-constraint" max-occurs="unbounded">
+                        <use-name>constraint</use-name>
+                        <group-as name="constraints" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="parameter-guideline" max-occurs="unbounded">
+                        <use-name>guideline</use-name>
+                        <group-as name="guidelines" in-json="ARRAY"/>
+                    </assembly>
+                    <choice>
+                        <field ref="parameter-value" max-occurs="unbounded">
+                            <use-name>value</use-name>
+                            <group-as name="values" in-json="ARRAY"/>
+                            <remarks>
+                                <p>Used to (re)define a parameter value.</p>
+                            </remarks>
+                        </field>
+                        <assembly ref="parameter-selection">
+                            <use-name>select</use-name>
+                        </assembly>
+                    </choice>
+                </model>
+            </define-assembly>
+            <assembly ref="alter" max-occurs="unbounded">
+                <group-as name="alters" in-json="ARRAY"/>
+            </assembly>
+        </model>
+        <constraint>
+            <is-unique id="unique-profile-modify-set-parameter" target="set-parameter">
+                <key-field target="@param-id"/>
+                <remarks>
+                    <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+
+    </define-assembly>
+    <define-assembly name="insert-controls">
+        <formal-name>Select controls</formal-name>
+        <description>Specifies which controls to use in the containing context.</description>
+        <define-flag as-type="token" name="order">
+            <formal-name>Order</formal-name>
+            <description>A designation of how a selection of controls in a profile is to be ordered.</description>
             <constraint>
-                  <!-- CHANGE: added allowed values for a property/@name -->
-                  <allowed-values target="prop/@name" allow-other="yes">
-            &allowed-values-control-group-property-name;
-                  </allowed-values>
+                <allowed-values>
+                    <enum value="keep"/>
+                    <enum value="ascending"/>
+                    <enum value="descending"/>
+                </allowed-values>
             </constraint>
-            <remarks>
-                  <p>When no <code>id-ref</code> is given, the addition is inserted into the control targeted by the alteration at the start or end as indicated by <code>position</code>. Only <code>position</code> values of "starting" or "ending" are permitted when there is no <code>id-ref</code>.</p>
-                  <p><code>id-ref</code>, when given, should indicate, by its ID, an element inside the control to serve as the anchor point for the addition. In this case, <code>position</code> value may be any of the permitted values.</p>
-            </remarks>
-      </define-assembly>
-      <define-flag as-type="token" name="with-child-controls">
-            <formal-name>Include contained controls with control</formal-name>
-            <description>When a control is included, whether its child (dependent) controls are also included.</description>
+        </define-flag>
+        <model>
+            <choice>
+                <assembly ref="include-all" min-occurs="1"/>
+                <assembly ref="select-control-by-id" min-occurs="1" max-occurs="unbounded">
+                    <use-name>include-controls</use-name>
+                    <group-as name="include-controls" in-json="ARRAY"/>
+                </assembly>
+            </choice>
+            <assembly ref="select-control-by-id" max-occurs="unbounded">
+                <use-name>exclude-controls</use-name>
+                <group-as name="exclude-controls" in-json="ARRAY"/>
+                <remarks>
+                    <p>Identifies which controls to exclude, or eliminate, from the set of matching includes.</p>
+                </remarks>
+            </assembly>
+        </model>
+        <remarks>
+            <p>To be schema-valid, this element must contain either (but not both) a single <code>include-all</code> directive, or a sequence of <code>include-controls</code> directives.</p>
+            <p>If this directive is not provided, then no controls are to be inserted; i.e., all controls are included explicitly.</p>
+        </remarks>
+    </define-assembly>
+    <define-assembly name="select-control-by-id" scope="local">
+        <formal-name>Call</formal-name>
+        <description>Call a control by its ID</description>
+        <flag ref="with-child-controls"/>
+        <model>
+            <define-field name="with-id" as-type="token" max-occurs="unbounded">
+                <formal-name>Match Controls by Identifier</formal-name>
+                <description></description>
+                <group-as name="with-ids" in-json="ARRAY"/>
+            </define-field>
+            <define-assembly name="matching" max-occurs="unbounded">
+                <formal-name>Match Controls by Pattern</formal-name>
+                <description>Select controls by (regular expression) match on ID</description>
+                <group-as name="matching" in-json="ARRAY"/>
+                <flag ref="pattern"/>
+            </define-assembly>
+        </model>
+        <remarks>
+            <p>If <code>with-child-controls</code> is <q>yes</q> on the call to a control, no sibling <code>call</code>elements need to be used to call any controls appearing within it. Since generally, this is how control enhancements are represented (as controls within controls), this provides a way to include controls with all their dependent controls (enhancements) without having to call them individually.</p>
+        </remarks>
+    </define-assembly>
+    <define-assembly name="alter">
+        <formal-name>Alteration</formal-name>
+        <description>An Alter element specifies changes to be made to an included control when a profile is resolved.</description>
+        <flag ref="control-id" required="yes"/>
+        <model>
+            <assembly ref="remove" max-occurs="unbounded">
+                <group-as name="removes" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="add" max-occurs="unbounded">
+                <group-as name="adds" in-json="ARRAY"/>
+            </assembly>
+        </model>
+        <remarks>
+            <p>Use <code>@control-id</code> to indicate the scope of alteration.</p>
+            <p>It is an error for two <code>alter</code> elements to apply to the same control. In practice, multiple alterations can be applied (together), but it creates confusion.</p>
+            <p>At present, no provision is made for altering many controls at once (for example, to systematically remove properties or add global properties); extending this element to match multiple control IDs could provide for this.</p>
+        </remarks>
+    </define-assembly>
+    <define-assembly name="remove">
+        <formal-name>Removal</formal-name>
+        <description>Specifies objects to be removed from a control based on specific aspects of the object that must all match.</description>
+        <define-flag name="by-name" as-type="token">
+            <formal-name>Reference by (assigned) name</formal-name>
+            <description>Identify items to remove by matching their assigned name</description>
+        </define-flag>
+        <define-flag name="by-class" as-type="token">
+            <formal-name>Reference by class</formal-name>
+            <description>Identify items to remove by matching their <code>class</code>.</description>
+        </define-flag>
+        <define-flag name="by-id" as-type="token">
+            <formal-name>Reference by ID</formal-name>
+            <description>Identify items to remove indicated by their <code>id</code>.</description>
+        </define-flag>
+        <define-flag name="by-item-name" as-type="token">
+            <formal-name>Item Name Reference</formal-name>
+            <description>Identify items to remove by the name of the item's information element name, e.g. <code>title</code> or <code>prop</code></description>
+        </define-flag>
+        <define-flag name="by-ns" as-type="token">
+            <formal-name>Item Namespace Reference</formal-name>
+            <description>Identify items to remove by the item's <code>ns</code>, which is the namespace associated with a <code>part</code>, or <code>prop</code>.</description>
+        </define-flag>
+        <remarks>
+            <p>Use <code>name-ref</code>, <code>class-ref</code>, <code>id-ref</code> or <code>generic-identifier</code> to indicate class tokens or ID reference, or the formal name, of the component to be removed or erased from a control, when a catalog is resolved. The control affected is indicated by the pointer on the removal's parent (containing) <code>alter</code> element.</p>
+            <p>To change an element, use <code>remove</code> to remove the element, then <code>add</code> to add it back again with changes.</p>
+        </remarks>
+    </define-assembly>
+    <define-assembly name="add">
+        <formal-name>Addition</formal-name>
+        <description>Specifies contents to be added into controls, in resolution</description>
+        <define-flag name="position" as-type="token">
+            <formal-name>Position</formal-name>
+            <description>Where to add the new content with respect to the targeted element (beside it or inside it)</description>
             <constraint>
-                  <allowed-values>
-                        <enum value="yes">Include child controls with an included control.</enum>
-                        <enum value="no">When importing a control, only include child controls that are also explicitly called.</enum>
-                  </allowed-values>
+                <allowed-values>
+                    <enum value="before">Preceding the id-ref target</enum>
+                    <enum value="after">Following the id-ref target</enum>
+                    <enum value="starting">Inside the control or id-ref target, at the start</enum>
+                    <enum value="ending">Inside the control or id-ref target, at the end</enum>
+                </allowed-values>
             </constraint>
-      </define-flag>
-      <define-flag as-type="string" name="pattern">
-            <formal-name>Pattern</formal-name>
-            <description>A <a href="https://en.wikipedia.org/wiki/Glob_(programming)">glob expression</a> matching the IDs of one or more controls to be selected.</description>
-      </define-flag>
+        </define-flag>
+        <define-flag name="by-id" as-type="token">
+            <formal-name>Reference by ID</formal-name>
+            <description>Target location of the addition.</description>
+        </define-flag>
+        <model>
+            <define-field name="title" as-type="markup-line">
+                <formal-name>Title Change</formal-name>
+                <description>A name given to the control, which may be used by a tool for display and navigation.</description>
+            </define-field>
+            <assembly ref="parameter" max-occurs="unbounded">
+                <!-- CHANGED: "parameters" to "params" -->
+                <group-as name="params" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="part" max-occurs="unbounded">
+                <group-as name="parts" in-json="ARRAY"/>
+            </assembly>
+        </model>
+        <constraint>
+            <!-- CHANGE: added allowed values for a property/@name -->
+            <allowed-values target="prop/@name" allow-other="yes">
+        &allowed-values-control-group-property-name;
+            </allowed-values>
+        </constraint>
+        <remarks>
+            <p>When no <code>id-ref</code> is given, the addition is inserted into the control targeted by the alteration at the start or end as indicated by <code>position</code>. Only <code>position</code> values of "starting" or "ending" are permitted when there is no <code>id-ref</code>.</p>
+            <p><code>id-ref</code>, when given, should indicate, by its ID, an element inside the control to serve as the anchor point for the addition. In this case, <code>position</code> value may be any of the permitted values.</p>
+        </remarks>
+    </define-assembly>
+    <define-flag as-type="token" name="with-child-controls">
+        <formal-name>Include contained controls with control</formal-name>
+        <description>When a control is included, whether its child (dependent) controls are also included.</description>
+        <constraint>
+            <allowed-values>
+                <enum value="yes">Include child controls with an included control.</enum>
+                <enum value="no">When importing a control, only include child controls that are also explicitly called.</enum>
+            </allowed-values>
+        </constraint>
+    </define-flag>
+    <define-flag as-type="string" name="pattern">
+        <formal-name>Pattern</formal-name>
+        <description>A <a href="https://en.wikipedia.org/wiki/Glob_(programming)">glob expression</a> matching the IDs of one or more controls to be selected.</description>
+    </define-flag>
 </METASCHEMA>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -1,1058 +1,1058 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ** NOTES **
 - Need to check latest FR SSP template for "Privacy Impact Designation".
-  Was it dropped in latest template, or is it missing from schema?
+    Was it dropped in latest template, or is it missing from schema?
 -->
 <!-- OSCAL Implementation Layer: System Security Plan (SSP) METASCHEMA -->
 <!-- validate with XSD and Schematron (linked) -->
 <!DOCTYPE METASCHEMA [
-  <!ENTITY allowed-values-responsible-roles-system SYSTEM "./shared-constraints/allowed-values-responsible-roles-system.ent">
-  <!ENTITY allowed-values-responsible-roles-operations SYSTEM "./shared-constraints/allowed-values-responsible-roles-operations.ent">
-  <!ENTITY allowed-values-responsible-roles-component-production SYSTEM "./shared-constraints/allowed-values-responsible-roles-component-production.ent">
+    <!ENTITY allowed-values-responsible-roles-system SYSTEM "./shared-constraints/allowed-values-responsible-roles-system.ent">
+    <!ENTITY allowed-values-responsible-roles-operations SYSTEM "./shared-constraints/allowed-values-responsible-roles-operations.ent">
+    <!ENTITY allowed-values-responsible-roles-component-production SYSTEM "./shared-constraints/allowed-values-responsible-roles-component-production.ent">
 ]>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
-  <schema-name>OSCAL System Security Plan (SSP) Model</schema-name>
-  <schema-version>1.0.1</schema-version>
-  <short-name>oscal-ssp</short-name>
-  <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
-  <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
-  <remarks>
-    <p>The OSCAL Control SSP format can be used to describe the information typically specified in a system security plan, such as those defined in NIST SP 800-18.</p>
-    <p>The root of the OSCAL System Security Plan (SSP) format is <code>system-security-plan</code>.</p>
-  </remarks>
+    xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
+    <schema-name>OSCAL System Security Plan (SSP) Model</schema-name>
+    <schema-version>1.0.1</schema-version>
+    <short-name>oscal-ssp</short-name>
+    <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
+    <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
+    <remarks>
+        <p>The OSCAL Control SSP format can be used to describe the information typically specified in a system security plan, such as those defined in NIST SP 800-18.</p>
+        <p>The root of the OSCAL System Security Plan (SSP) format is <code>system-security-plan</code>.</p>
+    </remarks>
 
-  <import href="oscal_metadata_metaschema.xml"/>
-  <import href="oscal_implementation-common_metaschema.xml"/>
+    <import href="oscal_metadata_metaschema.xml"/>
+    <import href="oscal_implementation-common_metaschema.xml"/>
 
-  <!-- ############################################## -->
-  <!-- # The SSP Assembly and supporting constructs # -->
-  <!-- ############################################## -->
-  <define-assembly name="system-security-plan">
-    <formal-name>System Security Plan (SSP)</formal-name>
-    <description>A system security plan, such as those described in NIST SP 800-18</description>
-    <root-name>system-security-plan</root-name>
-    <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>System Security Plan Universally Unique Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this system security plan (SSP) elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>SSP</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <model>
-      <assembly ref="metadata" min-occurs="1"/>
-      <assembly ref="import-profile" min-occurs="1"/>
-      <assembly ref="system-characteristics" min-occurs="1"/>
-      <assembly ref="system-implementation" min-occurs="1"/>
-      <assembly ref="control-implementation" min-occurs="1"/>
-      <assembly ref="back-matter"/>
-    </model>
-  </define-assembly>
-
-  <!-- ######################################################### -->
-  <!-- # The Import Profile Assembly and supporting constructs # -->
-  <!-- ######################################################### -->
-  <define-assembly name="import-profile">
-    <formal-name>Import Profile</formal-name>
-    <description>Used to import the OSCAL profile representing the system's control baseline.</description>
-    <define-flag name="href" as-type="uri-reference" required="yes">
-      <formal-name>Profile Reference</formal-name>
-      <description>A resolvable URL reference to the profile to use as the system's control baseline.</description>
-      <remarks>
-        <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code>
-          <code>resource</code> in the same document.</p>
-        <!-- TODO: Add a link to "within the scope of the containing OSCAL document" to point to documentation of identification scopes" -->
-        <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is within the scope of the containing OSCAL document.</p>
-        <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URI pointing to the location of the referenced resource. A relative URI will be resolved relative to the location of the document containing the link.</p>
-      </remarks>
-    </define-flag>
-    <model>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-  </define-assembly>
-
-  <!-- ################################################################# -->
-  <!-- # The System Characteristics Assembly and supporting constructs # -->
-  <!-- ################################################################# -->
-  <define-assembly name="system-characteristics">
-    <formal-name>System Characteristics</formal-name>
-    <description>Contains the characteristics of the system, such as its name, purpose, and security impact level.</description>
-    <model>
-      <field ref="system-id" min-occurs="1" max-occurs="unbounded">
-        <group-as name="system-ids" in-json="ARRAY"/>
-      </field>
-      <define-field name="system-name" as-type="string" min-occurs="1">
-        <formal-name>System Name - Full</formal-name>
-        <description>The full name of the system.</description>
-      </define-field>
-      <define-field name="system-name-short" as-type="string">
-        <formal-name>System Name - Short</formal-name>
-        <description>A short name for the system, such as an acronym, that is suitable for display in a data table or summary list.</description>
-      </define-field>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>System Description</formal-name>
-        <description>A summary of the system.</description>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <field ref="date-authorized"/>
-      <define-field name="security-sensitivity-level" min-occurs="1">
-        <formal-name>Security Sensitivity Level</formal-name>
-        <description>The overall information system sensitivity categorization, such as defined by <a href="https://doi.org/10.6028/NIST.FIPS.199">FIPS-199</a>.
-        </description>
-        <remarks>
-          <p>Often, organizations require the security sensitivity level to correspond with the highest confidentiality, integrity, or availability level identified by <code>security-impact-level</code>.
-          </p>
-        </remarks>
-      </define-field>
-      <assembly ref="system-information" min-occurs="1"/>
-      <assembly ref="security-impact-level" min-occurs="1"/>
-      <assembly ref="status" min-occurs="1"/>
-      <assembly ref="authorization-boundary" min-occurs="1"/>
-      <assembly ref="network-architecture"/>
-      <assembly ref="data-flow"/>
-      <assembly ref="responsible-party" max-occurs="unbounded">
-        <group-as name="responsible-parties" in-json="ARRAY"/>
-      </assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <allowed-values target="prop/@name" allow-other="yes">
-        <enum value="identity-assurance-level">A value of 1, 2, or 3 as defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
-        </enum>
-        <enum value="authenticator-assurance-level">A value of 1, 2, or 3 as defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
-        </enum>
-        <enum value="federation-assurance-level">A value of 1, 2, or 3 as defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
-        </enum>
-      </allowed-values>
-      <allowed-values target="prop[@name=('identity-assurance-level','authenticator-assurance-level','federation-assurance-level')]/@value">
-        <enum value="1">As defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
-        </enum>
-        <enum value="2">As defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
-        </enum>
-        <enum value="3">As defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
-        </enum>
-      </allowed-values>
-      <allowed-values target="prop/@name" allow-other="yes">
-        <enum value="cloud-deployment-model">The associated value is one of: public-cloud, private-cloud, community-cloud, government-only-cloud, hybrid-cloud, or other.</enum>
-        <enum value="cloud-service-model">The associated value is one of: saas, paas, iaas, or other.</enum>
-      </allowed-values>
-      <allowed-values target="prop[@name='cloud-deployment-model']/@value">
-        <enum value="public-cloud">The public cloud deployment model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
-        </enum>
-        <enum value="private-cloud">The private cloud deployment model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
-        </enum>
-        <enum value="community-cloud">The community cloud deployment model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
-        </enum>
-        <!-- TODO: consider generalizing this in a way that applies to other usage contexts. -->
-        <enum value="government-only-cloud">A specific type of community-cloud for use only by government services.</enum>
-        <enum value="other">Any other type of cloud deployment model that is exclusive to the other choices.</enum>
-        <remarks>
-          <p>The hybrid cloud deployment model, as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>, can be supported by selecting two or more of the existing deployment models.</p>
-        </remarks>
-      </allowed-values>
-      <allowed-values target="prop[@name='cloud-service-model']/@value">
-        <enum value="saas">Software as a service (SaaS) cloud service model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
-        </enum>
-        <enum value="paas">Platform as a service (PaaS) cloud service model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
-        </enum>
-        <enum value="iaas">Infrastructure as a service (IaaS) cloud service model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
-        </enum>
-        <enum value="other">Any other type of cloud service model that is exclusive to the other choices.</enum>
-      </allowed-values>
-      <is-unique id="unique-ssp-system-characteristics-responsible-party" target="responsible-party">
-        <key-field target="@role-id"/>
-        <remarks>
-          <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-        </remarks>
-      </is-unique>
-      <allowed-values target="responsible-party/@role-id" allow-other="yes">
-            &allowed-values-responsible-roles-system;
-      </allowed-values>
-    </constraint>
-  </define-assembly>
-  <define-assembly name="system-information">
-    <formal-name>System Information</formal-name>
-    <description>Contains details about all information types that are stored, processed, or transmitted by the system, such as privacy information, and those defined in <a href="https://doi.org/10.6028/NIST.SP.800-60v2r1">NIST SP 800-60</a>.
-    </description>
-    <model>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <define-assembly name="information-type" min-occurs="1" max-occurs="unbounded">
-        <formal-name>Information Type</formal-name>
-        <description>Contains details about one information type that is stored, processed, or transmitted by the system, such as privacy information, and those defined in <a href="https://doi.org/10.6028/NIST.SP.800-60v2r1">NIST SP 800-60</a>.
-        </description>
-        <group-as name="information-types" in-json="ARRAY"/>
-        <define-flag name="uuid" as-type="uuid">
-          <formal-name>Information Type Universally Unique Identifier</formal-name>
-          <!-- Identifier Declaration -->
-          <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this information type elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>information type</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+    <!-- ############################################## -->
+    <!-- # The SSP Assembly and supporting constructs # -->
+    <!-- ############################################## -->
+    <define-assembly name="system-security-plan">
+        <formal-name>System Security Plan (SSP)</formal-name>
+        <description>A system security plan, such as those described in NIST SP 800-18</description>
+        <root-name>system-security-plan</root-name>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>System Security Plan Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this system security plan (SSP) elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>SSP</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
         </define-flag>
         <model>
-          <define-field name="title" as-type="markup-line" min-occurs="1">
-            <formal-name>title field</formal-name>
-            <description>A human readable name for the information type. This title should be meaningful within the context of the system.</description>
-          </define-field>
-          <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-            <formal-name>Information Type Description</formal-name>
-            <description>A summary of how this information type is used within the system.</description>
-          </define-field>
-          <define-assembly name="categorization" max-occurs="unbounded">
-            <!-- CHANGED: replaced the information-type-id structure with the current structure -->
-            <formal-name>Information Type Categorization</formal-name>
-            <description>A set of information type identifiers qualified by the given identification <code>system</code> used, such as NIST SP 800-60.</description>
-            <group-as name="categorizations" in-json="ARRAY"/>
-            <define-flag name="system" as-type="uri" required="yes">
-              <formal-name>Information Type Identification System</formal-name>
-              <description>Specifies the information type identification system used.</description>
-              <constraint>
-                <allowed-values allow-other="yes">
-                  <enum value="https://doi.org/10.6028/NIST.SP.800-60v2r1">Based on the section identifiers in NIST <a href="https://doi.org/10.6028/NIST.SP.800-60v2r1">Special Publication 800-60 Volume II Revision 1</a>.
-                  </enum>
+            <assembly ref="metadata" min-occurs="1"/>
+            <assembly ref="import-profile" min-occurs="1"/>
+            <assembly ref="system-characteristics" min-occurs="1"/>
+            <assembly ref="system-implementation" min-occurs="1"/>
+            <assembly ref="control-implementation" min-occurs="1"/>
+            <assembly ref="back-matter"/>
+        </model>
+    </define-assembly>
+
+    <!-- ######################################################### -->
+    <!-- # The Import Profile Assembly and supporting constructs # -->
+    <!-- ######################################################### -->
+    <define-assembly name="import-profile">
+        <formal-name>Import Profile</formal-name>
+        <description>Used to import the OSCAL profile representing the system's control baseline.</description>
+        <define-flag name="href" as-type="uri-reference" required="yes">
+            <formal-name>Profile Reference</formal-name>
+            <description>A resolvable URL reference to the profile to use as the system's control baseline.</description>
+            <remarks>
+                <p>The value of the <code>href</code> can be an internet resource, or a local reference using a fragment e.g. #fragment that points to a <code>back-matter</code>
+                    <code>resource</code> in the same document.</p>
+                <!-- TODO: Add a link to "within the scope of the containing OSCAL document" to point to documentation of identification scopes" -->
+                <p>If a local reference using a fragment is used, this will be indicated by a fragment "#" followed by an identifier which references an identified <code>resource</code> in the document's <code>back-matter</code> or another object that is within the scope of the containing OSCAL document.</p>
+                <p>If an internet resource is used, the <code>href</code> value will be an absolute or relative URI pointing to the location of the referenced resource. A relative URI will be resolved relative to the location of the document containing the link.</p>
+            </remarks>
+        </define-flag>
+        <model>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+    </define-assembly>
+
+    <!-- ################################################################# -->
+    <!-- # The System Characteristics Assembly and supporting constructs # -->
+    <!-- ################################################################# -->
+    <define-assembly name="system-characteristics">
+        <formal-name>System Characteristics</formal-name>
+        <description>Contains the characteristics of the system, such as its name, purpose, and security impact level.</description>
+        <model>
+            <field ref="system-id" min-occurs="1" max-occurs="unbounded">
+                <group-as name="system-ids" in-json="ARRAY"/>
+            </field>
+            <define-field name="system-name" as-type="string" min-occurs="1">
+                <formal-name>System Name - Full</formal-name>
+                <description>The full name of the system.</description>
+            </define-field>
+            <define-field name="system-name-short" as-type="string">
+                <formal-name>System Name - Short</formal-name>
+                <description>A short name for the system, such as an acronym, that is suitable for display in a data table or summary list.</description>
+            </define-field>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>System Description</formal-name>
+                <description>A summary of the system.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <field ref="date-authorized"/>
+            <define-field name="security-sensitivity-level" min-occurs="1">
+                <formal-name>Security Sensitivity Level</formal-name>
+                <description>The overall information system sensitivity categorization, such as defined by <a href="https://doi.org/10.6028/NIST.FIPS.199">FIPS-199</a>.
+                </description>
+                <remarks>
+                    <p>Often, organizations require the security sensitivity level to correspond with the highest confidentiality, integrity, or availability level identified by <code>security-impact-level</code>.
+                    </p>
+                </remarks>
+            </define-field>
+            <assembly ref="system-information" min-occurs="1"/>
+            <assembly ref="security-impact-level" min-occurs="1"/>
+            <assembly ref="status" min-occurs="1"/>
+            <assembly ref="authorization-boundary" min-occurs="1"/>
+            <assembly ref="network-architecture"/>
+            <assembly ref="data-flow"/>
+            <assembly ref="responsible-party" max-occurs="unbounded">
+                <group-as name="responsible-parties" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <allowed-values target="prop/@name" allow-other="yes">
+                <enum value="identity-assurance-level">A value of 1, 2, or 3 as defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
+                </enum>
+                <enum value="authenticator-assurance-level">A value of 1, 2, or 3 as defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
+                </enum>
+                <enum value="federation-assurance-level">A value of 1, 2, or 3 as defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
+                </enum>
+            </allowed-values>
+            <allowed-values target="prop[@name=('identity-assurance-level','authenticator-assurance-level','federation-assurance-level')]/@value">
+                <enum value="1">As defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
+                </enum>
+                <enum value="2">As defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
+                </enum>
+                <enum value="3">As defined by <a href="https://doi.org/10.6028/NIST.SP.800-63-3">SP 800-63-3</a>.
+                </enum>
+            </allowed-values>
+            <allowed-values target="prop/@name" allow-other="yes">
+                <enum value="cloud-deployment-model">The associated value is one of: public-cloud, private-cloud, community-cloud, government-only-cloud, hybrid-cloud, or other.</enum>
+                <enum value="cloud-service-model">The associated value is one of: saas, paas, iaas, or other.</enum>
+            </allowed-values>
+            <allowed-values target="prop[@name='cloud-deployment-model']/@value">
+                <enum value="public-cloud">The public cloud deployment model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
+                </enum>
+                <enum value="private-cloud">The private cloud deployment model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
+                </enum>
+                <enum value="community-cloud">The community cloud deployment model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
+                </enum>
+                <!-- TODO: consider generalizing this in a way that applies to other usage contexts. -->
+                <enum value="government-only-cloud">A specific type of community-cloud for use only by government services.</enum>
+                <enum value="other">Any other type of cloud deployment model that is exclusive to the other choices.</enum>
+                <remarks>
+                    <p>The hybrid cloud deployment model, as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>, can be supported by selecting two or more of the existing deployment models.</p>
+                </remarks>
+            </allowed-values>
+            <allowed-values target="prop[@name='cloud-service-model']/@value">
+                <enum value="saas">Software as a service (SaaS) cloud service model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
+                </enum>
+                <enum value="paas">Platform as a service (PaaS) cloud service model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
+                </enum>
+                <enum value="iaas">Infrastructure as a service (IaaS) cloud service model as defined by <a href="https://doi.org/10.6028/NIST.SP.800-145">The NIST Definition of Cloud Computing</a>.
+                </enum>
+                <enum value="other">Any other type of cloud service model that is exclusive to the other choices.</enum>
+            </allowed-values>
+            <is-unique id="unique-ssp-system-characteristics-responsible-party" target="responsible-party">
+                <key-field target="@role-id"/>
+                <remarks>
+                    <p>Since <code>responsible-party</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+            <allowed-values target="responsible-party/@role-id" allow-other="yes">
+                        &allowed-values-responsible-roles-system;
+            </allowed-values>
+        </constraint>
+    </define-assembly>
+    <define-assembly name="system-information">
+        <formal-name>System Information</formal-name>
+        <description>Contains details about all information types that are stored, processed, or transmitted by the system, such as privacy information, and those defined in <a href="https://doi.org/10.6028/NIST.SP.800-60v2r1">NIST SP 800-60</a>.
+        </description>
+        <model>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <define-assembly name="information-type" min-occurs="1" max-occurs="unbounded">
+                <formal-name>Information Type</formal-name>
+                <description>Contains details about one information type that is stored, processed, or transmitted by the system, such as privacy information, and those defined in <a href="https://doi.org/10.6028/NIST.SP.800-60v2r1">NIST SP 800-60</a>.
+                </description>
+                <group-as name="information-types" in-json="ARRAY"/>
+                <define-flag name="uuid" as-type="uuid">
+                    <formal-name>Information Type Universally Unique Identifier</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this information type elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>information type</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+                <model>
+                    <define-field name="title" as-type="markup-line" min-occurs="1">
+                        <formal-name>title field</formal-name>
+                        <description>A human readable name for the information type. This title should be meaningful within the context of the system.</description>
+                    </define-field>
+                    <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                        <formal-name>Information Type Description</formal-name>
+                        <description>A summary of how this information type is used within the system.</description>
+                    </define-field>
+                    <define-assembly name="categorization" max-occurs="unbounded">
+                        <!-- CHANGED: replaced the information-type-id structure with the current structure -->
+                        <formal-name>Information Type Categorization</formal-name>
+                        <description>A set of information type identifiers qualified by the given identification <code>system</code> used, such as NIST SP 800-60.</description>
+                        <group-as name="categorizations" in-json="ARRAY"/>
+                        <define-flag name="system" as-type="uri" required="yes">
+                            <formal-name>Information Type Identification System</formal-name>
+                            <description>Specifies the information type identification system used.</description>
+                            <constraint>
+                                <allowed-values allow-other="yes">
+                                    <enum value="https://doi.org/10.6028/NIST.SP.800-60v2r1">Based on the section identifiers in NIST <a href="https://doi.org/10.6028/NIST.SP.800-60v2r1">Special Publication 800-60 Volume II Revision 1</a>.
+                                    </enum>
+                                </allowed-values>
+                            </constraint>
+                        </define-flag>
+                        <model>
+                            <define-field name="information-type-id" as-type="string" max-occurs="unbounded">
+                                <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
+                                <formal-name>Information Type Systematized Identifier</formal-name>
+                                <!-- Identifier Declaration -->
+                                <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier qualified by the given identification <code>system</code> used, such as NIST SP 800-60.    This identifier has <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope and can be used to reference this system elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                                <json-value-key>id</json-value-key>
+                                <group-as name="information-type-ids" in-json="ARRAY"/>
+                            </define-field>
+                        </model>
+                    </define-assembly>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                    </assembly>
+                    <define-assembly name="confidentiality-impact" min-occurs="1">
+                        <formal-name>Confidentiality Impact Level</formal-name>
+                        <description>The expected level of impact resulting from the unauthorized disclosure of the described information.</description>
+                        <model>
+                            <assembly ref="property" max-occurs="unbounded">
+                                <group-as name="props" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="link" max-occurs="unbounded">
+                                <group-as name="links" in-json="ARRAY"/>
+                            </assembly>
+                            <field ref="base" min-occurs="1"/>
+                            <field ref="selected"/>
+                            <field ref="adjustment-justification" in-xml="WITH_WRAPPER"/>
+                        </model>
+                    </define-assembly>
+                    <define-assembly name="integrity-impact" min-occurs="1">
+                        <formal-name>Integrity Impact Level</formal-name>
+                        <description>The expected level of impact resulting from the unauthorized modification of the described information.</description>
+                        <model>
+                            <assembly ref="property" max-occurs="unbounded">
+                                <group-as name="props" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="link" max-occurs="unbounded">
+                                <group-as name="links" in-json="ARRAY"/>
+                            </assembly>
+                            <field ref="base" min-occurs="1"/>
+                            <field ref="selected"/>
+                            <field ref="adjustment-justification" in-xml="WITH_WRAPPER"/>
+                        </model>
+                    </define-assembly>
+                    <define-assembly name="availability-impact" min-occurs="1">
+                        <formal-name>Availability Impact Level</formal-name>
+                        <description>The expected level of impact resulting from the disruption of access to or use of the described information or the information system.</description>
+                        <model>
+                            <assembly ref="property" max-occurs="unbounded">
+                                <group-as name="props" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="link" max-occurs="unbounded">
+                                <group-as name="links" in-json="ARRAY"/>
+                            </assembly>
+                            <field ref="base" min-occurs="1"/>
+                            <field ref="selected"/>
+                            <field ref="adjustment-justification" in-xml="WITH_WRAPPER"/>
+                        </model>
+                    </define-assembly>
+                </model>
+                <constraint>
+                    <expect level="WARNING" target="." test="@uuid">
+                        <message>It is a best practice to provide a UUID.</message>
+                    </expect>
+                </constraint>
+            </define-assembly>
+        </model>
+        <constraint>
+            <allowed-values target="prop/@name" allow-other="yes">
+                <enum value="privacy-designation">Is this a privacy sensitive system? yes or no</enum>
+            </allowed-values>
+            <allowed-values target="prop[@name='privacy-designation']/@value">
+                <enum value="yes">The system is privacy sensitive.</enum>
+                <enum value="no">The system isnot privacy sensitive.</enum>
+            </allowed-values>
+            <allowed-values target="link/@rel">
+                <enum value="privacy-impact-assessment">A link to the privacy impact assessment.</enum>
+            </allowed-values>
+            <matches target="link[@rel='privacy-impact-assessment']/@href[starts-with(.,'#')]" datatype="uri-reference"/>
+            <index-has-key name="index-back-matter-resource" target="link[@rel='privacy-impact-assessment' and starts-with(@href,'#')]">
+                <key-field target="@href" pattern="#(.*)"/>
+            </index-has-key>
+            <matches target="link[@rel='privacy-impact-assessment']/@href[not(starts-with(.,'#'))]" datatype="uri"/>
+            <allowed-values target="information-type/(confidentiality-impact|integrity-impact|availability-impact)/(base|selected)">
+                <enum value="fips-199-low">A 'low' sensitivity level as defined in <a href="https://doi.org/10.6028/NIST.FIPS.199">FIPS-199</a>.
+                </enum>
+                <enum value="fips-199-moderate">A 'moderate' sensitivity level as defined in <a href="https://doi.org/10.6028/NIST.FIPS.199">FIPS-199</a>.
+                </enum>
+                <enum value="fips-199-high">A 'high' sensitivity level as defined in <a href="https://doi.org/10.6028/NIST.FIPS.199">FIPS-199</a>.
+                </enum>
+                <remarks>
+                    <p>FIPS-199 taxonomy is provided here as a starting point. We will provide other taxonomies based on community requests.</p>
+                </remarks>
+            </allowed-values>
+        </constraint>
+    </define-assembly>
+    <define-field name="base" as-type="string" scope="local">
+        <formal-name>Base Level (Confidentiality, Integrity, or Availability)</formal-name>
+        <description>The prescribed base (Confidentiality, Integrity, or Availability) security impact level.</description>
+    </define-field>
+    <define-field name="selected" as-type="string" scope="local">
+        <formal-name>Selected Level (Confidentiality, Integrity, or Availability)</formal-name>
+        <description>The selected (Confidentiality, Integrity, or Availability) security impact level.</description>
+    </define-field>
+    <define-field name="adjustment-justification" as-type="markup-multiline" scope="local">
+        <formal-name>Adjustment Justification</formal-name>
+        <description>If the selected security level is different from the base security level, this contains the justification for the change.</description>
+    </define-field>
+    <define-assembly name="security-impact-level">
+        <formal-name>Security Impact Level</formal-name>
+        <description>The overall level of expected impact resulting from unauthorized disclosure, modification, or loss of access to information.</description>
+        <model>
+            <define-field name="security-objective-confidentiality" as-type="string" min-occurs="1">
+                <!-- CHANGED: cardinality to min 1 -->
+                <formal-name>Security Objective: Confidentiality</formal-name>
+                <description>A target-level of confidentiality for the system, based on the sensitivity of information within the system.</description>
+            </define-field>
+            <define-field name="security-objective-integrity" as-type="string" min-occurs="1">
+                <!-- CHANGED: cardinality to min 1 -->
+                <formal-name>Security Objective: Integrity</formal-name>
+                <description>A target-level of integrity for the system, based on the sensitivity of information within the system.</description>
+            </define-field>
+            <define-field name="security-objective-availability" as-type="string" min-occurs="1">
+                <!-- CHANGED: cardinality to min 1 -->
+                <formal-name>Security Objective: Availability</formal-name>
+                <description>A target-level of availability for the system, based on the sensitivity of information within the system.</description>
+            </define-field>
+        </model>
+    </define-assembly>
+    <define-assembly name="status" scope="local">
+        <formal-name>Status</formal-name>
+        <description>Describes the operational status of the system.</description>
+        <define-flag name="state" required="yes" as-type="string">
+            <formal-name>State</formal-name>
+            <description>The current operating status.</description>
+            <constraint>
+                <allowed-values>
+                    <enum value="operational">The system is currently operating in production.</enum>
+                    <enum value="under-development">The system is being designed, developed, or implemented</enum>
+                    <enum value="under-major-modification">The system is undergoing a major change, development, or transition.</enum>
+                    <enum value="disposition">The system is no longer operational.</enum>
+                    <enum value="other">Some other state.</enum>
                 </allowed-values>
-              </constraint>
-            </define-flag>
-            <model>
-              <define-field name="information-type-id" as-type="string" max-occurs="unbounded">
-                <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
-                <formal-name>Information Type Systematized Identifier</formal-name>
-                <!-- Identifier Declaration -->
-                <description>A <a href="/concepts/identifier-use/#human-oriented">human-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier qualified by the given identification <code>system</code> used, such as NIST SP 800-60.  This identifier has <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope and can be used to reference this system elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. This id should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-                <json-value-key>id</json-value-key>
-                <group-as name="information-type-ids" in-json="ARRAY"/>
-              </define-field>
-            </model>
-          </define-assembly>
-          <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-          </assembly>
-          <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-          </assembly>
-          <define-assembly name="confidentiality-impact" min-occurs="1">
-            <formal-name>Confidentiality Impact Level</formal-name>
-            <description>The expected level of impact resulting from the unauthorized disclosure of the described information.</description>
-            <model>
-              <assembly ref="property" max-occurs="unbounded">
-                <group-as name="props" in-json="ARRAY"/>
-              </assembly>
-              <assembly ref="link" max-occurs="unbounded">
-                <group-as name="links" in-json="ARRAY"/>
-              </assembly>
-              <field ref="base" min-occurs="1"/>
-              <field ref="selected"/>
-              <field ref="adjustment-justification" in-xml="WITH_WRAPPER"/>
-            </model>
-          </define-assembly>
-          <define-assembly name="integrity-impact" min-occurs="1">
-            <formal-name>Integrity Impact Level</formal-name>
-            <description>The expected level of impact resulting from the unauthorized modification of the described information.</description>
-            <model>
-              <assembly ref="property" max-occurs="unbounded">
-                <group-as name="props" in-json="ARRAY"/>
-              </assembly>
-              <assembly ref="link" max-occurs="unbounded">
-                <group-as name="links" in-json="ARRAY"/>
-              </assembly>
-              <field ref="base" min-occurs="1"/>
-              <field ref="selected"/>
-              <field ref="adjustment-justification" in-xml="WITH_WRAPPER"/>
-            </model>
-          </define-assembly>
-          <define-assembly name="availability-impact" min-occurs="1">
-            <formal-name>Availability Impact Level</formal-name>
-            <description>The expected level of impact resulting from the disruption of access to or use of the described information or the information system.</description>
-            <model>
-              <assembly ref="property" max-occurs="unbounded">
-                <group-as name="props" in-json="ARRAY"/>
-              </assembly>
-              <assembly ref="link" max-occurs="unbounded">
-                <group-as name="links" in-json="ARRAY"/>
-              </assembly>
-              <field ref="base" min-occurs="1"/>
-              <field ref="selected"/>
-              <field ref="adjustment-justification" in-xml="WITH_WRAPPER"/>
-            </model>
-          </define-assembly>
-        </model>
-        <constraint>
-          <expect level="WARNING" target="." test="@uuid">
-            <message>It is a best practice to provide a UUID.</message>
-          </expect>
-        </constraint>
-      </define-assembly>
-    </model>
-    <constraint>
-      <allowed-values target="prop/@name" allow-other="yes">
-        <enum value="privacy-designation">Is this a privacy sensitive system? yes or no</enum>
-      </allowed-values>
-      <allowed-values target="prop[@name='privacy-designation']/@value">
-        <enum value="yes">The system is privacy sensitive.</enum>
-        <enum value="no">The system isnot privacy sensitive.</enum>
-      </allowed-values>
-      <allowed-values target="link/@rel">
-        <enum value="privacy-impact-assessment">A link to the privacy impact assessment.</enum>
-      </allowed-values>
-      <matches target="link[@rel='privacy-impact-assessment']/@href[starts-with(.,'#')]" datatype="uri-reference"/>
-      <index-has-key name="index-back-matter-resource" target="link[@rel='privacy-impact-assessment' and starts-with(@href,'#')]">
-        <key-field target="@href" pattern="#(.*)"/>
-      </index-has-key>
-      <matches target="link[@rel='privacy-impact-assessment']/@href[not(starts-with(.,'#'))]" datatype="uri"/>
-      <allowed-values target="information-type/(confidentiality-impact|integrity-impact|availability-impact)/(base|selected)">
-        <enum value="fips-199-low">A 'low' sensitivity level as defined in <a href="https://doi.org/10.6028/NIST.FIPS.199">FIPS-199</a>.
-        </enum>
-        <enum value="fips-199-moderate">A 'moderate' sensitivity level as defined in <a href="https://doi.org/10.6028/NIST.FIPS.199">FIPS-199</a>.
-        </enum>
-        <enum value="fips-199-high">A 'high' sensitivity level as defined in <a href="https://doi.org/10.6028/NIST.FIPS.199">FIPS-199</a>.
-        </enum>
-        <remarks>
-          <p>FIPS-199 taxonomy is provided here as a starting point. We will provide other taxonomies based on community requests.</p>
-        </remarks>
-      </allowed-values>
-    </constraint>
-  </define-assembly>
-  <define-field name="base" as-type="string" scope="local">
-    <formal-name>Base Level (Confidentiality, Integrity, or Availability)</formal-name>
-    <description>The prescribed base (Confidentiality, Integrity, or Availability) security impact level.</description>
-  </define-field>
-  <define-field name="selected" as-type="string" scope="local">
-    <formal-name>Selected Level (Confidentiality, Integrity, or Availability)</formal-name>
-    <description>The selected (Confidentiality, Integrity, or Availability) security impact level.</description>
-  </define-field>
-  <define-field name="adjustment-justification" as-type="markup-multiline" scope="local">
-    <formal-name>Adjustment Justification</formal-name>
-    <description>If the selected security level is different from the base security level, this contains the justification for the change.</description>
-  </define-field>
-  <define-assembly name="security-impact-level">
-    <formal-name>Security Impact Level</formal-name>
-    <description>The overall level of expected impact resulting from unauthorized disclosure, modification, or loss of access to information.</description>
-    <model>
-      <define-field name="security-objective-confidentiality" as-type="string" min-occurs="1">
-        <!-- CHANGED: cardinality to min 1 -->
-        <formal-name>Security Objective: Confidentiality</formal-name>
-        <description>A target-level of confidentiality for the system, based on the sensitivity of information within the system.</description>
-      </define-field>
-      <define-field name="security-objective-integrity" as-type="string" min-occurs="1">
-        <!-- CHANGED: cardinality to min 1 -->
-        <formal-name>Security Objective: Integrity</formal-name>
-        <description>A target-level of integrity for the system, based on the sensitivity of information within the system.</description>
-      </define-field>
-      <define-field name="security-objective-availability" as-type="string" min-occurs="1">
-        <!-- CHANGED: cardinality to min 1 -->
-        <formal-name>Security Objective: Availability</formal-name>
-        <description>A target-level of availability for the system, based on the sensitivity of information within the system.</description>
-      </define-field>
-    </model>
-  </define-assembly>
-  <define-assembly name="status" scope="local">
-    <formal-name>Status</formal-name>
-    <description>Describes the operational status of the system.</description>
-    <define-flag name="state" required="yes" as-type="string">
-      <formal-name>State</formal-name>
-      <description>The current operating status.</description>
-      <constraint>
-        <allowed-values>
-          <enum value="operational">The system is currently operating in production.</enum>
-          <enum value="under-development">The system is being designed, developed, or implemented</enum>
-          <enum value="under-major-modification">The system is undergoing a major change, development, or transition.</enum>
-          <enum value="disposition">The system is no longer operational.</enum>
-          <enum value="other">Some other state.</enum>
-        </allowed-values>
-      </constraint>
-    </define-flag>
-    <model>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <remarks>
-      <p>If 'other' is selected, a remark must be included to describe the current state.</p>
-    </remarks>
-  </define-assembly>
-  <define-field name="date-authorized" as-type="date" scope="local">
-    <formal-name>System Authorization Date</formal-name>
-    <description>The date the system received its authorization.</description>
-  </define-field>
-  <define-assembly name="authorization-boundary">
-    <formal-name>Authorization Boundary</formal-name>
-    <description>A description of this system's authorization boundary, optionally supplemented by diagrams that illustrate the authorization boundary.</description>
-    <model>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Authorization Boundary Description</formal-name>
-        <description>A summary of the system's authorization boundary.</description>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-        <!-- TODO: Model specific link relationships? -->
-      </assembly>
-      <assembly ref="diagram" max-occurs="unbounded">
-        <group-as name="diagrams" in-json="ARRAY"/>
-        <remarks>
-          <p>A visual depiction of the system's authorization boundary.</p>
-        </remarks>
-      </assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <is-unique id="unique-ssp-authorization-boundary-diagram" target="diagram">
-        <key-field target="@uuid"/>
-        <remarks>
-          <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
-        </remarks>
-      </is-unique>
-    </constraint>
-  </define-assembly>
-  <define-assembly name="diagram">
-    <formal-name>Diagram</formal-name>
-    <description>A graphic that provides a visual representation the system, or some aspect of it.</description>
-    <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>Diagram ID</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this diagram elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>diagram</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <model>
-      <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-        <formal-name>Diagram Description</formal-name>
-        <description>A summary of the diagram.</description>
-        <remarks>
-          <p>This description is intended to be used as alternate text to support compliance with requirements from <a href="https://www.section508.gov/manage/laws-and-policies">Section 508 of the United States Workforce Rehabilitation Act of 1973</a>.
-          </p>
-        </remarks>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <define-field name="caption" as-type="markup-line">
-        <formal-name>Caption</formal-name>
-        <description>A brief caption to annotate the diagram.</description>
-      </define-field>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <allowed-values target="link/@rel">
-        <enum value="diagram">A reference to the diagram image.</enum>
-      </allowed-values>
-      <matches target="link[@rel='diagram']/@href[starts-with(.,'#')]" datatype="uri-reference"/>
-      <index-has-key name="index-back-matter-resource" target="link[@rel='diagram' and starts-with(@href,'#')]">
-        <key-field target="@href" pattern="#(.*)"/>
-      </index-has-key>
-      <matches target="link[@rel='diagram']/@href[not(starts-with(.,'#'))]" datatype="uri"/>
-    </constraint>
-    <remarks>
-      <p>A diagram must include a <code>link</code> with a rel value of "diagram", who's href references a remote URI or an internal reference within this document containing the diagram.</p>
-    </remarks>
-    <example>
-      <remarks>
-        <p>The internal reference "#diagram1" points to an attached resource defined in the <code>back-matter</code> as a <code>resource</code>. The <code>media-type</code> indicates that the image is a Portable Network Graphics (PNG) image.</p>
-      </remarks>
-      <o:diagram xmlns:o="http://csrc.nist.gov/ns/oscal/example" id="boundary-diagram-1">
-        <o:description>A boundary diagram.</o:description>
-        <o:link rel="diagram" href="#diagram1" media-type="image/png"/>
-      </o:diagram>
-    </example>
-  </define-assembly>
-  <define-assembly name="network-architecture">
-    <formal-name>Network Architecture</formal-name>
-    <description>A description of the system's network architecture, optionally supplemented by diagrams that illustrate the network architecture.</description>
-    <model>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Network Architecture Description</formal-name>
-        <description>A summary of the system's network architecture.</description>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-        <!-- TODO: Model specific link relationships? -->
-      </assembly>
-      <assembly ref="diagram" max-occurs="unbounded">
-        <group-as name="diagrams" in-json="ARRAY"/>
-      </assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <is-unique id="unique-ssp-network-architecture-diagram" target="diagram">
-        <key-field target="@uuid"/>
-        <remarks>
-          <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
-        </remarks>
-      </is-unique>
-    </constraint>
-    
-  </define-assembly>
-  <define-assembly name="data-flow">
-    <formal-name>Data Flow</formal-name>
-    <description>A description of the logical flow of information within the system and across its boundaries, optionally supplemented by diagrams that illustrate these flows.</description>
-    <model>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Data Flow Description</formal-name>
-        <description>A summary of the system's data flow.</description>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-        <!-- TODO: Model specific link relationships? -->
-      </assembly>
-      <assembly ref="diagram" max-occurs="unbounded">
-        <group-as name="diagrams" in-json="ARRAY"/>
-      </assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <is-unique id="unique-ssp-data-flow-diagram" target="diagram">
-        <key-field target="@uuid"/>
-        <remarks>
-          <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
-        </remarks>
-      </is-unique>
-    </constraint>
-  </define-assembly>
-
-  <!-- ################################################################ -->
-  <!-- # The System Implementation Assembly and supporting constructs # -->
-  <!-- ################################################################ -->
-  <define-assembly name="system-implementation">
-    <formal-name>System Implementation</formal-name>
-    <description>Provides information as to how the system is implemented.</description>
-    <model>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-        <!-- TODO: Model specific link relationships? -->
-      </assembly>
-      <define-assembly name="leveraged-authorization" max-occurs="unbounded">
-        <formal-name>Leveraged Authorization</formal-name>
-        <description>A description of another authorized system from which this system inherits capabilities that satisfy security requirements. Another term for this concept is a <em>common control provider</em>.
-        </description>
-        <group-as name="leveraged-authorizations" in-json="ARRAY"/>
-        <define-flag name="uuid" as-type="uuid" required="yes">
-          <formal-name>Leveraged Authorization Universally Unique Identifier</formal-name>
-          <!-- Identifier Declaration -->
-          <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope and can be used to reference this leveraged authorization elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>leveraged authorization</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+            </constraint>
         </define-flag>
         <model>
-          <define-field name="title" as-type="markup-line" min-occurs="1">
-            <formal-name>title field</formal-name>
-            <description>A human readable name for the leveraged authorization in the context of the system.</description>
-          </define-field>
-          <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-          </assembly>
-          <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-          </assembly>
-          <define-field name="party-uuid" as-type="uuid" min-occurs="1">
-            <formal-name>party-uuid field</formal-name>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <remarks>
+            <p>If 'other' is selected, a remark must be included to describe the current state.</p>
+        </remarks>
+    </define-assembly>
+    <define-field name="date-authorized" as-type="date" scope="local">
+        <formal-name>System Authorization Date</formal-name>
+        <description>The date the system received its authorization.</description>
+    </define-field>
+    <define-assembly name="authorization-boundary">
+        <formal-name>Authorization Boundary</formal-name>
+        <description>A description of this system's authorization boundary, optionally supplemented by diagrams that illustrate the authorization boundary.</description>
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Authorization Boundary Description</formal-name>
+                <description>A summary of the system's authorization boundary.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+                <!-- TODO: Model specific link relationships? -->
+            </assembly>
+            <assembly ref="diagram" max-occurs="unbounded">
+                <group-as name="diagrams" in-json="ARRAY"/>
+                <remarks>
+                    <p>A visual depiction of the system's authorization boundary.</p>
+                </remarks>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <is-unique id="unique-ssp-authorization-boundary-diagram" target="diagram">
+                <key-field target="@uuid"/>
+                <remarks>
+                    <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
+    <define-assembly name="diagram">
+        <formal-name>Diagram</formal-name>
+        <description>A graphic that provides a visual representation the system, or some aspect of it.</description>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Diagram ID</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this diagram elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>diagram</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <model>
+            <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                <formal-name>Diagram Description</formal-name>
+                <description>A summary of the diagram.</description>
+                <remarks>
+                    <p>This description is intended to be used as alternate text to support compliance with requirements from <a href="https://www.section508.gov/manage/laws-and-policies">Section 508 of the United States Workforce Rehabilitation Act of 1973</a>.
+                    </p>
+                </remarks>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <define-field name="caption" as-type="markup-line">
+                <formal-name>Caption</formal-name>
+                <description>A brief caption to annotate the diagram.</description>
+            </define-field>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <allowed-values target="link/@rel">
+                <enum value="diagram">A reference to the diagram image.</enum>
+            </allowed-values>
+            <matches target="link[@rel='diagram']/@href[starts-with(.,'#')]" datatype="uri-reference"/>
+            <index-has-key name="index-back-matter-resource" target="link[@rel='diagram' and starts-with(@href,'#')]">
+                <key-field target="@href" pattern="#(.*)"/>
+            </index-has-key>
+            <matches target="link[@rel='diagram']/@href[not(starts-with(.,'#'))]" datatype="uri"/>
+        </constraint>
+        <remarks>
+            <p>A diagram must include a <code>link</code> with a rel value of "diagram", who's href references a remote URI or an internal reference within this document containing the diagram.</p>
+        </remarks>
+        <example>
+            <remarks>
+                <p>The internal reference "#diagram1" points to an attached resource defined in the <code>back-matter</code> as a <code>resource</code>. The <code>media-type</code> indicates that the image is a Portable Network Graphics (PNG) image.</p>
+            </remarks>
+            <o:diagram xmlns:o="http://csrc.nist.gov/ns/oscal/example" id="boundary-diagram-1">
+                <o:description>A boundary diagram.</o:description>
+                <o:link rel="diagram" href="#diagram1" media-type="image/png"/>
+            </o:diagram>
+        </example>
+    </define-assembly>
+    <define-assembly name="network-architecture">
+        <formal-name>Network Architecture</formal-name>
+        <description>A description of the system's network architecture, optionally supplemented by diagrams that illustrate the network architecture.</description>
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Network Architecture Description</formal-name>
+                <description>A summary of the system's network architecture.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+                <!-- TODO: Model specific link relationships? -->
+            </assembly>
+            <assembly ref="diagram" max-occurs="unbounded">
+                <group-as name="diagrams" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <is-unique id="unique-ssp-network-architecture-diagram" target="diagram">
+                <key-field target="@uuid"/>
+                <remarks>
+                    <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+        
+    </define-assembly>
+    <define-assembly name="data-flow">
+        <formal-name>Data Flow</formal-name>
+        <description>A description of the logical flow of information within the system and across its boundaries, optionally supplemented by diagrams that illustrate these flows.</description>
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Data Flow Description</formal-name>
+                <description>A summary of the system's data flow.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+                <!-- TODO: Model specific link relationships? -->
+            </assembly>
+            <assembly ref="diagram" max-occurs="unbounded">
+                <group-as name="diagrams" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <is-unique id="unique-ssp-data-flow-diagram" target="diagram">
+                <key-field target="@uuid"/>
+                <remarks>
+                    <p>A given <code>uuid</code> must be assigned only once to a diagram.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
+
+    <!-- ################################################################ -->
+    <!-- # The System Implementation Assembly and supporting constructs # -->
+    <!-- ################################################################ -->
+    <define-assembly name="system-implementation">
+        <formal-name>System Implementation</formal-name>
+        <description>Provides information as to how the system is implemented.</description>
+        <model>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+                <!-- TODO: Model specific link relationships? -->
+            </assembly>
+            <define-assembly name="leveraged-authorization" max-occurs="unbounded">
+                <formal-name>Leveraged Authorization</formal-name>
+                <description>A description of another authorized system from which this system inherits capabilities that satisfy security requirements. Another term for this concept is a <em>common control provider</em>.
+                </description>
+                <group-as name="leveraged-authorizations" in-json="ARRAY"/>
+                <define-flag name="uuid" as-type="uuid" required="yes">
+                    <formal-name>Leveraged Authorization Universally Unique Identifier</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope and can be used to reference this leveraged authorization elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>leveraged authorization</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+                <model>
+                    <define-field name="title" as-type="markup-line" min-occurs="1">
+                        <formal-name>title field</formal-name>
+                        <description>A human readable name for the leveraged authorization in the context of the system.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                    </assembly>
+                    <define-field name="party-uuid" as-type="uuid" min-occurs="1">
+                        <formal-name>party-uuid field</formal-name>
+                        <!-- Identifier Reference -->
+                        <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the    <code>party</code> that manages the leveraged system.</description>
+                    </define-field>
+                    <field ref="date-authorized" min-occurs="1"/>
+                    <field ref="remarks" in-xml="WITH_WRAPPER"/>
+                </model>
+                <constraint>
+                    <allowed-values target="link/@rel">
+                        <enum value="system-security-plan">A reference to the system security plan for the leveraged authorization.</enum>
+                    </allowed-values>
+                    <matches target="link[@rel='system-security-plan']/@href[starts-with(.,'#')]" datatype="uri-reference"/>
+                    <index-has-key name="index-back-matter-resource" target="link[@rel='system-security-plan' and starts-with(@href,'#')]">
+                        <key-field target="@href" pattern="#(.*)"/>
+                    </index-has-key>
+                    <matches target="link[@rel='system-security-plan']/@href[not(starts-with(.,'#'))]" datatype="uri"/>
+                </constraint>
+            </define-assembly>
+
+            <assembly ref="system-user" min-occurs="1" max-occurs="unbounded">
+                <use-name>user</use-name>
+                <group-as name="users" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="system-component" min-occurs="1" max-occurs="unbounded">
+                <use-name>component</use-name>
+                <group-as name="components" in-json="ARRAY"/>
+            </assembly>
+            <!--                 <assembly ref="capability" max-occurs="unbounded">
+                        <group-as name="capabilities" in-json="BY_KEY"/>
+                 </assembly>
+                 -->
+            <assembly ref="inventory-item" min-occurs="0" max-occurs="unbounded">
+                <group-as name="inventory-items" in-json="ARRAY"/>
+                <remarks>
+                    <p>A set of <code>inventory-item</code> entries that represent the managed inventory instances of the system.</p>
+                </remarks>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <!-- TODO: future: for FedRAMP, have user counts as props: current/internal, current/external, future/internal, future, external -->
+            <index name="index-system-implementation-leveraged-authorization-uuid" target="leveraged-authorization">
+                <key-field target="@uuid"/>
+            </index>
+            <index-has-key name="index-system-implementation-leveraged-authorization-uuid" target="component/prop[@name='leveraged-authorization-uuid']">
+                <key-field target="@value"/>
+            </index-has-key>
+
+            <!-- References to components -->
+            <index name="index-system-implementation-component-uuid" target="component">
+                <key-field target="@uuid"/>
+            </index>
+            <index-has-key name="index-system-implementation-component-uuid" target="component/link[@rel='depends-on']">
+                <key-field target="@href"/>
+            </index-has-key>
+
+            <!-- References to components of @type="validation" -->
+            <index name="index-system-implementation-component-uuid-validation" target="component[@type='validation']">
+                <key-field target="@uuid"/>
+            </index>
+            <index-has-key name="index-system-implementation-component-uuid-validation" target="component/link[@rel='validated-by']">
+                <key-field target="@href"/>
+            </index-has-key>
+            <index-has-key name="index-system-implementation-component-uuid-validation" target="component/link[@rel='proof-of-compliance']">
+                <key-field target="@href"/>
+            </index-has-key>
+
+            <!-- References to components of @type="service" -->
+            <index name="index-system-implementation-component-uuid-service" target="component[@type='service']">
+                <key-field target="@uuid"/>
+            </index>
+            <index-has-key name="index-system-implementation-component-uuid-service" target="component/link[@rel='uses-service']">
+                <key-field target="@href"/>
+            </index-has-key>
+
+            <!-- References to components of @type="software" -->
+            <index name="index-system-implementation-component-uuid-software" target="component[@type='service']">
+                <key-field target="@uuid"/>
+            </index>
+            <index-has-key name="index-system-implementation-component-uuid-software" target="component[@type='service']/link[@rel='provided-by']">
+                <key-field target="@href"/>
+            </index-has-key>
+
+            <allowed-values target="(component | inventory-item)/prop[@name='allows-authenticated-scan']/@value">
+                <enum value="yes">The component allows an authenticated scan.</enum>
+                <enum value="no">The component does not allow an authenticated scan.</enum>
+            </allowed-values>
+
+            <!-- TODO: only allow a single "this-system" component -->
+
+            <is-unique id="unique-ssp-system-implementation-user" target="user">
+                <key-field target="@uuid"/>
+                <remarks>
+                    <p>A given <code>uuid</code> must be assigned only once to a user.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
+
+    <define-assembly name="control-implementation" scope="local">
+        <formal-name>Control Implementation</formal-name>
+        <description>Describes how the system satisfies a set of controls.</description>
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Control Implementation Description</formal-name>
+                <description>A statement describing important things to know about how this set of control satisfaction documentation is approached.</description>
+            </define-field>
+            <assembly ref="set-parameter" max-occurs="unbounded">
+                <group-as name="set-parameters" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="implemented-requirement" min-occurs="1" max-occurs="unbounded">
+                <group-as name="implemented-requirements" in-json="ARRAY"/>
+            </assembly>
+        </model>
+        <constraint>
+            <is-unique id="unique-ssp-control-implementation-set-parameter" target="set-parameter">
+                <key-field target="@param-id"/>
+                <remarks>
+                    <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+                </remarks>
+            </is-unique>
+            <index name="by-component-export-provided-uuid" target="implemented-requirement/by-component/export/provided">
+                <key-field target="@uuid"/>
+            </index>
+        </constraint>
+        <remarks>
+            <p>Use of <code>set-parameter</code> in this context, sets the parameter for all related controls referenced in an <code>implemented-requirement</code>. If the same parameter is also set in a specific <code>implemented-requirement</code>, then the new value will override this value.</p>
+        </remarks>
+    </define-assembly>
+    <define-assembly name="implemented-requirement" scope="local">
+        <formal-name>Control-based Requirement</formal-name>
+        <description>Describes how the system satisfies an individual control.</description>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Control Requirement Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this control requirement elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>control requirement</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <flag ref="control-id" required="yes"/>
+        <model>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+                <!-- TODO: Model specific link relationships -->
+            </assembly>
+            <assembly ref="set-parameter" max-occurs="unbounded">
+                <group-as name="set-parameters" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="responsible-role" max-occurs="unbounded">
+                <group-as name="responsible-roles" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="statement" max-occurs="unbounded">
+                <group-as name="statements" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="by-component" min-occurs="0" max-occurs="unbounded">
+                <group-as name="by-components" in-json="ARRAY"/>
+            </assembly>
+            <!-- TODO: Implement parameters -->
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <allowed-values target="prop/@name" allow-other="yes">
+                <enum value="control-origination">Identifies the source of the implemented control.</enum>
+            </allowed-values>
+            <allowed-values target="prop[@name='control-origination']/@value">
+                <enum value="organization">The control is implemented by the organization owning the system, but is not specific to the system itself.</enum>
+                <enum value="system-specific">The control is implemented specifically to this system.</enum>
+                <enum value="customer-configured">The control is provided by the system, but must be configured by the customer.</enum>
+                <enum value="customer-provided">The control must be implemented by the customer.</enum>
+                <enum value="inherited">This control is inherited from an underlying system.</enum>
+            </allowed-values>
+            <allowed-values target="prop/@name" allow-other="yes">
+                <enum value="leveraged-authorization">Indicates all or some portion of this control is inherited from an underlying authorized system.</enum>
+            </allowed-values>
+            <allowed-values target="responsible-role/@role-id" allow-other="yes">
+                        &allowed-values-responsible-roles-operations;
+            </allowed-values>
+            <index-has-key name="index-metadata-role-id" target="responsible-role|statement/responsible-role|.//by-component//responsible-role">
+                <key-field target="@role-id"/>
+            </index-has-key>
+            <index-has-key name="index-metadata-party-uuid" target="responsible-role|statement/responsible-role|.//by-component//responsible-role">
+                <key-field target="party-uuid"/>
+            </index-has-key>
+            <has-cardinality target=".//by-component" min-occurs="1">
+                <remarks>
+                    <p>Since all implementation statements are defined at the by-component level (e.g., type=this-system), there must be at least one by-component.</p>
+                </remarks>
+            </has-cardinality>
+            <is-unique id="unique-ssp-implemented-requirement-set-parameter" target="set-parameter">
+                <key-field target="@param-id"/>
+                <remarks>
+                    <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
+                </remarks>
+            </is-unique>
+            <is-unique id="unique-ssp-implemented-requirement-responsible-role" target="responsible-role">
+                <key-field target="@role-id"/>
+                <remarks>
+                    <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+            <is-unique id="unique-ssp-implemented-requirement-statement" target="statement">
+                <key-field target="@statement-id"/>
+                <remarks>
+                    <p>Since <code>statement</code> entries can be referenced using the statement's statement-id, each statement must be referenced only once.</p>
+                </remarks>
+            </is-unique>
+            <is-unique id="unique-ssp-implemented-requirement-by-component" target="by-component">
+                <key-field target="@component-uuid"/>
+                <remarks>
+                    <p>Since <code>by-component</code> can reference <code>component</code> entries using the component's uuid, each component must be referenced only once. This ensures that all implementation statements are contained in the same <code>by-component</code> entry.</p>
+                </remarks>
+            </is-unique>
+        </constraint>
+    </define-assembly>
+    <define-assembly name="statement" scope="local">
+        <formal-name>Specific Control Statement</formal-name>
+        <description>Identifies which statements within a control are addressed.</description>
+        <flag ref="statement-id" required="yes">
+            <remarks>
+                <p>A reference to the specific implemented statement associated with a control.</p>
+            </remarks>
+        </flag>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>Control Statement Reference Universally Unique Identifier</formal-name>
             <!-- Identifier Reference -->
-            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the  <code>party</code> that manages the leveraged system.</description>
-          </define-field>
-          <field ref="date-authorized" min-occurs="1"/>
-          <field ref="remarks" in-xml="WITH_WRAPPER"/>
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this control statement elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The <em>UUID</em> of the <code>control statement</code> in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).</description>
+        </define-flag>
+        <model>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="responsible-role" max-occurs="unbounded">
+                <group-as name="responsible-roles" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="by-component" max-occurs="unbounded">
+                <group-as name="by-components" in-json="ARRAY"/>
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
         </model>
         <constraint>
-          <allowed-values target="link/@rel">
-            <enum value="system-security-plan">A reference to the system security plan for the leveraged authorization.</enum>
-          </allowed-values>
-          <matches target="link[@rel='system-security-plan']/@href[starts-with(.,'#')]" datatype="uri-reference"/>
-          <index-has-key name="index-back-matter-resource" target="link[@rel='system-security-plan' and starts-with(@href,'#')]">
-            <key-field target="@href" pattern="#(.*)"/>
-          </index-has-key>
-          <matches target="link[@rel='system-security-plan']/@href[not(starts-with(.,'#'))]" datatype="uri"/>
-        </constraint>
-      </define-assembly>
-
-      <assembly ref="system-user" min-occurs="1" max-occurs="unbounded">
-        <use-name>user</use-name>
-        <group-as name="users" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="system-component" min-occurs="1" max-occurs="unbounded">
-        <use-name>component</use-name>
-        <group-as name="components" in-json="ARRAY"/>
-      </assembly>
-      <!--         <assembly ref="capability" max-occurs="unbounded">
-            <group-as name="capabilities" in-json="BY_KEY"/>
-         </assembly>
-         -->
-      <assembly ref="inventory-item" min-occurs="0" max-occurs="unbounded">
-        <group-as name="inventory-items" in-json="ARRAY"/>
-        <remarks>
-          <p>A set of <code>inventory-item</code> entries that represent the managed inventory instances of the system.</p>
-        </remarks>
-      </assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <!-- TODO: future: for FedRAMP, have user counts as props: current/internal, current/external, future/internal, future, external -->
-      <index name="index-system-implementation-leveraged-authorization-uuid" target="leveraged-authorization">
-        <key-field target="@uuid"/>
-      </index>
-      <index-has-key name="index-system-implementation-leveraged-authorization-uuid" target="component/prop[@name='leveraged-authorization-uuid']">
-        <key-field target="@value"/>
-      </index-has-key>
-
-      <!-- References to components -->
-      <index name="index-system-implementation-component-uuid" target="component">
-        <key-field target="@uuid"/>
-      </index>
-      <index-has-key name="index-system-implementation-component-uuid" target="component/link[@rel='depends-on']">
-        <key-field target="@href"/>
-      </index-has-key>
-
-      <!-- References to components of @type="validation" -->
-      <index name="index-system-implementation-component-uuid-validation" target="component[@type='validation']">
-        <key-field target="@uuid"/>
-      </index>
-      <index-has-key name="index-system-implementation-component-uuid-validation" target="component/link[@rel='validated-by']">
-        <key-field target="@href"/>
-      </index-has-key>
-      <index-has-key name="index-system-implementation-component-uuid-validation" target="component/link[@rel='proof-of-compliance']">
-        <key-field target="@href"/>
-      </index-has-key>
-
-      <!-- References to components of @type="service" -->
-      <index name="index-system-implementation-component-uuid-service" target="component[@type='service']">
-        <key-field target="@uuid"/>
-      </index>
-      <index-has-key name="index-system-implementation-component-uuid-service" target="component/link[@rel='uses-service']">
-        <key-field target="@href"/>
-      </index-has-key>
-
-      <!-- References to components of @type="software" -->
-      <index name="index-system-implementation-component-uuid-software" target="component[@type='service']">
-        <key-field target="@uuid"/>
-      </index>
-      <index-has-key name="index-system-implementation-component-uuid-software" target="component[@type='service']/link[@rel='provided-by']">
-        <key-field target="@href"/>
-      </index-has-key>
-
-      <allowed-values target="(component | inventory-item)/prop[@name='allows-authenticated-scan']/@value">
-        <enum value="yes">The component allows an authenticated scan.</enum>
-        <enum value="no">The component does not allow an authenticated scan.</enum>
-      </allowed-values>
-
-      <!-- TODO: only allow a single "this-system" component -->
-
-      <is-unique id="unique-ssp-system-implementation-user" target="user">
-        <key-field target="@uuid"/>
-        <remarks>
-          <p>A given <code>uuid</code> must be assigned only once to a user.</p>
-        </remarks>
-      </is-unique>
-    </constraint>
-  </define-assembly>
-
-  <define-assembly name="control-implementation" scope="local">
-    <formal-name>Control Implementation</formal-name>
-    <description>Describes how the system satisfies a set of controls.</description>
-    <model>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Control Implementation Description</formal-name>
-        <description>A statement describing important things to know about how this set of control satisfaction documentation is approached.</description>
-      </define-field>
-      <assembly ref="set-parameter" max-occurs="unbounded">
-        <group-as name="set-parameters" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="implemented-requirement" min-occurs="1" max-occurs="unbounded">
-        <group-as name="implemented-requirements" in-json="ARRAY"/>
-      </assembly>
-    </model>
-    <constraint>
-      <is-unique id="unique-ssp-control-implementation-set-parameter" target="set-parameter">
-        <key-field target="@param-id"/>
-        <remarks>
-          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
-        </remarks>
-      </is-unique>
-      <index name="by-component-export-provided-uuid" target="implemented-requirement/by-component/export/provided">
-        <key-field target="@uuid"/>
-      </index>
-    </constraint>
-    <remarks>
-      <p>Use of <code>set-parameter</code> in this context, sets the parameter for all related controls referenced in an <code>implemented-requirement</code>. If the same parameter is also set in a specific <code>implemented-requirement</code>, then the new value will override this value.</p>
-    </remarks>
-  </define-assembly>
-  <define-assembly name="implemented-requirement" scope="local">
-    <formal-name>Control-based Requirement</formal-name>
-    <description>Describes how the system satisfies an individual control.</description>
-    <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>Control Requirement Universally Unique Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this control requirement elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>control requirement</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <flag ref="control-id" required="yes"/>
-    <model>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-        <!-- TODO: Model specific link relationships -->
-      </assembly>
-      <assembly ref="set-parameter" max-occurs="unbounded">
-        <group-as name="set-parameters" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="responsible-role" max-occurs="unbounded">
-        <group-as name="responsible-roles" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="statement" max-occurs="unbounded">
-        <group-as name="statements" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="by-component" min-occurs="0" max-occurs="unbounded">
-        <group-as name="by-components" in-json="ARRAY"/>
-      </assembly>
-      <!-- TODO: Implement parameters -->
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <allowed-values target="prop/@name" allow-other="yes">
-        <enum value="control-origination">Identifies the source of the implemented control.</enum>
-      </allowed-values>
-      <allowed-values target="prop[@name='control-origination']/@value">
-        <enum value="organization">The control is implemented by the organization owning the system, but is not specific to the system itself.</enum>
-        <enum value="system-specific">The control is implemented specifically to this system.</enum>
-        <enum value="customer-configured">The control is provided by the system, but must be configured by the customer.</enum>
-        <enum value="customer-provided">The control must be implemented by the customer.</enum>
-        <enum value="inherited">This control is inherited from an underlying system.</enum>
-      </allowed-values>
-      <allowed-values target="prop/@name" allow-other="yes">
-        <enum value="leveraged-authorization">Indicates all or some portion of this control is inherited from an underlying authorized system.</enum>
-      </allowed-values>
-      <allowed-values target="responsible-role/@role-id" allow-other="yes">
-            &allowed-values-responsible-roles-operations;
-      </allowed-values>
-      <index-has-key name="index-metadata-role-id" target="responsible-role|statement/responsible-role|.//by-component//responsible-role">
-        <key-field target="@role-id"/>
-      </index-has-key>
-      <index-has-key name="index-metadata-party-uuid" target="responsible-role|statement/responsible-role|.//by-component//responsible-role">
-        <key-field target="party-uuid"/>
-      </index-has-key>
-      <has-cardinality target=".//by-component" min-occurs="1">
-        <remarks>
-          <p>Since all implementation statements are defined at the by-component level (e.g., type=this-system), there must be at least one by-component.</p>
-        </remarks>
-      </has-cardinality>
-      <is-unique id="unique-ssp-implemented-requirement-set-parameter" target="set-parameter">
-        <key-field target="@param-id"/>
-        <remarks>
-          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
-        </remarks>
-      </is-unique>
-      <is-unique id="unique-ssp-implemented-requirement-responsible-role" target="responsible-role">
-        <key-field target="@role-id"/>
-        <remarks>
-          <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-        </remarks>
-      </is-unique>
-      <is-unique id="unique-ssp-implemented-requirement-statement" target="statement">
-        <key-field target="@statement-id"/>
-        <remarks>
-          <p>Since <code>statement</code> entries can be referenced using the statement's statement-id, each statement must be referenced only once.</p>
-        </remarks>
-      </is-unique>
-      <is-unique id="unique-ssp-implemented-requirement-by-component" target="by-component">
-        <key-field target="@component-uuid"/>
-        <remarks>
-          <p>Since <code>by-component</code> can reference <code>component</code> entries using the component's uuid, each component must be referenced only once. This ensures that all implementation statements are contained in the same <code>by-component</code> entry.</p>
-        </remarks>
-      </is-unique>
-    </constraint>
-  </define-assembly>
-  <define-assembly name="statement" scope="local">
-    <formal-name>Specific Control Statement</formal-name>
-    <description>Identifies which statements within a control are addressed.</description>
-    <flag ref="statement-id" required="yes">
-      <remarks>
-        <p>A reference to the specific implemented statement associated with a control.</p>
-      </remarks>
-    </flag>
-    <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>Control Statement Reference Universally Unique Identifier</formal-name>
-      <!-- Identifier Reference -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this control statement elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The <em>UUID</em> of the <code>control statement</code> in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).</description>
-    </define-flag>
-    <model>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="responsible-role" max-occurs="unbounded">
-        <group-as name="responsible-roles" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="by-component" max-occurs="unbounded">
-        <group-as name="by-components" in-json="ARRAY"/>
-      </assembly>
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <allowed-values target="responsible-role/@role-id" allow-other="yes">
-            &allowed-values-responsible-roles-operations;
-      </allowed-values>
-      <is-unique id="unique-ssp-statement-responsible-role" target="responsible-role">
-        <key-field target="@role-id"/>
-        <remarks>
-          <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-        </remarks>
-      </is-unique>
-      <is-unique id="unique-ssp-implemented-requirement-statement-by-component" target="by-component">
-        <key-field target="@component-uuid"/>
-        <remarks>
-          <p>Since <code>by-component</code> can reference <code>component</code> entries using the component's uuid, each component must be referenced only once. This ensures that all implementation statements are contained in the same <code>by-component</code> entry.</p>
-        </remarks>
-      </is-unique>
-      
-    </constraint>
-  </define-assembly>
-  <define-assembly name="by-component">
-    <!-- QUESTION: Should set-parameter be moved here to allow component-specific parameter settings? or "this-system" for the whole system? -->
-    <formal-name>Component Control Implementation</formal-name>
-    <description>Defines how the referenced component implements a set of controls.</description>
-    <define-flag required="yes" name="component-uuid" as-type="uuid">
-      <formal-name>Component Universally Unique Identifier Reference</formal-name>
-      <!-- Identifier Reference -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the <code>component</code> that is implemeting a given control.</description>
-    </define-flag>
-    <define-flag name="uuid" as-type="uuid" required="yes">
-      <formal-name>By-Component Universally Unique Identifier</formal-name>
-      <!-- Identifier Declaration -->
-      <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this by-component entry elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>by-component</code> entry can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-    </define-flag>
-    <model>
-      <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-        <formal-name>Control Implementation Description</formal-name>
-        <description>An implementation statement that describes how a control or a control statement is implemented within the referenced system component.</description>
-      </define-field>
-      <assembly ref="property" max-occurs="unbounded">
-        <group-as name="props" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="link" max-occurs="unbounded">
-        <group-as name="links" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="set-parameter" max-occurs="unbounded">
-        <group-as name="set-parameters" in-json="ARRAY"/>
-      </assembly>
-      <assembly ref="implementation-status">
-        <remarks>
-          <p>The <code>implementation-status</code> is used to qualify the <code>status</code> value to indicate the degree to which the control is implemented.</p>
-        </remarks>
-      </assembly>
-      <define-assembly name="export" max-occurs="1">
-        <formal-name>Export</formal-name>
-        <description>Identifies content intended for external consumption, such as with leveraged organizations.</description>
-        <model>
-          <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
-            <formal-name>Control Implementation Export Description</formal-name>
-            <description>An implementation statement that describes the aspects of the control or control statement implementation that can be available to another system leveraging this system.</description>
-          </define-field>
-          <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-          </assembly>
-          <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-            <!-- TODO: Model specific link relationships -->
-          </assembly>
-          <define-assembly name="provided" max-occurs="unbounded">
-            <formal-name>Provided Control Implementation</formal-name>
-            <description>Describes a capability which may be inherited by a leveraging system.</description>
-            <!-- CHANGED: "provided-group" to "provided" -->
-            <group-as name="provided" in-json="ARRAY"/>
-            <define-flag name="uuid" as-type="uuid" required="yes">
-              <formal-name>Provided Universally Unique Identifier</formal-name>
-              <!-- Identifier Declaration -->
-              <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this provided entry elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>provided</code> entry can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <model>
-              <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-                <formal-name>Provided Control Implementation Description</formal-name>
-                <description>An implementation statement that describes the aspects of the control or control statement implementation that can be provided to another system leveraging this system.</description>
-              </define-field>
-              <assembly ref="property" max-occurs="unbounded">
-                <group-as name="props" in-json="ARRAY"/>
-              </assembly>
-              <assembly ref="link" max-occurs="unbounded">
-                <group-as name="links" in-json="ARRAY"/>
-                <!-- TODO: Model specific link relationships -->
-              </assembly>
-              <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
-                <group-as name="responsible-roles" in-json="ARRAY"/>
-              </assembly>
-              <field ref="remarks" in-xml="WITH_WRAPPER"/>
-            </model>
-            <constraint>
-              <is-unique id="unique-provided-responsible-role" target="responsible-role">
+            <allowed-values target="responsible-role/@role-id" allow-other="yes">
+                        &allowed-values-responsible-roles-operations;
+            </allowed-values>
+            <is-unique id="unique-ssp-statement-responsible-role" target="responsible-role">
                 <key-field target="@role-id"/>
                 <remarks>
-                  <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                    <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
                 </remarks>
-              </is-unique>
-            </constraint>
-          </define-assembly>
-          <define-assembly name="responsibility" max-occurs="unbounded">
-            <formal-name>Control Implementation Responsibility</formal-name>
-            <description>Describes a control implementation responsibility imposed on a leveraging system.</description>
-            <group-as name="responsibilities" in-json="ARRAY"/>
-            <define-flag name="uuid" as-type="uuid" required="yes">
-              <formal-name>Responsibility Universally Unique Identifier</formal-name>
-              <!-- Identifier Declaration -->
-              <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this responsibility elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>responsibility</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-            </define-flag>
-            <flag ref="provided-uuid" required="no" />
-            <model>
-              <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-                <formal-name>Control Implementation Responsibility Description</formal-name>
-                <description>An implementation statement that describes the aspects of the control or control statement implementation that a leveraging system must implement to satisfy the control provided by a leveraged system.</description>
-              </define-field>
-              <assembly ref="property" max-occurs="unbounded">
+            </is-unique>
+            <is-unique id="unique-ssp-implemented-requirement-statement-by-component" target="by-component">
+                <key-field target="@component-uuid"/>
+                <remarks>
+                    <p>Since <code>by-component</code> can reference <code>component</code> entries using the component's uuid, each component must be referenced only once. This ensures that all implementation statements are contained in the same <code>by-component</code> entry.</p>
+                </remarks>
+            </is-unique>
+
+        </constraint>
+    </define-assembly>
+    <define-assembly name="by-component">
+        <!-- QUESTION: Should set-parameter be moved here to allow component-specific parameter settings? or "this-system" for the whole system? -->
+        <formal-name>Component Control Implementation</formal-name>
+        <description>Defines how the referenced component implements a set of controls.</description>
+        <define-flag required="yes" name="component-uuid" as-type="uuid">
+            <formal-name>Component Universally Unique Identifier Reference</formal-name>
+            <!-- Identifier Reference -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the <code>component</code> that is implemeting a given control.</description>
+        </define-flag>
+        <define-flag name="uuid" as-type="uuid" required="yes">
+            <formal-name>By-Component Universally Unique Identifier</formal-name>
+            <!-- Identifier Declaration -->
+            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this by-component entry elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>by-component</code> entry can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+        </define-flag>
+        <model>
+            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                <formal-name>Control Implementation Description</formal-name>
+                <description>An implementation statement that describes how a control or a control statement is implemented within the referenced system component.</description>
+            </define-field>
+            <assembly ref="property" max-occurs="unbounded">
                 <group-as name="props" in-json="ARRAY"/>
-              </assembly>
-              <assembly ref="link" max-occurs="unbounded">
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
                 <group-as name="links" in-json="ARRAY"/>
-                <!-- TODO: Model specific link relationships -->
-              </assembly>
-              <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
+            </assembly>
+            <assembly ref="set-parameter" max-occurs="unbounded">
+                <group-as name="set-parameters" in-json="ARRAY"/>
+            </assembly>
+            <assembly ref="implementation-status">
+                <remarks>
+                    <p>The <code>implementation-status</code> is used to qualify the <code>status</code> value to indicate the degree to which the control is implemented.</p>
+                </remarks>
+            </assembly>
+            <define-assembly name="export" max-occurs="1">
+                <formal-name>Export</formal-name>
+                <description>Identifies content intended for external consumption, such as with leveraged organizations.</description>
+                <model>
+                    <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
+                        <formal-name>Control Implementation Export Description</formal-name>
+                        <description>An implementation statement that describes the aspects of the control or control statement implementation that can be available to another system leveraging this system.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                        <!-- TODO: Model specific link relationships -->
+                    </assembly>
+                    <define-assembly name="provided" max-occurs="unbounded">
+                        <formal-name>Provided Control Implementation</formal-name>
+                        <description>Describes a capability which may be inherited by a leveraging system.</description>
+                        <!-- CHANGED: "provided-group" to "provided" -->
+                        <group-as name="provided" in-json="ARRAY"/>
+                        <define-flag name="uuid" as-type="uuid" required="yes">
+                            <formal-name>Provided Universally Unique Identifier</formal-name>
+                            <!-- Identifier Declaration -->
+                            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this provided entry elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>provided</code> entry can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                        </define-flag>
+                        <model>
+                            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                                <formal-name>Provided Control Implementation Description</formal-name>
+                                <description>An implementation statement that describes the aspects of the control or control statement implementation that can be provided to another system leveraging this system.</description>
+                            </define-field>
+                            <assembly ref="property" max-occurs="unbounded">
+                                <group-as name="props" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="link" max-occurs="unbounded">
+                                <group-as name="links" in-json="ARRAY"/>
+                                <!-- TODO: Model specific link relationships -->
+                            </assembly>
+                            <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
+                                <group-as name="responsible-roles" in-json="ARRAY"/>
+                            </assembly>
+                            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+                        </model>
+                        <constraint>
+                            <is-unique id="unique-provided-responsible-role" target="responsible-role">
+                                <key-field target="@role-id"/>
+                                <remarks>
+                                    <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                                </remarks>
+                            </is-unique>
+                        </constraint>
+                    </define-assembly>
+                    <define-assembly name="responsibility" max-occurs="unbounded">
+                        <formal-name>Control Implementation Responsibility</formal-name>
+                        <description>Describes a control implementation responsibility imposed on a leveraging system.</description>
+                        <group-as name="responsibilities" in-json="ARRAY"/>
+                        <define-flag name="uuid" as-type="uuid" required="yes">
+                            <formal-name>Responsibility Universally Unique Identifier</formal-name>
+                            <!-- Identifier Declaration -->
+                            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this responsibility elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>responsibility</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                        </define-flag>
+                        <flag ref="provided-uuid" required="no" />
+                        <model>
+                            <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                                <formal-name>Control Implementation Responsibility Description</formal-name>
+                                <description>An implementation statement that describes the aspects of the control or control statement implementation that a leveraging system must implement to satisfy the control provided by a leveraged system.</description>
+                            </define-field>
+                            <assembly ref="property" max-occurs="unbounded">
+                                <group-as name="props" in-json="ARRAY"/>
+                            </assembly>
+                            <assembly ref="link" max-occurs="unbounded">
+                                <group-as name="links" in-json="ARRAY"/>
+                                <!-- TODO: Model specific link relationships -->
+                            </assembly>
+                            <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
+                                <group-as name="responsible-roles" in-json="ARRAY"/>
+                                <remarks>
+                                    <p>A role defined at the by-component level takes precedence over the same role defined on the parent implemented-requirement or on the referenced component. </p>
+                                </remarks>
+                            </assembly>
+                            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+                        </model>
+                        <constraint>
+                            <is-unique id="unique-responsibility-responsible-role" target="responsible-role">
+                                <key-field target="@role-id"/>
+                                <remarks>
+                                    <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                                </remarks>
+                            </is-unique>
+                        </constraint>
+                    </define-assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER"/>
+                </model>
+                <constraint>
+                    <has-cardinality target="provided|responsibility" min-occurs="1"/>
+                    <index-has-key name="by-component-export-provided-uuid" target="responsibility">
+                        <key-field target="@provided-uuid"/>
+                    </index-has-key>
+                </constraint>
+            </define-assembly>
+            <define-assembly name="inherited" max-occurs="unbounded">
+                <formal-name>Inherited Control Implementation</formal-name>
+                <description>Describes a control implementation inherited by a leveraging system.</description>
+                <!-- CHANGED: "inherited-group" to "inherited" -->
+                <group-as name="inherited" in-json="ARRAY"/>
+                <define-flag name="uuid" as-type="uuid" required="yes">
+                    <formal-name>Inherited Universally Unique Identifier</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this inherited entry elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>inherited control implementation</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+                <flag ref="provided-uuid" required="no" />
+                <model>
+                    <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                        <formal-name>Inherited Control Implementation Description</formal-name>
+                        <description>An implementation statement that describes the aspects of a control or control statement implementation that a leveraging system is inheriting from a leveraged system.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                        <!-- TODO: Model specific link relationships -->
+                    </assembly>
+                    <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
+                        <group-as name="responsible-roles" in-json="ARRAY"/>
+                    </assembly>
+                </model>
+                <constraint>
+                    <is-unique id="unique-inherited-responsible-role" target="responsible-role">
+                        <key-field target="@role-id"/>
+                        <remarks>
+                            <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                        </remarks>
+                    </is-unique>
+                </constraint>
+            </define-assembly>
+            <define-assembly name="satisfied" max-occurs="unbounded">
+                <formal-name>Satisfied Control Implementation Responsibility</formal-name>
+                <description>Describes how this system satisfies a responsibility imposed by a leveraged system.</description>
+                <!-- CHANGED: "satisfied-group" to "satisfied" -->
+                <group-as name="satisfied" in-json="ARRAY"/>
+                <define-flag name="uuid" as-type="uuid" required="yes">
+                    <formal-name>Satisfied Universally Unique Identifier</formal-name>
+                    <!-- Identifier Declaration -->
+                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this satisfied control implementation entry elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>control implementation</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                </define-flag>
+                <flag ref="responsibility-uuid" required="no" />
+                <model>
+                    <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
+                        <formal-name>Satisfied Control Implementation Responsibility Description</formal-name>
+                        <description>An implementation statement that describes the aspects of a control or control statement implementation that a leveraging system is implementing based on a requirement from a leveraged system.</description>
+                    </define-field>
+                    <assembly ref="property" max-occurs="unbounded">
+                        <group-as name="props" in-json="ARRAY"/>
+                    </assembly>
+                    <assembly ref="link" max-occurs="unbounded">
+                        <group-as name="links" in-json="ARRAY"/>
+                        <!-- TODO: Model specific link relationships -->
+                    </assembly>
+                    <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
+                        <group-as name="responsible-roles" in-json="ARRAY"/>
+                    </assembly>
+                    <field ref="remarks" in-xml="WITH_WRAPPER"/>
+                </model>
+                <constraint>
+                    <is-unique id="unique-satisfied-responsible-role" target="responsible-role">
+                        <key-field target="@role-id"/>
+                        <remarks>
+                            <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
+                        </remarks>
+                    </is-unique>
+                </constraint>
+            </define-assembly>
+            <assembly ref="responsible-role" max-occurs="unbounded">
                 <group-as name="responsible-roles" in-json="ARRAY"/>
+            </assembly>
+            <!-- CHANGED: removed "set-parameter" -->
+            <field ref="remarks" in-xml="WITH_WRAPPER"/>
+        </model>
+        <constraint>
+            <allowed-values target=".//responsible-role/@role-id" allow-other="yes">
+                        &allowed-values-responsible-roles-operations;
+                        &allowed-values-responsible-roles-component-production;
+            </allowed-values>
+            <is-unique id="unique-ssp-by-component-set-parameter" target="set-parameter">
+                <key-field target="@param-id"/>
                 <remarks>
-                  <p>A role defined at the by-component level takes precedence over the same role defined on the parent implemented-requirement or on the referenced component. </p>
+                    <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
                 </remarks>
-              </assembly>
-              <field ref="remarks" in-xml="WITH_WRAPPER"/>
-            </model>
-            <constraint>
-              <is-unique id="unique-responsibility-responsible-role" target="responsible-role">
-                <key-field target="@role-id"/>
-                <remarks>
-                  <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-                </remarks>
-              </is-unique>
-            </constraint>
-          </define-assembly>
-          <field ref="remarks" in-xml="WITH_WRAPPER"/>
-        </model>
-        <constraint>
-          <has-cardinality target="provided|responsibility" min-occurs="1"/>
-          <index-has-key name="by-component-export-provided-uuid" target="responsibility">
-            <key-field target="@provided-uuid"/>
-          </index-has-key>
+            </is-unique>
         </constraint>
-      </define-assembly>
-      <define-assembly name="inherited" max-occurs="unbounded">
-        <formal-name>Inherited Control Implementation</formal-name>
-        <description>Describes a control implementation inherited by a leveraging system.</description>
-        <!-- CHANGED: "inherited-group" to "inherited" -->
-        <group-as name="inherited" in-json="ARRAY"/>
-        <define-flag name="uuid" as-type="uuid" required="yes">
-          <formal-name>Inherited Universally Unique Identifier</formal-name>
-          <!-- Identifier Declaration -->
-          <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this inherited entry elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>inherited control implementation</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-        </define-flag>
-        <flag ref="provided-uuid" required="no" />
-        <model>
-          <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-            <formal-name>Inherited Control Implementation Description</formal-name>
-            <description>An implementation statement that describes the aspects of a control or control statement implementation that a leveraging system is inheriting from a leveraged system.</description>
-          </define-field>
-          <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-          </assembly>
-          <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-            <!-- TODO: Model specific link relationships -->
-          </assembly>
-          <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
-            <group-as name="responsible-roles" in-json="ARRAY"/>
-          </assembly>
-        </model>
-        <constraint>
-          <is-unique id="unique-inherited-responsible-role" target="responsible-role">
-            <key-field target="@role-id"/>
-            <remarks>
-              <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-            </remarks>
-          </is-unique>
-        </constraint>
-      </define-assembly>
-      <define-assembly name="satisfied" max-occurs="unbounded">
-        <formal-name>Satisfied Control Implementation Responsibility</formal-name>
-        <description>Describes how this system satisfies a responsibility imposed by a leveraged system.</description>
-        <!-- CHANGED: "satisfied-group" to "satisfied" -->
-        <group-as name="satisfied" in-json="ARRAY"/>
-        <define-flag name="uuid" as-type="uuid" required="yes">
-          <formal-name>Satisfied Universally Unique Identifier</formal-name>
-          <!-- Identifier Declaration -->
-          <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this satisfied control implementation entry elsewhere in <a href="/concepts/identifier-use/#ssp-identifiers">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>control implementation</code> can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-        </define-flag>
-        <flag ref="responsibility-uuid" required="no" />
-        <model>
-          <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
-            <formal-name>Satisfied Control Implementation Responsibility Description</formal-name>
-            <description>An implementation statement that describes the aspects of a control or control statement implementation that a leveraging system is implementing based on a requirement from a leveraged system.</description>
-          </define-field>
-          <assembly ref="property" max-occurs="unbounded">
-            <group-as name="props" in-json="ARRAY"/>
-          </assembly>
-          <assembly ref="link" max-occurs="unbounded">
-            <group-as name="links" in-json="ARRAY"/>
-            <!-- TODO: Model specific link relationships -->
-          </assembly>
-          <assembly ref="responsible-role" min-occurs="0" max-occurs="unbounded">
-            <group-as name="responsible-roles" in-json="ARRAY"/>
-          </assembly>
-          <field ref="remarks" in-xml="WITH_WRAPPER"/>
-        </model>
-        <constraint>
-          <is-unique id="unique-satisfied-responsible-role" target="responsible-role">
-            <key-field target="@role-id"/>
-            <remarks>
-              <p>Since <code>responsible-role</code> associates multiple <code>party-uuid</code> entries with a single <code>role-id</code>, each role-id must be referenced only once.</p>
-            </remarks>
-          </is-unique>
-        </constraint>
-      </define-assembly>
-      <assembly ref="responsible-role" max-occurs="unbounded">
-        <group-as name="responsible-roles" in-json="ARRAY"/>
-      </assembly>
-      <!-- CHANGED: removed "set-parameter" -->
-      <field ref="remarks" in-xml="WITH_WRAPPER"/>
-    </model>
-    <constraint>
-      <allowed-values target=".//responsible-role/@role-id" allow-other="yes">
-            &allowed-values-responsible-roles-operations;
-            &allowed-values-responsible-roles-component-production;
-      </allowed-values>
-      <is-unique id="unique-ssp-by-component-set-parameter" target="set-parameter">
-        <key-field target="@param-id"/>
-        <remarks>
-          <p>Since multiple <code>set-parameter</code> entries can be provided, each parameter must be set only once.</p>
-        </remarks>
-      </is-unique>
-    </constraint>
-  </define-assembly>
+    </define-assembly>
 
-  <define-flag name="provided-uuid" as-type="uuid" scope="local">
-    <formal-name>Provided UUID</formal-name>
-    <!-- Identifier Reference -->
-    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an inherited control implementation that a leveraging system is inheriting from a leveraged system.</description>
-  </define-flag>
+    <define-flag name="provided-uuid" as-type="uuid" scope="local">
+        <formal-name>Provided UUID</formal-name>
+        <!-- Identifier Reference -->
+        <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an inherited control implementation that a leveraging system is inheriting from a leveraged system.</description>
+    </define-flag>
 
-  <define-flag name="responsibility-uuid" as-type="uuid" scope="local">
-    <formal-name>Responsibility UUID</formal-name>
-    <!-- Identifier Reference -->
-    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a control implementation that satisfies a responsibility imposed by a leveraged system.</description>
-  </define-flag>
+    <define-flag name="responsibility-uuid" as-type="uuid" scope="local">
+        <formal-name>Responsibility UUID</formal-name>
+        <!-- Identifier Reference -->
+        <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to a control implementation that satisfies a responsibility imposed by a leveraged system.</description>
+    </define-flag>
 </METASCHEMA>

--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-select.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-select.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
     xmlns="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:opr="http://csrc.nist.gov/ns/oscal/profile-resolution"
@@ -10,7 +10,7 @@
     xpath-default-namespace="http://csrc.nist.gov/ns/oscal/1.0">
 
     <!-- Purpose: perform operations supporting the selection stage of OSCAL profile resolution. -->
-    <!-- XSLT version: 2.0 -->
+    <!-- XSLT version: 3.0 -->
 
     <xsl:strip-space elements="catalog group control param guideline select part
         metadata back-matter annotation party person org rlink address resource role responsible-party citation
@@ -83,7 +83,6 @@
         </metadata>
     </xsl:template>-->
 
-    <xsl:key name="cross-reference" match="resource" use="'#' || @id"/>
     <xsl:key name="cross-reference" match="resource" use="'#' || @uuid"/>
 
     <xsl:template priority="2" mode="o:select" match="import[starts-with(@href,'#')]">
@@ -94,7 +93,16 @@
 
     <xsl:template match="resource" mode="o:import">
         <xsl:variable name="linked-xml" select="child::rlink[ends-with(@href,'.xml') or matches(@media-type,'xml')][1]"/>
-        <xsl:apply-templates mode="o:select" select="o:resource-or-warning($linked-xml/@href)"/>
+        <xsl:choose>
+            <xsl:when test="exists($linked-xml)">
+        <xsl:apply-templates mode="o:select" select="o:resource-or-error($linked-xml/@href)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:message terminate="yes"
+                    expand-text="yes">Document not acquired for resource with uuid {@uuid
+                    }: No rlink with media-type='xml' or href ending with '.xml'</xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <xsl:template priority="1" mode="o:select" match="import">
@@ -104,7 +112,7 @@
         <xsl:apply-templates select="$linked-resource" mode="o:import">
             <xsl:with-param name="import-instruction" select="." tunnel="yes"/>
         </xsl:apply-templates>
-        <xsl:apply-templates mode="#current" select="o:resource-or-warning(@href)">
+        <xsl:apply-templates mode="#current" select="o:resource-or-error(@href)">
             <xsl:with-param name="import-instruction" select="." tunnel="yes"/>
         </xsl:apply-templates>
     </xsl:template>
@@ -118,10 +126,11 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template name="add-process-id">
+    <xsl:template name="add-process-id" as="attribute(opr:id)">
+        <xsl:param name="context" select="." as="element()"/>
         <xsl:attribute name="opr:id" namespace="http://csrc.nist.gov/ns/oscal/profile-resolution">
             <xsl:value-of
-                select="concat(opr:catalog-identifier(/o:catalog), '#', (@id, generate-id())[1])"/>
+                select="concat(opr:catalog-identifier($context/root()/o:catalog), '#', $context/(@id, generate-id())[1])"/>
         </xsl:attribute>
     </xsl:template>
 
@@ -131,7 +140,7 @@
     </xsl:function>
 
     <!-- A control is included if it is selected by the provided import instruction -->
-    <xsl:template match="control" mode="o:select">
+    <xsl:template match="control" mode="o:select" as="element(o:control)?">
         <xsl:param name="import-instruction" tunnel="yes" required="yes"/>
         <xsl:if test="o:selects($import-instruction,.)">
             <xsl:copy copy-namespaces="no">
@@ -174,22 +183,30 @@
             <xsl:sequence select="exists($importing/include-all)"/>
             <xsl:sequence select="some $c in ($importing/include-controls/with-id)
                                   satisfies ($c = $candidate/@id)"/>
+            <xsl:sequence select="some $c in ($importing/include-controls[o:calls-parents(.)]/with-id)
+                satisfies ($c = $candidate/descendant::control/@id)"/>
             <xsl:sequence select="some $c in ($importing/include-controls[o:calls-children(.)]/with-id)
                 satisfies ($c = $candidate/ancestor::control/@id)"/>
-            <xsl:sequence select="some $m in ($importing/include-controls/matching)
+            <xsl:sequence select="some $m in ($importing/include-controls/matching[@pattern != ''])
                                   satisfies (matches($candidate/@id,$m/@pattern/o:glob-as-regex(string(.)) ))"/>
-            <xsl:sequence select="some $m in ($importing/include/matching[o:calls-children(.)])
-                satisfies (matches($candidate/ancestor::control/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
+            <xsl:sequence select="some $m in ($importing/include-controls[o:calls-parents(.)]/matching[@pattern != '']), $a in $candidate/descendant::control 
+                satisfies (matches($a/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
+            <xsl:sequence select="some $m in ($importing/include-controls[o:calls-children(.)]/matching[@pattern != '']), $a in $candidate/ancestor::control 
+                satisfies (matches($a/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
         </xsl:variable>
         <xsl:variable name="exclude-reasons" as="xs:boolean+">
             <xsl:sequence select="exists($candidate/parent::control) and $importing/include-all/@with-child-controls='no'"/>
             <xsl:sequence select="some $c in ($importing/exclude-controls/with-id) satisfies ($c = $candidate/@id)"/>
+            <xsl:sequence select="some $c in ($importing/exclude-controls[o:calls-parents(.)]/with-id)
+                satisfies ($c = $candidate/descendant::control/@id)"/>
             <xsl:sequence select="some $c in ($importing/exclude-controls[o:calls-children(.)]/with-id)
                 satisfies ($c = $candidate/ancestor::control/@id)"/>
-            <xsl:sequence select="some $m in ($importing/exclude-controls/matching)
+            <xsl:sequence select="some $m in ($importing/exclude-controls/matching[@pattern != ''])
                 satisfies (matches($candidate/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
-            <xsl:sequence select="some $m in ($importing/exclude-controls[o:calls-children(.)]/matcjomg)
-                satisfies (matches($candidate/ancestor::control/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
+            <xsl:sequence select="some $m in ($importing/exclude-controls[o:calls-parents(.)]/matching[@pattern != '']), $a in $candidate/descendant::control
+                satisfies (matches($a/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
+            <xsl:sequence select="some $m in ($importing/exclude-controls[o:calls-children(.)]/matching[@pattern != '']), $a in $candidate/ancestor::control
+                satisfies (matches($a/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
         </xsl:variable>
         <!-- predicate [.] filters reasons as booleans -->
         <xsl:sequence select="exists($include-reasons[.]) and empty($exclude-reasons[.])"/>
@@ -200,26 +217,19 @@
         <xsl:sequence select="$caller/@with-child-controls='yes'"/>
     </xsl:function>
 
-    <!-- Returns a document when found, a <opr:warning> element when not. -->
-    <xsl:function name="o:resource-or-warning" as="document-node()">
+    <xsl:function name="o:calls-parents" as="xs:boolean">
+        <xsl:param name="caller" as="element()"/>
+        <xsl:sequence select="not($caller/@with-parent-controls='no')"/>
+    </xsl:function>
+
+    <!-- Returns a document when found, a fatal error when not. -->
+    <xsl:function name="o:resource-or-error" as="document-node()">
         <xsl:param name="href" as="attribute(href)"/>
         <xsl:variable name="resolved-href" select="resolve-uri($href,$href/base-uri())"/>
-        <xsl:choose>
-            <xsl:when test="doc-available($resolved-href)">
-                <xsl:sequence select="document($resolved-href)"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:document>
-                    <opr:WARNING>
-                        <xsl:text>Document not acquired: '</xsl:text>
-                        <xsl:value-of select="$href"/>
-                        <xsl:text>' resolved as '</xsl:text>
-                        <xsl:value-of select="$resolved-href"/>
-                        <xsl:text>' (as OSCAL XML)</xsl:text>
-                    </opr:WARNING>
-                </xsl:document>
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:assert test="doc-available($resolved-href)"
+            expand-text="yes">Document not acquired: {$href} resolved as {
+            $resolved-href} (as OSCAL XML)</xsl:assert>
+        <xsl:sequence select="document($resolved-href)"/>
     </xsl:function>
 
     <xsl:include href="oscal-profile-resolve-functions.xsl"/>
@@ -237,7 +247,7 @@
         <xsl:variable name="runtime" as="map(xs:string, item())">
             <xsl:map>
                 <xsl:map-entry key="'xslt-version'"        select="3.0"/>
-                <xsl:map-entry key="'stylesheet-location'" select="'../oscal-profile-RESOLVE.xsl'"/>
+                <xsl:map-entry key="'stylesheet-location'" select="'oscal-profile-RESOLVE.xsl'"/>
                 <xsl:map-entry key="'source-node'"         select="root($profile)"/>
                 <xsl:map-entry key="'stylesheet-params'"   select="$runtime-params"/>
             </xsl:map>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/catalog-no-uuid.xml
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/catalog-no-uuid.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"/>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/catalog-nonstandard-file-name-ext.xmlcat
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/catalog-nonstandard-file-name-ext.xmlcat
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="xmlcat"/>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/glob-rewrite.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/glob-rewrite.xspec
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE x:description [
-<!ENTITY filedir "file:/C:/Users/wap1/Documents/usnistgov/OSCAL/src/specifications/profile-resolution/profile-resolution-examples/catalogs" >
-]>
 <x:description xmlns="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:opr="http://csrc.nist.gov/ns/oscal/profile-resolution"
     xmlns:x="http://www.jenitennison.com/xslt/xspec"
     stylesheet="../../oscal-profile-resolve-select.xsl">
+    <x:scenario label="Tests for o:glob-as-regex function">
     <x:scenario label="Simple string">
         <x:call function="o:glob-as-regex">
             <x:param>ac</x:param>
@@ -30,5 +28,12 @@
             <x:param>ac-1(*)</x:param>
         </x:call>
         <x:expect label="Anchored and escaped with substitution" select="'^ac-1\(.*\)$'"/>
+        </x:scenario>
+        <x:scenario label="Empty string (degenerate case)">
+            <x:call function="o:glob-as-regex">
+                <x:param select="''"/>
+            </x:call>
+            <x:expect label="Anchored empty string" select="'^$'"/>
+        </x:scenario>
     </x:scenario>
 </x:description>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/resource-media-type.xml
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/resource-media-type.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../../../../specifications/profile-resolution/example-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- Modified by conversion XSLT 2021-04-05T11:22:08.131-04:00 - RC2 OSCAL becomes RC3 OSCAL -->
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="427f8c54-c3af-4ca3-a92c-f6abaa015ba5">
+   <metadata>
+      <title>Test Profile with Nonstandard File Name Extension in resource/rlink</title>
+      <last-modified>2020-05-30T14:39:37.3-04:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0-rc2</oscal-version>
+   </metadata>
+   <import href="#0050231f-4fd0-43d6-8fa0-431367cd83e1">
+      <include-all/>
+   </import>
+   <back-matter>
+      <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e1">
+         <rlink href="https://some-non-xml-url"/>
+         <rlink href="catalog-nonstandard-file-name-ext.xmlcat" media-type="xml"/>
+      </resource>
+      <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e1">
+         <!-- Duplicate uuid is intentional, for testing template with
+            mode="o:select" match="import[starts-with(@href,'#')]" -->
+         <rlink href="catalog-nonstandard-file-name-ext.xmlcat" media-type="xml"/>
+      </resource>
+   </back-matter>
+</profile>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/resource-multiple-rlinks.xml
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/resource-multiple-rlinks.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../../../../specifications/profile-resolution/example-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- Modified by conversion XSLT 2021-04-05T11:22:08.131-04:00 - RC2 OSCAL becomes RC3 OSCAL -->
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="427f8c54-c3af-4ca3-a92c-f6abaa015ba5">
+   <metadata>
+      <title>Test Profile with Nonstandard File Name Extension in resource/rlink</title>
+      <last-modified>2020-05-30T14:39:37.3-04:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0-rc2</oscal-version>
+   </metadata>
+   <import href="#0050231f-4fd0-43d6-8fa0-431367cd83e1">
+      <include-all/>
+   </import>
+   <back-matter>
+      <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e1">
+         <rlink href="catalog-nonstandard-file-name-ext.xmlcat" media-type="xml"/>
+         <rlink href="catalog-no-uuid.xml"/>
+      </resource>
+   </back-matter>
+</profile>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/select-mapping-controls.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/select-mapping-controls.xspec
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+  xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"
+  xmlns:opr="http://csrc.nist.gov/ns/oscal/profile-resolution"
+  xmlns:ov="http://csrc.nist.gov/ns/oscal/test/variable"
+  xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  stylesheet="../../oscal-profile-resolve-select.xsl"
+  xslt-version="3.0">
+
+    <!-- This file contains preliminary tests for behavior described in the
+        "Mapping Controls" section of the spec. The tests are at an
+        "integration" level rather than per-template or per-function level
+        because the feature is not implemented yet (i.e., the breakdown
+        into templates and functions is not determined).
+
+        Future integration-level or system-level tests should also cover
+        updating "all known references to the old ID in other included content,
+        allowing the new ID to be used in subsequent profile sections." -->
+
+    <!-- SPEC QUESTION: What are the optional sections of <mapping>
+        other than <controls>? Are groups, params, and parts among them?
+        https://github.com/usnistgov/OSCAL/discussions/1114
+        When this is determined, tests can be added for those sections. -->
+
+    <!-- Location of sample files, relative to compiled test in xspec/ subdirectory -->
+    <x:variable name="ov:filedir" as="xs:string" select="resolve-uri('../../../../../../specifications/profile-resolution/profile-resolution-examples')"/>
+
+    <x:scenario label="Import controls using ID mapping">
+        <x:scenario label="Basic case" pending="Mapping is not implemented yet">
+            <x:context mode="o:select">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                    <include-controls>
+                        <with-id>x1</with-id>
+                    </include-controls>
+                    <mapping>
+                        <controls>
+                            <map from="x1" to="map-x1"/>
+                        </controls>
+                    </mapping>
+                </import>
+            </x:context>
+            <x:expect label="Control X1 with id=map-x1">
+                <selection uuid="..." opr:src="...">
+                    <metadata>...</metadata>
+                    <group opr:id="...">
+                        <title>Group X of XYZ</title>
+                        <control id="map-x1" opr:id="...">
+                            <title>Control X1</title>
+                        </control>
+                    </group>
+                    <group opr:id="...">...</group>
+                    <group opr:id="...">...</group>
+                </selection>
+            </x:expect>
+            <x:expect label="opr:id of Control X1 has mapped ID after #"
+                test="$x:result//o:title[.='Control X1']/parent::o:control/@opr:id ! substring-after(.,'#')"
+                select="'map-x1'"/>
+        </x:scenario>
+        <x:scenario label="Catalog imported twice with different mappings" pending="Mapping is not implemented yet">
+            <x:context mode="o:select">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                    <include-controls>
+                        <with-id>x1</with-id>
+                    </include-controls>
+                    <mapping>
+                        <controls>
+                            <map from="x1" to="map1-x1"/>
+                        </controls>
+                    </mapping>
+                </import>
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                    <include-controls>
+                        <with-id>x1</with-id>
+                    </include-controls>
+                    <mapping>
+                        <controls>
+                            <map from="x1" to="map2-x1"/>
+                        </controls>
+                    </mapping>
+                </import>
+            </x:context>
+            <x:expect label="Control X1 twice with IDs map1-x1 and map2-x1">
+                <selection uuid="..." opr:src="...">
+                    <metadata>...</metadata>
+                    <group opr:id="...">
+                        <title>Group X of XYZ</title>
+                        <control id="map1-x1" opr:id="...">
+                            <title>Control X1</title>
+                        </control>
+                    </group>
+                    <group opr:id="...">...</group>
+                    <group opr:id="...">...</group>
+                </selection>
+                <selection uuid="..." opr:src="...">
+                    <metadata>...</metadata>
+                    <group opr:id="...">
+                        <title>Group X of XYZ</title>
+                        <control id="map2-x1" opr:id="...">
+                            <title>Control X1</title>
+                        </control>
+                    </group>
+                    <group opr:id="...">...</group>
+                    <group opr:id="...">...</group>
+                </selection>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Partial matching of text" pending="Mapping is not implemented yet">
+            <x:context mode="o:select">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                    <include-controls with-child-controls="yes">
+                        <with-id>z3</with-id>
+                    </include-controls>
+                    <mapping>
+                        <controls>
+                            <map from="z3.a" to="map-z3.a"/>
+                        </controls>
+                    </mapping>
+                </import>
+            </x:context>
+            <x:expect label="Control Z3-A has mapped ID, while Z3-A-1 has unchanged ID"
+                test="$x:result//o:title[.='Control Z3']/parent::o:control">
+                <control id="z3" opr:id="..."><title>Control Z3</title>
+                    <control id="map-z3.a" opr:id="..."><title>Control Z3-A</title>
+                        <control id="z3.a-1" opr:id="..."><title>Control Z3-A-1</title></control>
+                    </control>
+                </control>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Attempt to use pattern in 'from'">
+            <x:context mode="o:select">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                    <include-controls with-child-controls="yes">
+                        <with-id>z3</with-id>
+                    </include-controls>
+                    <mapping>
+                        <controls>
+                            <map from="z3*" to="map-z3"/>
+                        </controls>
+                    </mapping>
+                </import>
+            </x:context>
+            <x:expect label="IDs are unchanged because 'from' must be exact match"
+                test="$x:result//o:title[.='Control Z3']/parent::o:control">
+                <control id="z3" opr:id="..."><title>Control Z3</title>
+                    <control id="z3.a" opr:id="..."><title>Control Z3-A</title>
+                        <control id="z3.a-1" opr:id="..."><title>Control Z3-A-1</title></control>
+                    </control>
+                </control>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Multiple mappings from the same ID" pending="Mapping is not implemented yet">
+            <x:context mode="o:select">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                    <include-controls>
+                        <with-id>x1</with-id>
+                    </include-controls>
+                    <mapping>
+                        <controls>
+                            <map from="x1" to="map-x1"/>
+                            <map from="x1" to="map-again-x1"/>
+                        </controls>
+                    </mapping>
+                </import>
+            </x:context>
+            <x:expect label="ID of Control X1 uses first value (SPEC QUESTION: is that the expected behavior? https://github.com/usnistgov/OSCAL/discussions/1115)"
+                test="$x:result//o:title[.='Control X1']/parent::o:control/@id/string()"
+                select="'map-x1'"/>
+        </x:scenario>
+        <x:scenario label="'to' of one mapping matches 'from' of another mapping" pending="Mapping is not implemented yet">
+            <x:context mode="o:select">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                    <include-controls>
+                        <with-id>x1</with-id>
+                    </include-controls>
+                    <mapping>
+                        <controls>
+                            <map from="x1" to="map-x1"/>
+                            <map from="map-x1" to="map-again-x1"/>
+                        </controls>
+                    </mapping>
+                </import>
+            </x:context>
+            <x:expect label="ID of Control X1 uses 'to' value, ignoring subsequent mapping (SPEC QUESTION: is that the expected behavior? https://github.com/usnistgov/OSCAL/discussions/1115)"
+                test="$x:result//o:title[.='Control X1']/parent::o:control/@id/string()"
+                select="'map-x1'"/>
+        </x:scenario>
+        <x:scenario label="'to' ID appears in exclusion directive">
+            <x:context mode="o:select">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                    <include-controls>
+                        <with-id>x1</with-id>
+                    </include-controls>
+                    <exclude-controls>
+                        <with-id>map-x1</with-id>
+                    </exclude-controls>
+                    <mapping>
+                        <controls>
+                            <map from="x1" to="map-x1"/>
+                        </controls>
+                    </mapping>
+                </import>
+            </x:context>
+            <x:expect label="Control X1 is included (mapping occurs after exclusion logic) (SPEC QUESTION: is that the expected behavior? https://github.com/usnistgov/OSCAL/discussions/1116)"
+                test="exists($x:result//o:title[.='Control X1'])"/>
+        </x:scenario>
+        <x:scenario label="ID matches but mapping is not for controls">
+            <x:context mode="o:select">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                    <include-controls>
+                        <with-id>x1</with-id>
+                    </include-controls>
+                    <mapping>
+                        <params>
+                            <map from="x1" to="map-x1"/>
+                        </params>
+                    </mapping>
+                </import>
+            </x:context>
+            <x:expect label="ID of Control X1 is unchanged"
+                test="$x:result//o:title[.='Control X1']/parent::o:control/@id/string()"
+                select="'x1'"/>
+        </x:scenario>
+        <x:scenario label="No applicable mapping">
+            <x:context mode="o:select">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                    <include-controls>
+                        <with-id>x1</with-id>
+                    </include-controls>
+                    <mapping>
+                        <controls>
+                            <map from="nonexistent" to="map-x1"/>
+                        </controls>
+                    </mapping>
+                </import>
+            </x:context>
+            <x:expect label="ID of Control X1 is unchanged"
+                test="$x:result//o:title[.='Control X1']/parent::o:control/@id/string()"
+                select="'x1'"/>
+        </x:scenario>
+    </x:scenario>
+
+</x:description>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/select-rlink.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/select-rlink.xspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE x:description [
-<!ENTITY filedir "file:/C:/Users/wap1/Documents/usnistgov/OSCAL/src/specifications/profile-resolution/profile-resolution-examples/catalogs" >
+<!ENTITY filedir "../../../../../../../src/specifications/profile-resolution/profile-resolution-examples/catalogs" >
 ]>
 <x:description xmlns="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:opr="http://csrc.nist.gov/ns/oscal/profile-resolution"
@@ -101,7 +101,7 @@
                 </back-matter>
             </profile>
         </x:context>
-        <x:expect label="Select all controls, grouped">
+        <x:expect label="Control selected from XML remote resource, ignoring JSON resource">
             <profile>
                 <selection uuid="..." opr:src="...">
                     <metadata>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/select-rlink.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/select-rlink.xspec
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE x:description [
-<!ENTITY filedir "../../../../../../../src/specifications/profile-resolution/profile-resolution-examples/catalogs" >
-]>
 <x:description xmlns="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:opr="http://csrc.nist.gov/ns/oscal/profile-resolution"
+    xmlns:ov="http://csrc.nist.gov/ns/oscal/test/variable"
     xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     stylesheet="../../oscal-profile-resolve-select.xsl">
+    
+    <!-- Location of sample files, relative to compiled test in xspec/ subdirectory -->
+    <x:variable name="ov:filedir" as="xs:string" select="resolve-uri('../../../../../../specifications/profile-resolution/profile-resolution-examples')"/>
+
     <x:scenario label="Direct import by file href">
         <x:context>
             <profile>
-                <import href="&filedir;/xyz-tiny_catalog.xml">
+                <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
                     <include-controls>
                         <with-id>z3</with-id>
                     </include-controls>
@@ -50,7 +53,7 @@
                 <back-matter>
                     <resource uuid="6e57d296-39c1-4e83-8107-4dcc2ede751b">
                         <title>Tiny Catalog</title>
-                        <rlink href="&filedir;/xyz-tiny_catalog.xml"/>
+                        <rlink href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml"/>
                     </resource>
                 </back-matter>
             </profile>
@@ -95,8 +98,8 @@
                 <back-matter>
                     <resource uuid="6e57d296-39c1-4e83-8107-4dcc2ede751b">
                         <title>Tiny Catalog</title>
-                        <rlink href="&filedir;/xyz-tiny_catalog.xml"/>
-                        <rlink href="&filedir;/xyz-tiny_catalog.json"/>
+                        <rlink href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml"/>
+                        <rlink href="{$ov:filedir}/catalogs/xyz-tiny_catalog.json"/>
                     </resource>
                 </back-matter>
             </profile>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/select.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/select.xspec
@@ -1,367 +1,1446 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE x:description [
-<!ENTITY filedir "file:/C:/Users/wap1/Documents/usnistgov/OSCAL/src/specifications/profile-resolution/profile-resolution-examples/catalogs" >
-]>
 <x:description xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+    xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:opr="http://csrc.nist.gov/ns/oscal/profile-resolution"
+    xmlns:ov="http://csrc.nist.gov/ns/oscal/test/variable"
     xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    stylesheet="../../oscal-profile-resolve-select.xsl">
-    <x:scenario label="Profile root">
-        <x:context>
-            <profile/>
-        </x:context>
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    stylesheet="../../oscal-profile-resolve-select.xsl"
+    xslt-version="3.0">
 
-        <x:expect label="root becomes root">
-            <profile/>
-        </x:expect>
-    </x:scenario>
-    <x:scenario label="Profile select empty import">
-        <x:context>
-            <profile>
-                <import href="&filedir;/xyz-tiny_catalog.xml"/>
-            </profile>
-        </x:context>
+    <!-- Location of sample files, relative to compiled test in xspec/ subdirectory -->
+    <x:variable name="ov:filedir" as="xs:string" select="resolve-uri('../../../../../../specifications/profile-resolution/profile-resolution-examples')"/>
 
-        <x:expect label="Select no controls">
-            <profile>
-                <selection uuid="..." opr:src="...">
-                    <metadata>
-                        <title>XYZ Tiny Catalog</title>
-                        <last-modified>2020-05-30T14:51:42.355-04:00</last-modified>
-                        <version>1.0</version>
-                        <oscal-version>1.0.0-rc2</oscal-version>
-                    </metadata>
-                    <group opr:id="160a974c-2aaf-45cd-b504-44bb86bebada#d19e10">
-                        <title>Group X of XYZ</title>
-                    </group>
-                    <group opr:id="160a974c-2aaf-45cd-b504-44bb86bebada#d19e18">
-                        <title>Group Y of XYZ</title>
-                    </group>
-                    <group opr:id="160a974c-2aaf-45cd-b504-44bb86bebada#d19e26">
-                        <title>Group Z of XYZ</title>
-                    </group>
-                </selection>
-            </profile>
-        </x:expect>
+    <x:variable name="ov:unique" as="function(*)"
+        select="function($seq as xs:string*) as xs:boolean {
+        count($seq) = count(distinct-values($seq))
+        }"/>
+
+    <x:variable name="ov:catalog-selection-structure" as="element(o:selection)">
+        <selection opr:src="..." uuid="...">
+            <metadata>...</metadata>
+            <group opr:id="...">...</group>
+            <group opr:id="...">...</group>
+            <group opr:id="...">...</group>
+        </selection>
+    </x:variable>
+
+    <x:scenario label="Tests for match='* | @*' template for all modes">
+        <x:variable name="ov:arbitrary-element" as="element(arbitrary-element)">
+            <arbitrary-element xmlns="" arbitrary-attribute="val">text<child/></arbitrary-element>
+        </x:variable>
+        <x:scenario label="Element">
+            <x:context select="$ov:arbitrary-element"/>
+            <x:expect label="Copy" select="$ov:arbitrary-element"/>
+        </x:scenario>
+        <x:scenario label="Attribute">
+            <x:context select="$ov:arbitrary-element/@arbitrary-attribute"/>
+            <x:expect label="Copy"
+                test="$x:result instance of attribute(arbitrary-attribute) and $x:result/string()='val'"/>
+        </x:scenario>
     </x:scenario>
-    <x:scenario label="Profile select include all">
-        <x:context>
-            <profile>
-                <import href="&filedir;/xyz-tiny_catalog.xml">
-                    <include-all/>
-                </import>
-            </profile>
-        </x:context>
-        <x:expect label="Select all controls, grouped">
-            <profile>
-                <selection uuid="..." opr:src="...">
-                    <metadata>
-                        <title>XYZ Tiny Catalog</title>
-                        <last-modified>2020-05-30T14:51:42.355-04:00</last-modified>
-                        <version>1.0</version>
-                        <oscal-version>1.0.0-rc2</oscal-version>
-                    </metadata>
-                    <group opr:id="...">
-                        <title>Group X of XYZ</title>
-                        <control id="x1" opr:id="..."><title>Control X1</title></control>
-                        <control id="x2" opr:id="..."><title>Control X2</title></control>
-                        <control id="x3" opr:id="..."><title>Control X3</title></control>
-                    </group>
-                    <group opr:id="...">
-                        <title>Group Y of XYZ</title>
-                        <control id="y1" opr:id="..."><title>Control Y1</title></control>
-                        <control id="y2" opr:id="..."><title>Control Y2</title></control>
-                        <control id="y3" opr:id="..."><title>Control Y3</title></control>
-                    </group>
-                    <group opr:id="...">
-                        <title>Group Z of XYZ</title>
-                        <control id="z1" opr:id="..."><title>Control Z1</title></control>
-                        <control id="z2" opr:id="..."><title>Control Z2</title></control>
-                        <control id="z3" opr:id="..."><title>Control Z3</title>
-                            <control id="z3.a" opr:id="..."><title>Control Z3-A</title>
-                                <control id="z3.a-1" opr:id="..."><title>Control Z3-A-1</title></control>
+
+    <x:scenario label="Tests for match='comment() | processing-instruction()' template for all modes">
+        <x:scenario label="Comment">
+            <x:context><!--comment--></x:context>
+            <x:expect label="Nothing" select="()"/>
+        </x:scenario>
+        <x:scenario label="Processing instruction">
+            <x:context><?pi type="sample" href="file.css"?></x:context>
+            <x:expect label="Nothing" select="()"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for match='profile' template">
+        <x:scenario label="Profile root">
+            <x:context>
+                <profile/>
+            </x:context>
+    
+            <x:expect label="root becomes root">
+                <profile/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Profile select empty import">
+            <x:context>
+                <profile>
+                    <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml"/>
+                </profile>
+            </x:context>
+    
+            <x:expect label="Include group structure but select no controls">
+                <profile>
+                    <selection uuid="..." opr:src="...">
+                        <metadata>
+                            <title>XYZ Tiny Catalog</title>
+                            <last-modified>2020-05-30T14:51:42.355-04:00</last-modified>
+                            <version>1.0</version>
+                            <oscal-version>1.0.0-rc2</oscal-version>
+                        </metadata>
+                        <group opr:id="...">
+                            <title>Group X of XYZ</title>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group Y of XYZ</title>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group Z of XYZ</title>
+                        </group>
+                    </selection>
+                </profile>
+            </x:expect>
+            <x:expect label="opr:id values are unique"
+                test="$x:result//*/@opr:id => $ov:unique()"/>
+            <!-- If the pattern of opr:id values isn't worth testing, then delete the next
+                variables and assertions. Similar in "Profile select include all" scenario.--> 
+            <x:variable name="ov:group_id" as="attribute()+" select="$x:result//o:group/@opr:id"/>
+            <x:variable name="ov:catalog_uuid" as="xs:string" select="doc($ov:filedir || '/catalogs/xyz-tiny_catalog.xml')/o:catalog/@uuid"/>
+            <x:expect label="Each group has opr:id whose substring before # matches the selection uuid,"
+                test="every $id in $ov:group_id satisfies starts-with($id, $id/ancestor::o:selection/@uuid || '#')"/>
+            <x:expect label="which matches the original catalog's top-level uuid."
+                test="$x:result/o:selection/@uuid = $ov:catalog_uuid"/>
+        </x:scenario>
+        <x:scenario label="Error case: Profile cannot find catalog" catch="yes">
+            <x:context>
+                <profile>
+                    <import href="nonexistent_catalog.xml"/>
+                </profile>
+            </x:context>
+            <x:expect label="Fatal XSLT error"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+        </x:scenario>
+        <x:scenario label="Profile select include all">
+            <x:context>
+                <profile>
+                    <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                        <include-all/>
+                    </import>
+                </profile>
+            </x:context>
+            <x:expect label="Select all controls, grouped">
+                <profile>
+                    <selection uuid="..." opr:src="...">
+                        <metadata>...</metadata>
+                        <group opr:id="...">
+                            <title>Group X of XYZ</title>
+                            <control id="x1" opr:id="..."><title>Control X1</title></control>
+                            <control id="x2" opr:id="..."><title>Control X2</title></control>
+                            <control id="x3" opr:id="..."><title>Control X3</title></control>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group Y of XYZ</title>
+                            <control id="y1" opr:id="..."><title>Control Y1</title></control>
+                            <control id="y2" opr:id="..."><title>Control Y2</title></control>
+                            <control id="y3" opr:id="..."><title>Control Y3</title></control>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group Z of XYZ</title>
+                            <control id="z1" opr:id="..."><title>Control Z1</title></control>
+                            <control id="z2" opr:id="..."><title>Control Z2</title></control>
+                            <control id="z3" opr:id="..."><title>Control Z3</title>
+                                <control id="z3.a" opr:id="..."><title>Control Z3-A</title>
+                                    <control id="z3.a-1" opr:id="..."><title>Control Z3-A-1</title></control>
+                                </control>
                             </control>
-                        </control>
-                    </group>
-                </selection>
-            </profile>
-        </x:expect>
-    </x:scenario>
-    <x:scenario label="Profile select include call control-id">
-        <x:context>
-            <profile>
-                <import href="&filedir;/xyz-tiny_catalog.xml">
-                    <include-controls>
-                        <with-id>x1</with-id>
-                    </include-controls>
-                </import>
-            </profile>
-        </x:context>
-
-        <x:expect label="Control x1, in its group, with other groups empty">
-            <profile>
-                <selection uuid="..." opr:src="...">
-                    <metadata>
-                        <title>XYZ Tiny Catalog</title>
-                        <last-modified>2020-05-30T14:51:42.355-04:00</last-modified>
-                        <version>1.0</version>
-                        <oscal-version>1.0.0-rc2</oscal-version>
-                    </metadata>
-                    <group opr:id="...">
+                        </group>
+                    </selection>
+                </profile>
+            </x:expect>
+            <x:expect label="opr:id values are unique"
+                test="$x:result//*/@opr:id => $ov:unique()"/>
+            <x:variable name="ov:control_id" as="attribute()+" select="$x:result//o:control/@opr:id"/>
+            <x:variable name="ov:catalog_uuid" as="xs:string" select="doc($ov:filedir || '/catalogs/xyz-tiny_catalog.xml')/o:catalog/@uuid"/>
+            <x:expect label="Each control has opr:id whose substring before # matches the selection uuid,"
+                test="every $id in $ov:control_id satisfies starts-with($id, $id/ancestor::o:selection/@uuid || '#')"/>
+            <x:expect label="which matches the original catalog's top-level uuid."
+                test="$x:result/o:selection/@uuid = $ov:catalog_uuid"/>
+        </x:scenario>
+        <x:scenario label="Profile select include call control-id">
+            <x:context>
+                <profile>
+                    <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                        <include-controls>
+                            <with-id>x1</with-id>
+                        </include-controls>
+                    </import>
+                </profile>
+            </x:context>
+    
+            <x:expect label="Control x1, in its group, with other groups empty">
+                <profile>
+                    <selection uuid="..." opr:src="...">
+                        <metadata>...</metadata>
+                        <group opr:id="...">
                             <title>Group X of XYZ</title>
                             <control id="x1" opr:id="..."><title>Control X1</title></control>
                         </group>
                        <group opr:id="..."><title>Group Y of XYZ</title></group>
                        <group opr:id="..."><title>Group Z of XYZ</title></group>
                    </selection>
-            </profile>
-        </x:expect>
-    </x:scenario>
-
-    <x:scenario label="Profile select include call match">
-        <x:context>
-            <profile>
-                <import href="&filedir;/xyz-tiny_catalog.xml">
-                    <include-controls>
-                        <!-- any x control -->
-                        <matching pattern="x*"/>
-                    </include-controls>
-                </import>
-            </profile>
-        </x:context>
-
-        <x:expect label="The x controls, matched as such">
-            <profile>
-                <selection uuid="..." opr:src="...">
-                    <metadata>
-                        <title>XYZ Tiny Catalog</title>
-                        <last-modified>2020-05-30T14:51:42.355-04:00</last-modified>
-                        <version>1.0</version>
-                        <oscal-version>1.0.0-rc2</oscal-version>
-                    </metadata>
-                    <group opr:id="...">
-                        <title>Group X of XYZ</title>
-                        <control id="x1" opr:id="..."><title>Control X1</title></control>
-                        <control id="x2" opr:id="..."><title>Control X2</title></control>
-                        <control id="x3" opr:id="..."><title>Control X3</title></control>
-                    </group>
-                    <group opr:id="..."><title>Group Y of XYZ</title></group>
-                    <group opr:id="..."><title>Group Z of XYZ</title></group>
-                </selection>
-            </profile>
-        </x:expect>
-    </x:scenario>
-
-    <x:scenario label="Profile implicit select all, excluding x1 y1 z1">
-        <x:context>
-            <profile>
-                <import href="&filedir;/xyz-tiny_catalog.xml">
-                    <include-all/>
-                    <exclude-controls>
-                        <with-id>x1</with-id>
-                        <with-id>y1</with-id>
-                        <with-id>z1</with-id>
-                    </exclude-controls>
-                </import>
-            </profile>
-        </x:context>
-
-        <x:expect label="All controls but x1,y1,z1, grouped">
-            <profile>
-                <selection uuid="..." opr:src="...">
-                    <metadata>
-                        <title>XYZ Tiny Catalog</title>
-                        <last-modified>2020-05-30T14:51:42.355-04:00</last-modified>
-                        <version>1.0</version>
-                        <oscal-version>1.0.0-rc2</oscal-version>
-                    </metadata>
-                    <group opr:id="...">
-                        <title>Group X of XYZ</title>
-                        <control id="x2" opr:id="..."><title>Control X2</title></control>
-                        <control id="x3" opr:id="..."><title>Control X3</title></control>
-                    </group>
-                    <group opr:id="...">
-                        <title>Group Y of XYZ</title>
-                        <control id="y2" opr:id="..."><title>Control Y2</title></control>
-                        <control id="y3" opr:id="..."><title>Control Y3</title></control>
-                    </group>
-                    <group opr:id="...">
-                        <title>Group Z of XYZ</title>
-                        <control id="z2" opr:id="..."><title>Control Z2</title></control>
-                        <control id="z3" opr:id="..."><title>Control Z3</title>
-                            <control id="z3.a" opr:id="..."><title>Control Z3-A</title>
-                                <control id="z3.a-1" opr:id="..."><title>Control Z3-A-1</title></control>
+                </profile>
+            </x:expect>
+        </x:scenario>
+    
+        <x:scenario label="Profile select include call match">
+            <x:context>
+                <profile>
+                    <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                        <include-controls>
+                            <!-- any x control -->
+                            <matching pattern="x*"/>
+                        </include-controls>
+                    </import>
+                </profile>
+            </x:context>
+    
+            <x:expect label="The x controls, matched as such">
+                <profile>
+                    <selection uuid="..." opr:src="...">
+                        <metadata>...</metadata>
+                        <group opr:id="...">
+                            <title>Group X of XYZ</title>
+                            <control id="x1" opr:id="..."><title>Control X1</title></control>
+                            <control id="x2" opr:id="..."><title>Control X2</title></control>
+                            <control id="x3" opr:id="..."><title>Control X3</title></control>
+                        </group>
+                        <group opr:id="..."><title>Group Y of XYZ</title></group>
+                        <group opr:id="..."><title>Group Z of XYZ</title></group>
+                    </selection>
+                </profile>
+            </x:expect>
+        </x:scenario>
+    
+        <x:scenario label="Profile implicit select all, excluding x1 y1 z1">
+            <x:context>
+                <profile>
+                    <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                        <include-all/>
+                        <exclude-controls>
+                            <with-id>x1</with-id>
+                            <with-id>y1</with-id>
+                            <with-id>z1</with-id>
+                        </exclude-controls>
+                    </import>
+                </profile>
+            </x:context>
+    
+            <x:expect label="All controls but x1,y1,z1, grouped">
+                <profile>
+                    <selection uuid="..." opr:src="...">
+                        <metadata>...</metadata>
+                        <group opr:id="...">
+                            <title>Group X of XYZ</title>
+                            <control id="x2" opr:id="..."><title>Control X2</title></control>
+                            <control id="x3" opr:id="..."><title>Control X3</title></control>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group Y of XYZ</title>
+                            <control id="y2" opr:id="..."><title>Control Y2</title></control>
+                            <control id="y3" opr:id="..."><title>Control Y3</title></control>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group Z of XYZ</title>
+                            <control id="z2" opr:id="..."><title>Control Z2</title></control>
+                            <control id="z3" opr:id="..."><title>Control Z3</title>
+                                <control id="z3.a" opr:id="..."><title>Control Z3-A</title>
+                                    <control id="z3.a-1" opr:id="..."><title>Control Z3-A-1</title></control>
+                                </control>
                             </control>
-                        </control>
-                    </group>
-                </selection>
-            </profile>
-        </x:expect>
-    </x:scenario>
-
-    <x:scenario label="Recursive 'with-child-controls'">
-        <x:context>
-            <profile>
-                <import href="&filedir;/xyz-tiny_catalog.xml">
-                    <include-controls with-child-controls="yes">
-                        <with-id>z3</with-id>
-                    </include-controls>
-                </import>
-            </profile>
-        </x:context>
-
-        <x:expect label="Only the Z3 control, with all control descendants">
-            <profile>
-                <selection uuid="..." opr:src="...">
-                    <metadata>
-                        <title>XYZ Tiny Catalog</title>
-                        <last-modified>2020-05-30T14:51:42.355-04:00</last-modified>
-                        <version>1.0</version>
-                        <oscal-version>1.0.0-rc2</oscal-version>
-                    </metadata>
-                    <group opr:id="...">
-                        <title>Group X of XYZ</title>
-                    </group>
-                    <group opr:id="...">
-                        <title>Group Y of XYZ</title>
-                    </group>
-                    <group opr:id="...">
-                        <title>Group Z of XYZ</title>
-                        <control id="z3" opr:id="..."><title>Control Z3</title>
-                            <control id="z3.a" opr:id="..."><title>Control Z3-A</title>
-                                <control id="z3.a-1" opr:id="..."><title>Control Z3-A-1</title></control>
+                        </group>
+                    </selection>
+                </profile>
+            </x:expect>
+        </x:scenario>
+    
+        <x:scenario label="Recursive 'with-child-controls'">
+            <x:context>
+                <profile>
+                    <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                        <include-controls with-child-controls="yes">
+                            <with-id>z3</with-id>
+                        </include-controls>
+                    </import>
+                </profile>
+            </x:context>
+    
+            <x:expect label="Only the Z3 control, with all control descendants">
+                <profile>
+                    <selection uuid="..." opr:src="...">
+                        <metadata>...</metadata>
+                        <group opr:id="...">
+                            <title>Group X of XYZ</title>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group Y of XYZ</title>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group Z of XYZ</title>
+                            <control id="z3" opr:id="..."><title>Control Z3</title>
+                                <control id="z3.a" opr:id="..."><title>Control Z3-A</title>
+                                    <control id="z3.a-1" opr:id="..."><title>Control Z3-A-1</title></control>
+                                </control>
                             </control>
-                        </control>
-                    </group>
-                </selection>
-            </profile>
-        </x:expect>
-    </x:scenario>
-
-    <x:scenario label="Doubled import, exclusive call">
-        <x:context>
-            <profile>
-                <import href="&filedir;/xyz-tiny_catalog.xml">
-                    <include-controls>
-                        <with-id>x1</with-id>
-                    </include-controls>
-                </import>
-                <import href="&filedir;/xyz-tiny_catalog.xml">
-                    <include-controls>
-                        <with-id>y1</with-id>
-                    </include-controls>
-                </import>
-            </profile>
-        </x:context>
-
-        <x:expect label="Showing two control selections">
-            <profile>
-                <selection uuid="..." opr:src="...">
-                    <metadata>
-                        <title>XYZ Tiny Catalog</title>
-                        <last-modified>2020-05-30T14:51:42.355-04:00</last-modified>
-                        <version>1.0</version>
-                        <oscal-version>1.0.0-rc2</oscal-version>
-                    </metadata>
-                    <group opr:id="...">
-                        <title>Group X of XYZ</title>
-                        <control id="x1" opr:id="..."><title>Control X1</title></control>
-                    </group>
-                    <group opr:id="..."><title>Group Y of XYZ</title></group>
-                    <group opr:id="..."><title>Group Z of XYZ</title></group>
-                </selection>
-                <selection uuid="..." opr:src="...">
-                    <metadata>
-                        <title>XYZ Tiny Catalog</title>
-                        <last-modified>2020-05-30T14:51:42.355-04:00</last-modified>
-                        <version>1.0</version>
-                        <oscal-version>1.0.0-rc2</oscal-version>
-                    </metadata>
-                    <group opr:id="...">
-                        <title>Group X of XYZ</title>
-                    </group>
-                    <group opr:id="...">
-                        <title>Group Y of XYZ</title>
-                        <control id="y1" opr:id="..."><title>Control Y1</title></control>
-                    </group>
-                    <group opr:id="..."><title>Group Z of XYZ</title></group>
-                </selection>
-            </profile>
-        </x:expect>
-    </x:scenario>
-
-    <x:scenario label="Loose parameters">
-        <x:context>
-            <profile>
-                <import href="&filedir;/abc-full_catalog.xml">
-                    <include-controls>
-                        <with-id>a1</with-id>
-                        <with-id>b1</with-id>
-                    </include-controls>
-                </import>
-            </profile>
-        </x:context>
-
-        <x:expect label="Two controls in three groups with back matter and loose parameters">
-            <profile>
-                <selection uuid="..." opr:src="...">
-                    <metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                        <title>ABC Catalog</title>
-                        <last-modified>2020-05-30T14:51:38.311-04:00</last-modified>
-                        <version>1.0</version>
-                        <oscal-version>1.0.0-rc2</oscal-version>
-                    </metadata>
-                    <group opr:id="...">
-                        <title>Group A of C</title>
-                        <param id="param-A.a" opr:id="...">
-                            <label>A.a parameter</label>
-                            <value>A.a value</value>
-                        </param>
-                        <param id="param-A.b" opr:id="...">
-                            <select>
-                                <choice>A.b parameter selection choice 1</choice>
-                                <choice>A.b parameter selection choice 2</choice>
-                                <choice>A.b parameter selection choice 3</choice>
-                            </select>
-                        </param>
-                        <control id="a1" opr:id="...">
-                            <title>Control A1</title>
-                            <param id="param-a1.a" opr:id="...">
-                                <label>a1.a parameter</label>
-                                <value>a1.a value</value>
+                        </group>
+                    </selection>
+                </profile>
+            </x:expect>
+        </x:scenario>
+    
+        <x:scenario label="Doubled import, exclusive call">
+            <x:context>
+                <profile>
+                    <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                        <include-controls>
+                            <with-id>x1</with-id>
+                        </include-controls>
+                    </import>
+                    <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
+                        <include-controls>
+                            <with-id>y1</with-id>
+                        </include-controls>
+                    </import>
+                </profile>
+            </x:context>
+    
+            <x:expect label="Showing two control selections">
+                <profile>
+                    <selection uuid="..." opr:src="...">
+                        <metadata>...</metadata>
+                        <group opr:id="...">
+                            <title>Group X of XYZ</title>
+                            <control id="x1" opr:id="..."><title>Control X1</title></control>
+                        </group>
+                        <group opr:id="..."><title>Group Y of XYZ</title></group>
+                        <group opr:id="..."><title>Group Z of XYZ</title></group>
+                    </selection>
+                    <selection uuid="..." opr:src="...">
+                        <metadata>...</metadata>
+                        <group opr:id="...">
+                            <title>Group X of XYZ</title>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group Y of XYZ</title>
+                            <control id="y1" opr:id="..."><title>Control Y1</title></control>
+                        </group>
+                        <group opr:id="..."><title>Group Z of XYZ</title></group>
+                    </selection>
+                </profile>
+            </x:expect>
+            <x:expect label="In this implementation, the doubled import makes the group IDs non-unique"
+                test="$x:result//o:group/@opr:id => $ov:unique() => not()"/>
+            <x:expect label="In this implementation, the doubled import makes the selection UUIDs non-unique"
+                test="$x:result//o:selection/@uuid => $ov:unique() => not()"/>
+            <x:expect label="Within each selection, opr:id values are unique"
+                test="every $sel in $x:result//o:selection satisfies $sel//*/@opr:id => $ov:unique()"/>
+        </x:scenario>
+    
+        <x:scenario label="Loose parameters">
+            <x:context>
+                <profile>
+                    <import href="{$ov:filedir}/catalogs/abc-full_catalog.xml">
+                        <include-controls>
+                            <with-id>a1</with-id>
+                            <with-id>b1</with-id>
+                        </include-controls>
+                    </import>
+                </profile>
+            </x:context>
+    
+            <x:expect label="Two controls in three groups with back matter and loose parameters">
+                <profile>
+                    <selection uuid="..." opr:src="...">
+                        <metadata>...</metadata>
+                        <group opr:id="...">
+                            <title>Group A of C</title>
+                            <param id="param-A.a" opr:id="...">
+                                <label>A.a parameter</label>
+                                <value>A.a value</value>
                             </param>
-                            <prop name="place" value="1st"/>
-                            <part name="statement" id="a1-stmt">
-                                <p>A1 aaaaa aaaaaaaaaa</p>
-                                <p>Parameter A.a is set: <insert type="param" id-ref="param-A.a"/>...</p>
-                                <p>Parameter a1.a is set: <insert type="param" id-ref="param-a1.a"/>...</p>
-                                <p>Also, we <a href="#citation">refer to a citation</a>.</p>
-                            </part>
-                        </control>
-                    </group>
-                    <group opr:id="...">
-                        <title>Group B of C</title>
-                        <control id="b1" opr:id="...">
-                            <title>Control B1</title>
-                            <prop name="place" value="4th"/>
-                            <part name="statement" id="b1-stmt">
-                                <p>B1 bbbb bbbbbbb.</p>
-                            </part>
-                        </control>
-                    </group>
-                    <group opr:id="...">
-                        <title>Group C of C</title>
-                    </group>
-                    <back-matter>
-                        <resource uuid="...">
-                            <citation>
-                                <text>A citation to an out of line document.</text>
-                            </citation>
-                        </resource>
-                    </back-matter>
-                </selection>
-            </profile>
+                            <param id="param-A.b" opr:id="...">
+                                <select>
+                                    <choice>A.b parameter selection choice 1</choice>
+                                    <choice>A.b parameter selection choice 2</choice>
+                                    <choice>A.b parameter selection choice 3</choice>
+                                </select>
+                            </param>
+                            <control id="a1" opr:id="...">
+                                <title>Control A1</title>
+                                <param id="param-a1.a" opr:id="...">
+                                    <label>a1.a parameter</label>
+                                    <value>a1.a value</value>
+                                </param>
+                                <prop name="label" value="1st"/>
+                                <part name="statement" id="a1-stmt">
+                                    <p>A1 aaaaa aaaaaaaaaa</p>
+                                    <p>Parameter A.a is set: <insert type="param" id-ref="param-A.a"/></p>
+                                    <p>Parameter a1.a is set: <insert type="param" id-ref="param-a1.a"/></p>
+                                </part>
+                            </control>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group B of C</title>
+                            <control id="b1" opr:id="...">
+                                <title>Control B1</title>
+                                <prop name="label" value="4th"/>
+                                <part name="statement" id="b1-stmt">
+                                    <p>B1 bbbb bbbbbbb.</p>
+                                </part>
+                            </control>
+                        </group>
+                        <group opr:id="...">
+                            <title>Group C of C</title>
+                        </group>
+                        <back-matter>
+                            <resource uuid="...">
+                                <citation>
+                                    <text>A citation to an out of line document.</text>
+                                </citation>
+                            </resource>
+                            <resource uuid="...">
+                                <citation>
+                                    <text>A citation to an out of line document.</text>
+                                </citation>
+                            </resource>
+                            <resource uuid="...">
+                                <prop name="keep" value="always"/>
+                                <citation>
+                                    <text>A citation to an out of line document.</text>
+                                </citation>
+                            </resource>
+                        </back-matter>
+                    </selection>
+                </profile>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for match='profile' mode='o:select' template">
+        <!-- Tests for this template are incomplete. When it is decided whether to keep this
+            approach, we can add more test scenarios.-->
+        <x:scenario label="Profile that calls itself" catch="yes" pending="Returns nothing now">
+            <x:context mode="o:select" select="doc($ov:filedir || '/base-test_profile.xml')/o:profile">
+                <x:param name="uri-stack" tunnel="yes"
+                    select="xs:anyURI($ov:filedir || '/base-test_profile.xml')"/>
+            </x:context>
+            <x:expect label="Fatal XSLT error due to circular reference"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+        </x:scenario>
+        <x:scenario label="Profile that calls a distinct profile"
+            pending="Not implemented yet; revisit later">
+            <x:context mode="o:select" select="doc($ov:filedir || '/base2-test_profile.xml')/o:profile">
+                <x:param name="uri-stack" tunnel="yes"
+                    select="xs:anyURI($ov:filedir || '/base-test_profile.xml')"/>
+            </x:context>
+            <x:expect label="Catalog">
+                <catalog uuid="...">...</catalog>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for match='catalog' mode='o:select' template">
+        <x:scenario label="Catalog document">
+            <x:context mode="o:select" select="doc($ov:filedir || '/catalogs/xyz-tiny_catalog.xml')//o:catalog">
+                <x:param name="import-instruction" tunnel="yes">
+                    <import/>
+                </x:param>
+            </x:context>
+            <x:expect label="Selection from catalog"
+                select="$ov:catalog-selection-structure"/>
+        </x:scenario>
+        <x:scenario label="Catalog with attributes from various namespaces">
+            <x:context mode="o:select">
+                <o:catalog uuid="val" y:attr1="val1" z:attr2="val2" xmlns:y="some-ns" xmlns:z="http://www.w3.org/2001/XMLSchema-instance"/>
+            </x:context>
+            <x:expect label="Attributes other than from XMLSchema-instance namespace get copied">
+                <selection opr:src="..." uuid="val" y:attr1="val1" xmlns:y="some-ns"/>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for match='import[starts-with(@href,'#')]' mode='o:select' template">
+        <x:scenario label="import element matches resource element">
+            <x:context mode="o:select" select="(doc($ov:filedir || '/base2-test_profile.xml')//o:import)[1]"/>
+            <x:expect label="Selection from linked catalog"
+                select="$ov:catalog-selection-structure"/>
+        </x:scenario>
+        <x:scenario label="import element matches multiple resource elements">
+            <x:context mode="o:select" href="resource-media-type.xml"
+                select="(//o:import)[1]"/>
+            <x:expect label="One selection from linked catalog, per matching resource element">
+                <selection opr:src="..." uuid="xmlcat">...</selection>
+                <selection opr:src="..." uuid="xmlcat">...</selection>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="import element does not match resource element">
+            <!-- QUESTION: Is the behavior correct? https://github.com/usnistgov/OSCAL/issues/1079 -->
+            <x:context mode="o:select">
+                <import href="#nonexistent"/>
+            </x:context>
+            <x:expect label="Nothing" select="()"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for match='resource' mode='o:import' template">
+        <x:scenario label="Select rlink by href alone">
+            <x:context mode="o:import" select="(doc($ov:filedir || '/base2-test_profile.xml')//o:resource)[1]">
+                <x:param name="import-instruction" tunnel="yes">
+                    <import/>
+                </x:param>
+            </x:context>
+            <!-- Above, $import-instruction tunnel param is required by dowstream template. -->
+            <x:expect label="Selection from linked catalog"
+                select="$ov:catalog-selection-structure"/>
+        </x:scenario>
+        <x:scenario label="Select rlink by media-type attribute">
+            <x:context mode="o:import" href="resource-media-type.xml"
+                select="(//o:resource)[1]"/>
+            <x:expect label="Selection from linked catalog">
+                <selection opr:src="..." uuid="...">...</selection>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Multiple viable rlink children">
+            <x:context mode="o:import" href="resource-multiple-rlinks.xml"
+                select="(//o:resource)[1]"/>
+            <x:expect label="Selection based on first viable rlink">
+                <selection opr:src="..." uuid="xmlcat">...</selection>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Error case: No rlink child with suitable href or media-type" catch="yes">
+            <x:context mode="o:import">
+                <resource uuid="foo">
+                    <rlink href="foo.json"/>
+                </resource>
+            </x:context>
+            <x:variable name="ov:expected_error" as="xs:string">Document not acquired for resource with uuid foo: No rlink with media-type='xml' or href ending with '.xml'</x:variable>
+            <x:expect label="Fatal XSLT error"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+            <!-- The next assertion requires a newer XSpec version; passes in Oxygen v24, fails in Oxygen v22.1 -->
+            <x:expect label="with message specific to situation"
+                test="$x:result('err')('value')/string()"
+                select="$ov:expected_error"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for match='import' mode='o:select' template">
+        <x:scenario label="Resource is available">
+            <x:context mode="o:select"
+                select="(doc($ov:filedir || '/base-test_profile.xml')//o:import)[1]"/>
+            <x:expect label="Selection from imported catalog"
+                select="$ov:catalog-selection-structure"/>
+        </x:scenario>
+        <x:scenario label="Error case: Resource is not available" catch="yes">
+            <x:context mode="o:select"
+                select="(doc($ov:filedir || '/broken_profile.xml')//o:import)[1]"/>
+            <x:expect label="Fatal XSLT error"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+        </x:scenario>
+        <x:scenario label="Error case: Resource reference is circular" catch="yes" pending="XSLT needs to catch up to spec">
+            <x:context mode="o:select"
+                select="(doc($ov:filedir || '/circular_profile.xml')//o:import)[1]"/>
+            <x:expect label="Fatal XSLT error"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+        </x:scenario>
+        <x:scenario label="Error case: href is not castable as xs:anyURI" catch="yes">
+            <x:context mode="o:select"><import/></x:context>
+            <x:expect label="Fatal XSLT error"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for match='group' mode='o:select' template">
+        <x:context mode="o:select" select="//o:group">
+            <catalog uuid="catalog-uuid">
+               <group attr="val">
+                   <title>Group X of XYZ</title>
+               </group>
+            </catalog>
+        </x:context>
+        <x:expect label="Copy of element with opr:id inserted">
+            <group attr="val" opr:id="...">
+                <title>Group X of XYZ</title>
+            </group>
         </x:expect>
     </x:scenario>
 
+    <x:scenario label="Tests for add-process-id template">
+        <x:scenario label="Context element has id">
+            <x:context select="//o:control">
+                <catalog uuid="catalog-uuid">
+                    <control id="control-id"/>
+                </catalog>
+            </x:context>
+            <x:call template="add-process-id"/>
+            <x:expect label="opr:id attribute"
+                test="$x:result instance of attribute(opr:id)"/>
+            <x:expect label="whose value is hash-separated join of catalog uuid and context id"
+                test="$x:result/string()" select="'catalog-uuid#control-id'"/>
+        </x:scenario>
+        <x:scenario label="Context element lacks id">
+            <x:context select="//o:control">
+                <catalog uuid="catalog-uuid">
+                    <control/>
+                </catalog>
+            </x:context>
+            <x:call template="add-process-id"/>
+            <x:expect label="opr:id attribute"
+                test="$x:result instance of attribute(opr:id)"/>
+            <x:expect label="whose value is hash-separated join of catalog uuid and a generated id"
+                test="matches($x:result/string(), 'catalog-uuid#.+')"/>
+        </x:scenario>
+    </x:scenario>
+    
+    <x:scenario label="Tests for opr:catalog-identifier function">
+        <x:scenario label="Catalog has uuid">
+            <x:call function="opr:catalog-identifier">
+                <x:param>
+                    <catalog uuid="abc"/>
+                </x:param>
+            </x:call>
+            <x:expect label="Returns uuid" select="'abc'"/>
+        </x:scenario>
+        <x:scenario label="Catalog lacks uuid">
+            <x:call function="opr:catalog-identifier">
+                <x:param href="catalog-no-uuid.xml" select="/o:catalog"/>
+            </x:call>
+            <x:expect label="Returns document URI of catalog" test="ends-with($x:result,'/catalog-no-uuid.xml')"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for match='control' mode='o:select' template">
+        <x:scenario label="Control is selected">
+            <!--Below, $import-instruction is an <import> element that
+                selects the control with id="a1" and the context node
+                has id="a1". -->
+            <x:context mode="o:select"
+                select="doc($ov:filedir || '/catalogs/abc-simple_catalog.xml')//o:control[@id='a1']">
+                <x:param name="import-instruction" tunnel="yes"
+                    select="(doc($ov:filedir || '/base2-test_profile.xml')//o:import)[1]"/>
+            </x:context>
+            <x:expect label="Copy of control element with opr:id inserted">
+                <control id="a1" opr:id="...">...</control>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Control is not selected">
+            <x:context mode="o:select">
+                <x:param name="import-instruction" tunnel="yes">
+                    <import/>
+                </x:param>
+                <control id="x1"/>
+            </x:context>
+            <x:expect label="Nothing" select="()"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for match='param' mode='o:select' template">
+        <x:context mode="o:select" select="//o:param">
+            <catalog uuid="catalog-uuid">
+                <!--Skip metadata because not relevant for this scenario.-->
+                <control id="a1">
+                    <title>Control A1</title>
+                    <param id="a1_prm1">
+                        <label>A1 Parameter 1</label>
+                    </param>
+                </control>
+            </catalog>
+        </x:context>
+        <x:expect label="Copy of param element with opr:id inserted">
+            <param id="a1_prm1" opr:id="...">
+                <label>A1 Parameter 1</label>
+            </param>
+        </x:expect>
+    </x:scenario>
+
+    <x:scenario label="Tests for o:selects function">
+        <x:variable name="ov:control-hierarchy" as="element(o:control)">
+            <control id="level-one">
+                <control id="level-two">
+                    <control id="level-three">
+                        <control id="level-four"/>
+                    </control>
+                </control>
+            </control>
+        </x:variable>
+        <x:scenario label="Test each include reason, with no exclude reasons. ">
+            <x:scenario label="Include all.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control/>
+                    </x:param>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Include all, omit with-child-controls, and candidate is descendant.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Select by ID.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <with-id>abc</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id="abc"/>
+                    </x:param>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Select by ID, but candidate does not match.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <with-id>abc</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id="nonmatch"/>
+                    </x:param>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Select descendant ID, omitting with-parent-controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <with-id>level-four</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="true (with-parent-controls defaults to yes)" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Select descendant ID, and explicitly include parent controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-parent-controls="yes">
+                                <with-id>level-four</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Select descendant ID and do not include parent controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-parent-controls="no">
+                                <with-id>level-four</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Select ancestor ID and include child controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-child-controls="yes">
+                                <with-id>level-two</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Select ancestor ID, omitting with-child-controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <with-id>level-two</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="false (with-child-controls defaults to no)" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Select ancestor ID and do not include child controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-child-controls="no">
+                                <with-id>level-two</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Match ID.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <matching pattern="ab*"/>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id="abc"/>
+                    </x:param>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Try to match ID, but candidate is not a match.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <matching pattern="ab*"/>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id="nonmatch"/>
+                    </x:param>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="matching object with no pattern.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <matching/>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id="abc"/>
+                    </x:param>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="matching object with empty string as pattern.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <matching pattern=""/>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id=""/>
+                    </x:param>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Match descendant ID, omitting with-parent-controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <matching pattern="*-four"/>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="true (with-parent-controls defaults to yes)" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Match descendant ID, with parent controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-parent-controls="yes">
+                                <matching pattern="*-four"/>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Match descendant ID, without parent controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-parent-controls="no">
+                                <matching pattern="*-four"/>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Match ancestor ID, omitting with-child-controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <matching pattern="*-two"/>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="false (with-child-controls defaults to no)" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Match ancestor ID, with child controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-child-controls="yes">
+                                <matching pattern="*-two"/>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Match ancestor ID, without child controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-child-controls="no">
+                                <matching pattern="*-two"/>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Include grandchild with parent controls, and include child without parent controls">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-parent-controls="yes">
+                                <with-id>level-four</with-id>
+                            </include-controls>
+                            <include-controls with-parent-controls="no">
+                                <with-id>level-three</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate"
+                        select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Include grandparent with child controls, and include parent without child controls">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-child-controls="yes">
+                                <with-id>level-two</with-id>
+                            </include-controls>
+                            <include-controls with-child-controls="no">
+                                <with-id>level-three</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate"
+                        select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="Provide an include reason, and test each exclude reason. ">
+            <x:scenario label="Include all, but explicitly not with child controls, and candidate is descendant.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all with-child-controls="no"/>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Exclude by ID.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls>
+                                <with-id>abc</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id="abc"/>
+                    </x:param>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Exclude by ID but candidate does not match.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls>
+                                <with-id>abc</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id="nonmatch"/>
+                    </x:param>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Exclude descendant ID, omitting with-parent-controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls>
+                                <with-id>level-four</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="false (with-parent-controls defaults to yes)" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Exclude descendant ID with parent controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls with-parent-controls="yes">
+                                <with-id>level-four</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Exclude descendant ID without parent controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls with-parent-controls="no">
+                                <with-id>level-four</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Exclude ancestor ID, omitting with-child-controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls>
+                                <with-id>level-two</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="true (with-child-controls defaults to no)" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Exclude ancestor ID and child controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls with-child-controls="yes">
+                                <with-id>level-two</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Exclude ancestor ID without child controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls with-child-controls="no">
+                                <with-id>level-two</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Include grandparent with child controls, and exclude parent with child controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-child-controls="yes">
+                                <with-id>level-two</with-id>
+                            </include-controls>
+                            <exclude-controls with-child-controls="yes">
+                                <with-id>level-three</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate"
+                        select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Include grandparent with child controls, and exclude parent without excluding child controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls with-child-controls="yes">
+                                <with-id>level-two</with-id>
+                            </include-controls>
+                            <exclude-controls with-child-controls="no">
+                                <with-id>level-three</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate"
+                        select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Match ID.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls>
+                                <matching pattern="ab*"/>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id="abc"/>
+                    </x:param>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Try to match ID, but candidate is not a match.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls>
+                                <matching pattern="ab*"/>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id="nonmatch"/>
+                    </x:param>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="matching object with no pattern.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls>
+                                <matching pattern=""/>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id="abc"/>
+                    </x:param>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="matching object with empty string as pattern.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls>
+                                <matching pattern=""/>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate">
+                        <control id=""/>
+                    </x:param>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Match descendant ID, omitting with-parent-controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls>
+                                <matching pattern="*-four"/>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="false (with-parent-controls defaults to yes)" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Match descendant ID, with parent controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls with-parent-controls="yes">
+                                <matching pattern="*-four"/>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Match descendant ID, without parent controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls with-parent-controls="no">
+                                <matching pattern="*-four"/>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Match ancestor ID, omitting with-child-controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls>
+                                <matching pattern="*-two"/>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="true (with-child-controls defaults to no)" select="true()"/>
+            </x:scenario>
+            <x:scenario label="Match ancestor ID, with child controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls with-child-controls="yes">
+                                <matching pattern="*-two"/>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="Match ancestor ID, without child controls.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-all/>
+                            <exclude-controls with-child-controls="no">
+                                <matching pattern="*-two"/>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="true" select="true()"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="Spot-check that having multiple include reasons is fine.">
+            <x:call function="o:selects">
+                <x:param name="importing">
+                    <import>
+                        <include-controls with-child-controls="yes">
+                            <matching pattern="*-two"/>
+                        </include-controls>
+                        <include-controls>
+                            <with-id>level-four</with-id>
+                        </include-controls>
+                    </import>
+                </x:param>
+                <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+            </x:call>
+            <x:expect label="true" select="true()"/>
+        </x:scenario>
+        <x:scenario label="Spot-check that having multiple exclude reasons is fine.">
+            <x:call function="o:selects">
+                <x:param name="importing">
+                    <import>
+                        <exclude-controls with-child-controls="yes">
+                            <matching pattern="*-two"/>
+                        </exclude-controls>
+                        <exclude-controls>
+                            <with-id>level-four</with-id>
+                        </exclude-controls>
+                    </import>
+                </x:param>
+                <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+            </x:call>
+            <x:expect label="false" select="false()"/>
+        </x:scenario>
+        <x:scenario label="Spot-check that exclude reasons override include reasons, ">
+            <x:scenario label="if exclude reason appears first.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <exclude-controls>
+                                <with-id>level-four</with-id>
+                            </exclude-controls>
+                            <include-controls>
+                                <with-id>level-four</with-id>
+                            </include-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+            <x:scenario label="if exclude reason appears second.">
+                <x:call function="o:selects">
+                    <x:param name="importing">
+                        <import>
+                            <include-controls>
+                                <with-id>level-four</with-id>
+                            </include-controls>
+                            <exclude-controls>
+                                <with-id>level-four</with-id>
+                            </exclude-controls>
+                        </import>
+                    </x:param>
+                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
+                </x:call>
+                <x:expect label="false" select="false()"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="Edge case of no import instructions">
+            <x:call function="o:selects">
+                <x:param name="importing">
+                    <import/>
+                </x:param>
+                <x:param name="candidate">
+                    <control/>
+                </x:param>
+            </x:call>
+            <x:expect label="false" select="false()"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for o:calls-children function">
+        <x:scenario label="with-child-controls attribute is 'yes'">
+            <x:call function="o:calls-children">
+                <x:param>
+                    <elem with-child-controls="yes"/>
+                </x:param>
+            </x:call>
+            <x:expect label="true" select="true()"/>
+        </x:scenario>
+        <x:scenario label="with-child-controls attribute is 'no'">
+            <x:call function="o:calls-children">
+                <x:param>
+                    <elem with-child-controls="no"/>
+                </x:param>
+            </x:call>
+            <x:expect label="false" select="false()"/>
+        </x:scenario>
+        <x:scenario label="with-child-controls attribute is omitted">
+            <x:call function="o:calls-children">
+                <x:param>
+                    <elem/>
+                </x:param>
+            </x:call>
+            <x:expect label="false" select="false()"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for o:calls-parents function">
+        <x:scenario label="with-parent-controls attribute is 'yes'">
+            <x:call function="o:calls-parents">
+                <x:param>
+                    <elem with-parent-controls="yes"/>
+                </x:param>
+            </x:call>
+            <x:expect label="true" select="true()"/>
+        </x:scenario>
+        <x:scenario label="with-parent-controls attribute is 'no'">
+            <x:call function="o:calls-parents">
+                <x:param>
+                    <elem with-parent-controls="no"/>
+                </x:param>
+            </x:call>
+            <x:expect label="false" select="false()"/>
+        </x:scenario>
+        <x:scenario label="with-parent-controls attribute is omitted">
+            <x:call function="o:calls-parents">
+                <x:param>
+                    <elem/>
+                </x:param>
+            </x:call>
+            <x:expect label="true" select="true()"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for o:resource-or-error function">
+        <x:scenario label="Document is available">
+            <x:call function="o:resource-or-error">
+                <x:param select="(doc($ov:filedir || '/base-test_profile.xml')//o:import)[1]/@href"/>
+            </x:call>
+            <x:expect label="Resolved document" test="exists($x:result/self::document-node()/o:catalog)"/>
+        </x:scenario>
+        <x:scenario label="Error case: Document is not available" catch="yes">
+            <x:call function="o:resource-or-error">
+                <x:param select="(doc($ov:filedir || '/broken_profile.xml')//o:import)[1]/@href"/>
+            </x:call>
+            <x:expect label="Fatal XSLT error"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+        </x:scenario>
+    </x:scenario>
+    
+    <x:scenario label="Tests for o:resolve-profile function" pending="incomplete">
+        <!-- Intended for the case where an profile imports another profile,
+            this function is not in use yet. For now, just test that the
+            function can run. When it is decided whether to keep this
+            approach, we can add more test scenarios. -->
+        <x:scenario label="Sanity check">
+            <x:call function="o:resolve-profile">
+                <x:param name="profile">
+                    <o:profile href="{$ov:filedir}/base-test_profile.xml"/>
+                </x:param>
+                <x:param name="uri-stack" select="xs:anyURI($ov:filedir || '/base-test_profile.xml')"/>
+            </x:call>
+            <x:expect label="Catalog">
+                <catalog uuid="...">...</catalog>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
 </x:description>

--- a/src/utils/util/resolver-pipeline/testing/2_metadata/random-util.xspec
+++ b/src/utils/util/resolver-pipeline/testing/2_metadata/random-util.xspec
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:ov="http://csrc.nist.gov/ns/oscal/xspec/variable"
+    xmlns:r="http://csrc.nist.gov/ns/random"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    stylesheet="../../random-util.xsl"
+    xslt-version="3.0">
+
+    <!-- For repeatable testing, use a fixed germ. Also, XSpec
+        cannot evaluate document-uri(/) in the default parameter
+        value from the XSLT. -->
+    <x:param name="germ">x</x:param>
+
+    <x:variable name="ov:uuid-v4-regex" as="xs:string">^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$</x:variable>
+    <x:variable name="ov:seed" as="item()" select="'x'"/>
+    <x:variable name="ov:PRNG" as="map(xs:string, item())" select="random-number-generator($ov:seed)"/>
+
+    <x:scenario label="Tests for top-level template">
+        <x:call template="xsl:initial-template"/>
+        <!-- Assertions here are minimal because r:make-uuid
+            has function-level tests below. -->
+        <x:expect label="Repeatable result for the seed, 'a'"
+            test="$x:result/a[1]/string()" select="$x:result/a[2]/string()"/>
+        <x:expect label="The 'b' uuid is different from the 'a' uuid"
+            test="not($x:result/a[1]/string() = $x:result/b/string())"/>
+    </x:scenario>
+
+    <x:scenario label="Tests for r:make-uuid function">
+        <x:call function="r:make-uuid">
+            <x:param name="seed" select="$ov:seed"/>
+        </x:call>
+        <x:expect label="Same as calling r:make-uuid-sequence with seq-length=1"
+            select="r:make-uuid-sequence($ov:seed, 1)"/>      
+    </x:scenario>
+    <x:scenario label="Tests for r:make-uuid-sequence function">
+        <x:scenario label="seq-length=1">
+            <x:variable name="ov:seq-length" as="xs:integer" select="1"/>
+            <x:call function="r:make-uuid-sequence">
+                <x:param name="seed" select="$ov:seed"/>
+                <x:param name="seq-length" select="$ov:seq-length"/>
+            </x:call>
+            <x:like label="SHARED: Check sequence of uuids"/>
+        </x:scenario>
+        <x:scenario label="seq-length=10000">
+            <x:variable name="ov:seq-length" as="xs:integer" select="10000"/>
+            <x:call function="r:make-uuid-sequence">
+                <x:param name="seed" select="$ov:seed"/>
+                <x:param name="seq-length" select="$ov:seq-length"/>
+            </x:call>
+            <x:like label="SHARED: Check sequence of uuids"/>
+            <x:expect label="Check uniqueness of strings in the sequence"
+                test="$x:result => distinct-values() => count() = $ov:seq-length"/>
+            <x:expect label="Check that 2nd uuid is not a shift of 1st uuid"
+                test="not(starts-with($x:result[2],substring($x:result[1],2,7)))"/>
+        </x:scenario>
+        <x:scenario label="seq-length=500,000" pending="To save time, run only when needed">
+            <x:variable name="ov:seq-length" as="xs:integer" select="500000"/>
+            <x:call function="r:make-uuid-sequence">
+                <x:param name="seed" select="$ov:seed"/>
+                <x:param name="seq-length" select="$ov:seq-length"/>
+            </x:call>
+            <x:like label="SHARED: Check sequence of uuids"/>
+            <x:expect label="Check uniqueness of strings in the sequence"
+                test="$x:result => distinct-values() => count() = $ov:seq-length"/>
+        </x:scenario>
+        <x:scenario label="Edge case: seq-length=0">
+            <x:call function="r:make-uuid-sequence">
+                <x:param name="seed" select="$ov:seed"/>
+                <x:param name="seq-length" as="xs:integer" select="0"/>
+            </x:call>
+            <x:expect label="Nothing" select="()"/>
+        </x:scenario>
+    </x:scenario>
+    <x:scenario label="Tests for r:make-random-string-sequence function">
+        <x:scenario label="Template starts with _">
+            <x:variable name="ov:template" select="'_xyz'"/>
+            <x:call function="r:make-random-string-sequence">
+                <x:param name="seed" select="$ov:seed"/>
+                <x:param name="seq-length" select="1"/>
+                <x:param name="template" select="$ov:template"/>
+            </x:call>
+            <x:expect label="Starts with hex digit"
+                test="matches($x:result,'^[0-9a-f]')"/>
+            <x:expect label="Same length as template"
+                test="string-length($x:result)=string-length($ov:template)"/>
+            <x:expect label="For this template, characters after the first are not hex digits"
+                test="not(matches(substring($x:result,2),'[0-9a-f]'))"/>
+        </x:scenario>
+        <x:scenario label="Template starts with =">
+            <x:variable name="ov:template" select="'=xyz'"/>
+            <x:call function="r:make-random-string-sequence">
+                <x:param name="seed" select="$ov:seed"/>
+                <x:param name="seq-length" select="1"/>
+                <x:param name="template" select="$ov:template"/>
+            </x:call>
+            <x:expect label="Starts with 8, 9, a, or b"
+                test="matches($x:result,'^[89ab]')"/>
+            <x:expect label="Same length as template"
+                test="string-length($x:result)=string-length($ov:template)"/>
+            <x:expect label="For this template, characters after the first are not 8, 9, a, or b"
+                test="not(matches(substring($x:result,2),'[89ab]'))"/>
+        </x:scenario>
+        <x:scenario label="Template is empty string">
+            <x:call function="r:make-random-string-sequence">
+                <x:param name="seed" select="$ov:seed"/>
+                <x:param name="seq-length" select="1"/>
+                <x:param name="template" select="''"/>
+            </x:call>
+            <x:expect label="Empty string" select="''"/>
+        </x:scenario>
+        <x:scenario label="Long template of repeated '_' characters">
+            <x:variable name="ov:template" select="string-join(for $j in (1 to 10000) return '_','')"/>
+            <x:variable name="ov:expected-digits" as="xs:string" select="'^[0-9a-f]+$'"/>
+            <x:call function="r:make-random-string-sequence">
+                <x:param name="seed" select="$ov:seed"/>
+                <x:param name="seq-length" select="1"/>
+                <x:param name="template" select="$ov:template"/>
+            </x:call>
+            <x:like label="SHARED: Check long output"/>
+        </x:scenario>
+        <x:scenario label="Long template of repeated '=' characters">
+            <x:variable name="ov:template" select="string-join(for $j in (1 to 10000) return '=','')"/>
+            <x:variable name="ov:expected-digits" as="xs:string" select="'^[89ab]+$'"/>
+            <x:call function="r:make-random-string-sequence">
+                <x:param name="seed" select="$ov:seed"/>
+                <x:param name="seq-length" select="1"/>
+                <x:param name="template" select="$ov:template"/>
+            </x:call>
+            <x:like label="SHARED: Check long output"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Test for '_' character with mode=uuid-char">
+        <x:context select="'_'" mode="uuid-char">
+            <x:param name="PRNG" select="$ov:PRNG"/>
+        </x:context>
+        <x:expect label="One hex digit"
+            test="matches($x:result,'^[0-9a-f]$')"/>
+        <!-- The "Long template of repeated '_' characters" scenario
+            checks that it is not the same hex digit for all PRNG inputs. -->
+    </x:scenario>
+    <x:scenario label="Test for '=' character with mode=uuid-char">
+        <x:context select="'='" mode="uuid-char">
+            <x:param name="PRNG" select="$ov:PRNG"/>
+        </x:context>
+        <x:expect label="One character 8, 9, a, or b"
+            test="matches($x:result,'^[89ab]$')"/>
+        <!-- The "Long template of repeated '=' characters" scenario
+            checks that it is not the same hex digit for all PRNG inputs. -->
+    </x:scenario>
+    <x:scenario label="Tests for characters other than '_' or '=', with mode=uuid-char">
+        <!-- These tests exercise the default template behavior for mode="uuid-char". -->
+        <x:scenario label="Empty string">
+            <x:context select="''" mode="uuid-char">
+                <x:param name="PRNG" select="$ov:PRNG"/>
+            </x:context>
+            <x:expect label="Text node with no content"
+                test="$x:result instance of text() and string-length($x:result) eq 0"/>
+        </x:scenario>
+        <x:scenario label="Hyphen">
+            <x:context select="'-'" mode="uuid-char">
+                <x:param name="PRNG" select="$ov:PRNG"/>
+            </x:context>
+            <x:expect label="Text node with hyphen">-</x:expect>
+        </x:scenario>
+        <x:scenario label="A non-ASCII character">
+            <x:variable name="ov:charnum" as="xs:integer" select="500"/>
+            <x:context select="codepoints-to-string($ov:charnum)" mode="uuid-char">
+                <x:param name="PRNG" select="random-number-generator('123')"/>
+            </x:context>
+            <x:expect label="Text node with same character"
+                expand-text="yes">{codepoints-to-string($ov:charnum)}</x:expect>
+        </x:scenario>
+    </x:scenario>
+
+    <!-- SHARED scenarios -->
+
+    <x:scenario shared="yes" label="SHARED: Check long output">
+        <!-- This set of shared assertions expects the referencing
+            scenario to have defined <x:variable name="ov:expected-digits" .../> -->
+        <x:expect label="String of digits in expected set"
+            test="matches($x:result,$ov:expected-digits)"/>
+        <x:expect label="Same length as template"
+            test="string-length($x:result) = string-length($ov:template)"/>
+        <x:variable name="ov:distinct-codepoints" as="xs:integer+"
+            select="$x:result => string-to-codepoints() => distinct-values()"/>
+        <x:expect label="String is not the same digit repeated"
+            test="count($ov:distinct-codepoints) gt 1"/>
+    </x:scenario>
+    
+    <x:scenario shared="yes" label="SHARED: Check sequence of uuids">
+        <!-- This set of shared assertions expects the referencing
+            scenario or its ancestor to have defined
+            <x:variable name="ov:seq-length" .../> and
+            <x:variable name="ov:seed" .../> -->
+        <x:expect label="Correct number of strings"
+            test="$x:result instance of xs:string+ and count($x:result) eq $ov:seq-length"/>
+        <x:expect label="Each string matches uuid regular expression"
+            test="every $uuid in $x:result satisfies matches($uuid, $ov:uuid-v4-regex)"/>
+        <x:expect label="Check repeatability for same seed"
+            test="deep-equal($x:result, r:make-uuid-sequence($ov:seed, $ov:seq-length))"/>
+        <x:expect label="Not typically equal to function output for a different seed"
+            test="not(deep-equal($x:result, r:make-uuid-sequence($ov:seed || '1', $ov:seq-length)))"/>
+    </x:scenario>
+
+</x:description>


### PR DESCRIPTION
# Committer Notes

This was done in order to create a uniformal indentation between the metaschemas as fully described in issue #1183 which this PR fixes.
(Since this is an easy fix I didn't wait for the response in #1183, but feel free to ignore this PR until the discussion there is resolved)

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?
