### PR TITLE
Add GHA Workflow for Cron Schedule of Site and Markdown Docs Link Checking

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,62 @@
+name: Link Check
+
+on:
+  schedule:
+    - cron: "00 8 * * *" # 0800 UTC is 0400 AM EDT
+  repository_dispatch:
+  workflow_dispatch:
+    inputs:
+      ignorePattern:
+        description: 'a pattern provided to grep for files/directories to ignore'
+        required: false
+        default: '^docs/'
+        type: string
+      markdownLinkCheckConfig:
+        description: 'the path to the markdown link check config file'
+        required: false
+        default: 'build/config/.markdown-link-check/config.json'
+        type: string
+      site_git_ref:
+        description: 'git ref, a SHA commit or branch or tag, for the published HTML content'
+        required: true
+        default: 'nist-pages'
+        type: string
+      site_git_ref_path:
+        description: 'the subdirectory to check out git ref and check links in website content'
+        required: true
+        default: 'published'
+        type: string
+      create_issue:
+        description: 'create new GitHub issue if broken links found'
+        required: false
+        default: true
+        type: boolean
+jobs:
+  schedule-validate-repo-markdown-links:
+    uses: ./.github/workflows/workflow-validate-repo-markdown.yml
+    if: github.event_name != 'workflow_dispatch'
+    with:
+      ignorePattern: '^docs/'
+      markdownLinkCheckConfig: 'build/config/.markdown-link-check/config.json'
+      create_issue: true
+  schedule-validate-repo-markdown-links-debug:
+    uses: ./.github/workflows/workflow-validate-repo-markdown.yml
+    if: github.event_name == 'workflow_dispatch'
+    with:
+      ignorePattern: ${{ github.event.inputs.ignorePattern }}
+      markdownLinkCheckConfig: ${{ github.event.inputs.markdownLinkCheckConfig }}
+      create_issue: ${{ contains('true', github.event.inputs.create_issue) }}
+  schedule-validate-website-links:
+    uses: ./.github/workflows/workflow-validate-website-content.yml
+    if: github.event_name != 'workflow_dispatch'
+    with:
+      site_git_ref: 'nist-pages'
+      site_git_ref_path: 'published'
+      create_issue: true
+  schedule-validate-website-links-debug:
+    uses: ./.github/workflows/workflow-validate-website-content.yml
+    if: github.event_name == 'workflow_dispatch'
+    with:
+      site_git_ref: ${{ github.event.inputs.site_git_ref }}
+      site_git_ref_path: ${{ github.event.inputs.site_git_ref_path }}
+      create_issue: ${{ contains('true', github.event.inputs.create_issue) }}

--- a/.github/workflows/workflow-generate-website.yml
+++ b/.github/workflows/workflow-generate-website.yml
@@ -62,6 +62,11 @@ on:
         required: false
         default: true
         type: boolean
+      create_issue:
+        description: 'create new GitHub issue if broken links found'
+        required: false
+        default: false
+        type: boolean
 jobs:
   build-and-push-website:
     name: Build and Push Website
@@ -148,14 +153,14 @@ jobs:
       uses: lycheeverse/lychee-action@f1da3291e1d03cbe11a413ae9f16b62fec99e6b6 # v1.4.1
       with:
         args: --exclude-file ./build/config/.lycheeignore --verbose --no-progress './docs/public/**/*.html' --accept 200,206,429
-        format: json
-        output: html_link_report.json
+        format: markdown
+        output: html_link_report.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/upload-artifact@v3 # current: 6673cd052c4cd6fcf4b4e6e60ea986c889389535
       with:
         name: html_link_report
-        path: html_link_report.json
+        path: html_link_report.md
         retention-days: 5
     - uses: actions/github-script@v3 # current: f05a81df23035049204b043b50c3322045ce7eb3
       if: steps.linkchecker.outputs.exit_code != 0

--- a/.github/workflows/workflow-validate-repo-markdown.yml
+++ b/.github/workflows/workflow-validate-repo-markdown.yml
@@ -12,18 +12,11 @@ on:
         required: false
         default: 'build/config/.markdown-link-check/config.json'
         type: string
-  workflow_dispatch:
-    inputs:
-      ignorePattern:
-        description: 'a pattern provided to grep for files/directories to ignore'
+      create_issue:
+        description: 'create new GitHub issue if broken links found'
         required: false
-        default: '^docs/'
-        type: string
-      markdownLinkCheckConfig:
-        description: 'the path to the markdown link check config file'
-        required: false
-        default: 'build/config/.markdown-link-check/config.json'
-        type: string
+        default: false
+        type: boolean
 jobs:
   validate-repo-markdown:
     name: Validate Repo Markdown
@@ -59,4 +52,19 @@ jobs:
     - name: Validate repo Markdown content instances
       run: |
         # this command will filter out any docs Markdown files, which are checked in a different job
