### PR TITLE
Add clarifying media type documentation for usnisgov/OSCAL#1255.

### DIFF
--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -815,7 +815,7 @@
         <description>Specifies a media type as defined by the Internet Assigned Numbers Authority (IANA) <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">Media Types Registry</a>.
         </description>
         <remarks>
-            <p>The IANA Media Types Registry should be used, but currently there is no official media type for YAML. OSCAL documents should specify <code>application/yaml</code> or <code>application/oscal+yaml</code> with a structured name suffix, per <a href="https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2.8">RFC 6838 Section 4.2.8</a>.</p>
+            <p>The IANA Media Types Registry should be used, but currently there is no official media type for YAML. OSCAL documents should specify <code>application/yaml</code> for general YAML content, or <code>application/oscal+yaml</code> for YAML-based OSCAL content. This approach aligns with use of a structured name suffix, per <a href="https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2.8">RFC 6838 Section 4.2.8</a>.</p>
         </remarks>
     </define-flag>
 

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -814,6 +814,9 @@
         <formal-name>Media Type</formal-name>
         <description>Specifies a media type as defined by the Internet Assigned Numbers Authority (IANA) <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">Media Types Registry</a>.
         </description>
+        <remarks>
+            <p>The IANA Media Types Registry should be used, but currently there is no official media type for YAML. OSCAL documents should specify <code>application/yaml</code> or <code>application/oscal+yaml</code> with a structured name suffix, per <a href="https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2.8">RFC 6838 Section 4.2.8</a>.</p>
+        </remarks>
     </define-flag>
 
     <define-field name="remarks" as-type="markup-multiline">


### PR DESCRIPTION
# Committer Notes

Clarify YAML media types to minimize ambiguity around the lack of an official IANA Media Registry Type. Closes usnistgov/OSCAL#1255.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
