### PR TITLE
clarified the semantics of implemented-requirement in a component def…

### DIFF
--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -358,7 +358,7 @@
     <model>
       <define-field name="description" as-type="markup-multiline" min-occurs="1" in-xml="WITH_WRAPPER">
         <formal-name>Control Implementation Description</formal-name>
-        <description>A description of how the specified control is implemented for the containing component or capability.</description>
+        <description>A suggestion for how the specified control may be implemented if the containing component or capability is instantiated in a system security plan.</description>
       </define-field>
       <assembly ref="property" max-occurs="unbounded">
         <group-as name="props" in-json="ARRAY"/>
@@ -397,6 +397,9 @@
         </remarks>
       </is-unique>
     </constraint>
+    <remarks>
+      <p>Implemented requirements within a component or capability in a component definition provide a means to suggest possible control implementation details, which may be used by a different party when authoring a system security plan. Thus, these requirements defined in a component definition are only a suggestion of how to implement, which may be adopted wholesale, changed, or ignored by a person defining an information system implementation.</p>
+    </remarks>
   </define-assembly>
   <define-assembly name="statement" scope="local">
     <formal-name>Control Statement Implementation</formal-name>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -690,7 +690,7 @@
   </define-assembly>
   <define-assembly name="implemented-requirement" scope="local">
     <formal-name>Control-based Requirement</formal-name>
-    <description>Describes how the system satisfies an individual control.</description>
+    <description>Describes how the system satisfies the requirements of an individual control.</description>
     <define-flag name="uuid" as-type="uuid" required="yes">
       <formal-name>Control Requirement Universally Unique Identifier</formal-name>
       <!-- Identifier Declaration -->


### PR DESCRIPTION
# Committer Notes

Clarified the semantics of implemented-requirement in a component definition as only a suggestion of how to implement. Resolves #1194.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