-        git ls-files "*/*.md" -z | grep --null-data -v "${{ inputs.ignorePattern }}" | xargs -0 -n1 markdown-link-check -q -c "${{ inputs.markdownLinkCheckConfig }}"
+        git ls-files "*.md" -z | \
+        grep --null-data -v "${{ inputs.ignorePattern }}" | \
+        xargs -0 markdown-link-check -c "${{ inputs.markdownLinkCheckConfig }}" | \
+        tee mlc_report.log
+        # Exit code of xargs and markdown-link-check, not git or grep or tee pipe elements
+        exit ${PIPESTATUS[2]}
+      id: linkchecker
+    - name: Create issue if bad links detected in repo
+      if: failure() && inputs.create_issue == true
+      uses: peter-evans/create-issue-from-file@97e6f902a416aac38834e23fa52e166aad0437d2 # v3.0.0
+      with:
+        title: Scheduled Check of Markdown Documents Found Bad Hyperlinks
+        content-filepath: mlc_report.log
+        labels: |
+          bug
+          Scope: Documentation

--- a/.github/workflows/workflow-validate-website-content.yml
+++ b/.github/workflows/workflow-validate-website-content.yml
@@ -1,0 +1,50 @@
+name: Validate Website Content
+
+on:
+  workflow_call:
+    inputs:
+      site_git_ref:
+        description: 'git ref, a SHA commit or branch or tag, for the published HTML content'
+        required: true
+        default: 'nist-pages'
+        type: string
+      site_git_ref_path:
+        description: 'the subdirectory to check out git ref and check links in website content'
+        required: true
+        default: 'published'
+        type: string
+      create_issue:
+        description: 'create new GitHub issue if broken links found'
+        required: false
+        default: false
+        type: boolean
+jobs:
+  schedule-validate-website-links:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Latest
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # this ensures that the tag and commit history are available
+    - name: Checkout git ref of published website content
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.site_git_ref }}
+        path: ${{ inputs.site_git_ref_path }}
+    - name: Check website HTML content links
+      id: linkchecker
+      uses: lycheeverse/lychee-action@f1da3291e1d03cbe11a413ae9f16b62fec99e6b6 # v1.4.1
+      with:
+        args: --exclude-file ./build/config/.lycheeignore --verbose --no-progress --accept 200,206,429 './published/**/*.html'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create issue if bad links detected
+      if: steps.linkchecker.outputs.exit_code != 0 && inputs.create_issue
+      uses: peter-evans/create-issue-from-file@97e6f902a416aac38834e23fa52e166aad0437d2 # v3.0.0
+      with:
+        title: Scheduled Check of Website Content Found Bad Hyperlinks
+        content-filepath: ./lychee/out.md
+        labels: |
+          bug
+          Scope: Documentation
+          Scope: Website          

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Contributions can be made to the following branches in this repository:
 - **release-\***: The release branches are used to provide patches to a major or minor version of OSCAL. The branches are named release-*major*.*minor*. You should provide changes only to the highest numbered *minor* release for a given *major* release. Patch releases are made more frequently than *major* or *minor* releases.
 - **develop**: This branch is used to queue changes for the next *major*/*minor* release of OSCAL. A *major*/*minor* release will result in the creation of a new release branch, once the development has been completed and the update is to be staged for release.
 
-More information about how [releases](../../releases) are managed in this repository can be found in the [versioning and branching guide](./versioning-and-branching.md).
+More information about how [releases](../../releases) are managed in this repository can be found in the [versioning and branching guide](versioning-and-branching.md).
 
 The OSCAL project uses a typical GitHub fork and pull request [workflow](https://guides.github.com/introduction/flow/). To establish a development environment for contributing to the OSCAL project, you must do the following:
 

--- a/build/config/.markdown-link-check/config.json
+++ b/build/config/.markdown-link-check/config.json
@@ -2,6 +2,12 @@
   "ignorePatterns": [
         {
             "pattern": "https://docs.github.com"
+        },
+        {
+            "pattern": "https://guides.github.com"
+        },
+        {
+            "pattern": "https://help.github.com"
         }
   ],
   "replacementPatterns": [
@@ -12,6 +18,14 @@
         {
             "pattern": "^../../projects",
             "replacement": "https://github.com/usnistgov/OSCAL/projects"
+        },
+        {
+            "pattern": "^../../releases",
+            "replacement": "https://github.com/usnistgov/OSCAL/releases"
+        },
+        {
+            "pattern": "^../../tree",
+            "replacement": "https://github.com/usnistgov/OSCAL/tree"
         }
     ]
 }


### PR DESCRIPTION
# Committer Notes

Closes usnistgov/OSCAL#1230.

This has been touched up. Before `git commit --amend`ing the final PR, I ran a bad build with known bad links removed  from the ignore, evidenced with [this GitHub Actions "Link Check" workflow run](https://github.com/aj-stein-nist/OSCAL/actions/runs/2335764425).

To sample the Markdown and website content issue format, see the sample bug reports below.

- aj-stein-nist/OSCAL#35
- aj-stein-nist/OSCAL#36

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
