### PR TITLE
Fix GitHub links pointing to `master` branch

### DIFF
--- a/content/fedramp.gov/README.md
+++ b/content/fedramp.gov/README.md
@@ -1,3 +1,3 @@
 # Content Moved
 
-All OSCAL FedRAMP content files have been moved to the [OSCAL content GitHub repository](https://github.com/usnistgov/oscal-content/tree/master/fedramp.gov).
+All OSCAL FedRAMP content files have been moved to the [OSCAL content GitHub repository](https://github.com/usnistgov/oscal-content/tree/main/fedramp.gov).

--- a/content/fedramp.gov/README.md
+++ b/content/fedramp.gov/README.md
@@ -1,3 +1,3 @@
 # Content Moved
 
-All OSCAL FedRAMP content files have been moved to the [OSCAL content GitHub repository](https://github.com/usnistgov/oscal-content/tree/main/fedramp.gov).
+All OSCAL FedRAMP content files have been moved to the [OSCAL content GitHub repository](https://github.com/GSA/fedramp-automation/tree/master/dist/content/baselines).

--- a/content/nist.gov/SP800-53/README.md
+++ b/content/nist.gov/SP800-53/README.md
@@ -1,3 +1,3 @@
 # Content Moved
 
-All NIST Special Publication (SP) 800-53 OSCAL content files have been moved to the [OSCAL content GitHub repository](https://github.com/usnistgov/oscal-content/tree/master/nist.gov/SP800-53).
+All NIST Special Publication (SP) 800-53 OSCAL content files have been moved to the [OSCAL content GitHub repository](https://github.com/usnistgov/oscal-content/tree/main/nist.gov/SP800-53).

--- a/content/nist.gov/SP800-53/rev4/README.md
+++ b/content/nist.gov/SP800-53/rev4/README.md
@@ -1,3 +1,3 @@
 # Content Moved
 
-All NIST Special Publication (SP) 800-53 OSCAL content files have been moved to the [OSCAL content GitHub repository](https://github.com/usnistgov/oscal-content/tree/master/nist.gov/SP800-53/rev4).
+All NIST Special Publication (SP) 800-53 OSCAL content files have been moved to the [OSCAL content GitHub repository](https://github.com/usnistgov/oscal-content/tree/main/nist.gov/SP800-53/rev4).

--- a/content/nist.gov/SP800-53/rev5/README.md
+++ b/content/nist.gov/SP800-53/rev5/README.md
@@ -1,3 +1,3 @@
 # Content Moved
 
-All NIST Special Publication (SP) 800-53 OSCAL content files have been moved to the [OSCAL content GitHub repository](https://github.com/usnistgov/oscal-content/tree/master/nist.gov/SP800-53/rev5).
+All NIST Special Publication (SP) 800-53 OSCAL content files have been moved to the [OSCAL content GitHub repository](https://github.com/usnistgov/oscal-content/tree/main/nist.gov/SP800-53/rev5).

--- a/src/metaschema/readme.md
+++ b/src/metaschema/readme.md
@@ -10,7 +10,7 @@ OSCAL Metaschemas are used to generate other OSCAL artifacts based on the metasc
 
 Use of Metaschemas in OSCAL allow us to maintain seamless and consistent support for multiple OSCAL model formats, including XML and JSON. Content can also be kept up-to-date in multiple formats using generated content converters, and can be validated using generated schema. Adding support for new formats (e.g., YAML) can accomplished by extending the Metaschema tooling to produce schema and converters for other formats.
 
-The Metaschema syntax (an XML application) is also described and constrained with its [own schema](https://github.com/usnistgov/metaschema/blob/master/toolchains/xslt-M4/validate/metaschema.xsd), and with a [Schematron constraints set](https://github.com/usnistgov/metaschema/blob/master/toolchains/xslt-M4/validate/metaschema-composition-check.sch). The latter is able to enforce some of the rules described below.
+The Metaschema syntax (an XML application) is also described and constrained with its [own schema](https://github.com/usnistgov/metaschema/blob/main/toolchains/xslt-M4/validate/metaschema.xsd), and with a [Schematron constraints set](https://github.com/usnistgov/metaschema/blob/main/toolchains/xslt-M4/validate/metaschema-composition-check.sch). The latter is able to enforce some of the rules described below.
 
 ## Enumerated values
 


### PR DESCRIPTION
# Committer Notes

There are currently some links which point to GitHub repos with the `master` branch.
All the repos they're pointing to don't have a `master` branch anymore since it was replaced with `main`.
This PR fixes the links.

FYI - The links still currently work, but show an annoying "Branch master was renamed to main." message every time you follow them.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?
