### PR TITLE
1256 concepts identifier use

### DIFF
--- a/docs/content/concepts/identifier-use/_index.md
+++ b/docs/content/concepts/identifier-use/_index.md
@@ -26,8 +26,6 @@ UUIDs were chosen because:
 - UUIDs can be issued without a central authority
 - UUIDs are represented in 128 bits, providing for a large address space with low risk of identifier collisions for randomly generated values
 
-The opaque nature of UUIDs, which consist of a series of hexadecimal characters, makes them less than ideal for wildcard matching scenarios.  Thus, their use in OSCAL is intended for identification only where an exact match is required. Where wildcard matching is needed, the other data elements associated with the entity should be evaluated for a match instead. 
-
 {{<callout>}}The opaque nature of UUIDs, which consist of a series of hexadecimal characters, makes them less than ideal for wildcard matching scenarios.  Thus, their use in OSCAL is intended for identification only where an exact match is required. Where wildcard matching is needed, the other data elements associated with the entity should be evaluated for a match instead. {{</callout>}}
 
 The [OSCAL XML Reference Index](/reference/latest/complete/xml-index/#/@uuid) and [OSCAL JSON Reference Index](/reference/latest/complete/json-index/#/uuid) provide a listing of UUIDs in the core OSCAL models.  References to these identifiers typically follow a naming convention of the object type followed by “-uuid”.  For example, see the XML reference index for [location-uuid](/reference/latest/complete/xml-index/#/location-uuid) (or [location-uuids](/reference/latest/complete/json-index/#/uuid) in the JSON reference index).


### PR DESCRIPTION
# Committer Notes
This PR resolves issue#1256 by removing duplicate text above the callout box on the [Concepts - Identifier Use Page](https://pages.nist.gov/OSCAL/concepts/identifier-use/#identifier-type)

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
