### PR TITLE
Generate Owner, Repo Stub and Branch URLs Dynamically for Reference Model Docs for Development Snapshot

### DIFF
--- a/docs/archetypes/reference-index.md
+++ b/docs/archetypes/reference-index.md
@@ -11,6 +11,7 @@ sidenav:
   debug: false
 oscal:
     type: "{{ getenv "HUGO_REF_TYPE" }}"
+    remote: "{{ getenv "HUGO_REF_REMOTE" }}"
     branch: "{{ getenv "HUGO_REF_BRANCH" }}"
     revision: "{{ getenv "HUGO_REF_REVISION" }}"
     version: "{{ getenv "HUGO_REF_VERSION" }}"

--- a/docs/layouts/_default/reference-release.html
+++ b/docs/layouts/_default/reference-release.html
@@ -40,7 +40,11 @@
             {{ if isset .Params "heading" }}<h1>{{ .Params.heading }}</h1>{{else}}<h1>{{ .Title }}</h1>{{ end }}
           </header>
           <p><span class="usa-tag">Release Version</span> {{ if eq .Params.oscal.version "develop" }}Latest Development Snapshot{{ else }}OSCAL v{{ .Params.oscal.version }}{{ end }}</p>
+          {{ if isset .Params.oscal "remote" }}
+          <p><span class="usa-tag">Github</span> <a href="https://github.com/{{ .Params.oscal.remote }}">{{ .Params.oscal.remote }}</a> <span class="usa-tag">{{ if eq .Params.oscal.type "tag" }}Tag{{ else }}Branch{{end}}</span> <a href="https://github.com/{{ .Params.oscal.remote }}/tree/{{ .Params.oscal.branch }}">{{ .Params.oscal.branch }}</a></p>
+          {{ else }}
           <p><span class="usa-tag">Github</span> <a href="https://github.com/usnistgov/OSCAL">usnistgov/OSCAL</a> <span class="usa-tag">{{ if eq .Params.oscal.type "tag" }}Tag{{ else }}Branch{{end}}</span> <a href="https://github.com/usnistgov/OSCAL/tree/{{ .Params.oscal.branch }}">{{ .Params.oscal.branch }}</a></p>
+          {{ end }}
           {{ .Content }}
           {{ if gt (len .Pages) 0 }}
           <p>The following documentation is provided for this release.</p>


### PR DESCRIPTION
# Committer Notes

Dynamically compute remote owner and repo name stub. For the reference model documentation develop branch, we want the owner, repo name, and branch to be dynamically computed and not statically generated and presumed to be from the official main repo, usnistgov/OSCAL. Closes usnistgov/OSCAL#1286

Development snapshot based off of running this branch locally on my workstation with hugo:

![image](https://user-images.githubusercontent.com/94922603/170335596-22302c66-8819-4e38-b8df-104e5bcceeaa.png)

Main latest release:

![image](https://user-images.githubusercontent.com/94922603/170336132-85b751b8-c345-4174-b89d-1da347144b8f.png)

Tagged release:

![image](https://user-images.githubusercontent.com/94922603/170336362-1f599ad0-f0f0-4d2e-977d-e2a1e29b0a6c.png)


### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
