### PR TITLE
Profile resolution spec: Add req-modify-alter-add-one-title

### DIFF
--- a/src/specifications/profile-resolution/profile-resolution-specml.xml
+++ b/src/specifications/profile-resolution/profile-resolution-specml.xml
@@ -1167,6 +1167,10 @@ intermediate:
             <src>prop</src> in the control when
             <src>position</src> is
             <code>starting</code>.</req>
+            <req level="must" id="req-modify-alter-add-one-title">If an add directive adds a new
+              <tgt>title</tgt> to a control or other object that the schema limits to one title,
+              the processor MUST keep only the last title of that object. That is, an added title
+              replaces, not supplements, an existing title.</req>
           </p>
 
           <mapping>


### PR DESCRIPTION
# Committer Notes

This pull request updates the profile resolution specification to explain the alter/add/title pattern. This change arises from #1306. Let me know if you think the information should be in a different location or have different phrasing.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
