### PR TITLE
Profile resolver: Test finish phase, plus minor XSLT enhancements and fixes

### DIFF
--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-finish.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-finish.xsl
@@ -16,17 +16,22 @@
     </xsl:template>
 
     <!-- Finalizing profile resolution into a catalog:
-           reordering metadata, group and control contents to valid order
-           removing loose orphan parameters
-             orphans given inside controls are retained
-           removing unclaimed inventory
-             defined as any 'citation' or 'resource' in back matter
-               without something somewhere linking to it
-
+         - Reordering metadata, group and control contents to valid order
+         - Removing loose orphan parameters
+           - Orphans given inside controls are retained
+         - Removing extra elements of types that permit at most one
+           - Use [last()] instead of [1] to accommodate the case of
+             replacing a title during modify phase. The modify phase
+             adds the title following the original one.
+           - Some "[last()]" expressions are expected to have no effect
+             if input documents are schema-valid but are included to
+             avoid producing schema-invalid output.
+         - Removing unclaimed inventory, defined as any 'resource'
+           in back matter without something somewhere linking to it
 
          What we are not doing:
-           removing broken links
-           remove opqr and xsi namespaces (that happens in the shell)
+         - Removing broken links
+         - Remove opr and xsi namespaces (that happens in the shell)
     -->
 <!-- An XQuery run on a metaschema can return a sequence of instructions
 
@@ -34,54 +39,49 @@
     for $n in (//*:define-assembly[@name=$where]/*:model/*/(@name | @ref))
     return <apply-templates mode="#current" select="{ $n }"/>
 
+    Caveat: This query does not account for elements that can occur at most once,
+    or aliasing via use-name.
     -->
-
-    <xsl:param name="path-to-source" as="xs:string?"/>
-
-    <xsl:template match="metadata/link[@rel='resolution-source']">
-        <!-- splicing together a path with '/' -->
-        <link rel="resolution-source" href="{string-join(
-            ($path-to-source[matches(.,'\S')],replace(@href,'.*/','')), '/')}">
-            <xsl:apply-templates></xsl:apply-templates>
-        </link>
-    </xsl:template>
 
     <xsl:template match="catalog">
         <xsl:copy copy-namespaces="no">
             <xsl:apply-templates mode="#current" select="@*"/>
-            <xsl:apply-templates mode="#current" select="metadata"/>
+            <xsl:apply-templates mode="#current" select="metadata[last()]"/>
             <xsl:apply-templates mode="#current" select="opr:*"/>
             <xsl:apply-templates mode="#current" select="param"/>
             <xsl:apply-templates mode="#current" select="control"/>
             <xsl:apply-templates mode="#current" select="group"/>
-            <xsl:apply-templates mode="#current" select="back-matter"/>
+            <xsl:apply-templates mode="#current" select="back-matter[last()]"/>
         </xsl:copy>
     </xsl:template>
 
     <xsl:template match="metadata">
         <xsl:copy copy-namespaces="no">
             <xsl:apply-templates mode="#current" select="@*"/>
-            <xsl:apply-templates mode="#current" select="title"/>
-            <xsl:apply-templates mode="#current" select="published"/>
-            <xsl:apply-templates mode="#current" select="last-modified"/>
-            <xsl:apply-templates mode="#current" select="version"/>
-            <xsl:apply-templates mode="#current" select="oscal-version"/>
-            <xsl:apply-templates mode="#current" select="doc-id"/>
+            <xsl:apply-templates mode="#current" select="title[last()]"/>
+            <xsl:apply-templates mode="#current" select="published[last()]"/>
+            <xsl:apply-templates mode="#current" select="last-modified[last()]"/>
+            <xsl:apply-templates mode="#current" select="version[last()]"/>
+            <xsl:apply-templates mode="#current" select="oscal-version[last()]"/>
+            <xsl:apply-templates mode="#current" select="revisions[last()]"/>
+            <xsl:apply-templates mode="#current" select="document-id"/>
             <xsl:apply-templates mode="#current" select="prop"/>
             <xsl:apply-templates mode="#current" select="link"/>
             <xsl:apply-templates mode="#current" select="role"/>
+            <xsl:apply-templates mode="#current" select="location"/>
             <xsl:apply-templates mode="#current" select="party"/>
             <xsl:apply-templates mode="#current" select="responsible-party"/>
-            <xsl:apply-templates mode="#current" select="remarks"/>
+            <xsl:apply-templates mode="#current" select="remarks[last()]"/>
         </xsl:copy>
     </xsl:template>
 
     <xsl:template match="group">
         <xsl:copy copy-namespaces="no">
             <xsl:apply-templates mode="#current" select="@*"/>
-            <xsl:apply-templates mode="#current" select="title"/>
+            <xsl:apply-templates mode="#current" select="title[last()]"/>
             <xsl:apply-templates mode="#current" select="param"/>
             <xsl:apply-templates mode="#current" select="prop"/>
+            <xsl:apply-templates mode="#current" select="link"/>
 
             <xsl:apply-templates mode="#current" select="part"/>
             <xsl:apply-templates mode="#current" select="control"/>
@@ -92,20 +92,23 @@
     <xsl:template match="control">
         <xsl:copy copy-namespaces="no">
             <xsl:apply-templates mode="#current" select="@*"/>
-            <xsl:apply-templates mode="#current" select="title"/>
+            <!-- Keep only the last title. There could be multiple titles if
+                modify phase processed alter/add/title. -->
+            <xsl:apply-templates mode="#current" select="title[last()]"/>
             <xsl:apply-templates mode="#current" select="param"/>
             <xsl:apply-templates mode="#current" select="prop"/>
-            <xsl:apply-templates mode="#current" select="annotation"/>
             <xsl:apply-templates mode="#current" select="link"/>
             <xsl:apply-templates mode="#current" select="part"/>
             <xsl:apply-templates mode="#current" select="control"/>
         </xsl:copy>
     </xsl:template>
 
-  <xsl:key name="param-insertions" match="insert" use="@param-id"/>
+    <xsl:key name="param-insertions" match="insert[@type='param']" use="@id-ref"/>
 
-  <xsl:template match="catalog/param[empty(key('param-insertions',@id))]
-      | group/param[empty(key('param-insertions',@id))]"/>
+    <!-- Suppress loose param elements that do not have corresponding insert element(s)
+        and that do not have an explicit instruction to keep them. -->
+    <xsl:template match="catalog/param[empty(key('param-insertions',@id))][not(prop[@name='keep'][@value='always'])]
+        | group/param[empty(key('param-insertions',@id))][not(prop[@name='keep'][@value='always'])]"/>
 
     <!-- Don't copy back-matter wrapper if it has no contents in result -->
     <xsl:template match="back-matter">
@@ -116,6 +119,8 @@
 
     <xsl:key name="cross-reference" match="*[starts-with(@href,'#')]" use="substring-after(@href,'#')"/>
 
-    <xsl:template match="resource[empty(key('cross-reference',@uuid))][not(prop[@name='keep']='always')]"/>
+    <!-- Suppress resource elements that are not referenced and that do not
+        have an explicit instruction to keep them. -->
+    <xsl:template match="resource[empty(key('cross-reference',@uuid))][not(prop[@name='keep'][@value='always'])]"/>
 
 </xsl:stylesheet>

--- a/src/utils/util/resolver-pipeline/testing/5_finished/finish.xspec
+++ b/src/utils/util/resolver-pipeline/testing/5_finished/finish.xspec
@@ -1,171 +1,572 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+    xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"
+    xmlns:opr="http://csrc.nist.gov/ns/oscal/profile-resolution"
+    xmlns:ov="http://csrc.nist.gov/ns/oscal/xspec/variable"
     xmlns:x="http://www.jenitennison.com/xslt/xspec"
     stylesheet="../../oscal-profile-resolve-finish.xsl">
-    <x:scenario label="Base">
-        <x:context>
-            <catalog id="abc"/>
-        </x:context>
-        <x:expect label="profile becomes catalog">
-            <catalog id="abc"/>
-        </x:expect>
+
+    <x:scenario label="Tests for match=* | @* template in all modes">
+        <x:variable name="ov:arbitrary-element" as="element(arbitrary-element)">
+            <arbitrary-element xmlns="" arbitrary-attribute="val">text<child/></arbitrary-element>
+        </x:variable>
+        <x:scenario label="Element">
+            <x:context select="$ov:arbitrary-element"/>
+            <x:expect label="Copy" select="$ov:arbitrary-element"/>
+        </x:scenario>
+        <x:scenario label="Attribute">
+            <x:context select="$ov:arbitrary-element/@arbitrary-attribute"/>
+            <x:expect label="Copy"
+                test="$x:result instance of attribute(arbitrary-attribute) and $x:result/string()='val'"/>
+        </x:scenario>
     </x:scenario>
-    <x:scenario label="Loose parameter, unreferenced">
-        <x:context>
-            <catalog id="worksheet">
-                <metadata>
-                    <title>Catalog</title>
-                </metadata>
-                <param id="loose">
-                    <label>Loose parameter</label>
-                </param>
-                <control id="control_A">
-                    <title>Control A</title>
-                </control>
-            </catalog>
-        </x:context>
-        <x:expect label="orphan parameter is dropped">
-            <catalog id="worksheet">
-                <metadata>
-                    <title>Catalog</title>
-                </metadata>
-                <control id="control_A">
-                    <title>Control A</title>
-                </control>
-            </catalog>
-        </x:expect>
+
+    <x:scenario label="Tests for match=catalog template">
+        <x:scenario label="Base">
+            <x:context>
+                <catalog id="abc"/>
+            </x:context>
+            <x:expect label="profile becomes catalog">
+                <catalog id="abc"/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Catalog with incorrectly sequenced children">
+            <x:context>
+                <catalog id="worksheet">
+                    <back-matter>
+                        <opr:foo/>
+                    </back-matter>
+                    <group>
+                        <title>Group 1</title>
+                    </group>
+                    <control id="control_A">
+                        <title>Control A</title>
+                        <part>
+                            <p><insert type="param" id-ref="loose"/> goes here.</p>
+                        </part>
+                    </control>
+                    <param id="loose">
+                        <label>Loose parameter</label>
+                    </param>
+                    <opr:foo/>
+                    <metadata>
+                        <title>Catalog</title>
+                    </metadata>
+                </catalog>                
+            </x:context>
+            <x:expect label="Catalog with correct sequence of children">
+                <catalog id="worksheet">
+                    <metadata>...</metadata>
+                    <opr:foo/>
+                    <param id="loose">...</param>
+                    <control id="control_A">...</control>
+                    <group>...</group>
+                    <back-matter>...</back-matter>
+                </catalog>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Catalog with multiple metadata and back-matter children">
+            <x:context>
+                <catalog id="worksheet">
+                    <metadata>
+                        <title>Catalog X</title>
+                        <version>1.2</version>
+                    </metadata>
+                    <metadata>
+                        <title>Catalog Y</title>
+                        <version>1.3</version>
+                    </metadata>
+                    <back-matter>
+                        <opr:foo/>
+                    </back-matter>
+                    <back-matter>
+                        <opr:bar/>
+                    </back-matter>
+                </catalog>                
+            </x:context>
+            <x:expect label="Catalog with last metadata child and last back-matter child">
+                <catalog id="worksheet">
+                    <metadata>
+                        <title>Catalog Y</title>
+                        <version>1.3</version>
+                    </metadata>
+                    <back-matter>
+                        <opr:bar/>
+                    </back-matter>
+                </catalog>                                
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Catalog with loose parameter as child, ">
+            <x:scenario label="unreferenced">
+                <x:context>
+                    <catalog id="worksheet">
+                        <metadata>
+                            <title>Catalog</title>
+                        </metadata>
+                        <param id="loose">
+                            <label>Loose parameter</label>
+                        </param>
+                        <control id="control_A">
+                            <title>Control A</title>
+                        </control>
+                    </catalog>
+                </x:context>
+                <x:expect label="orphan parameter is dropped">
+                    <catalog id="worksheet">
+                        <metadata>
+                            <title>Catalog</title>
+                        </metadata>
+                        <control id="control_A">
+                            <title>Control A</title>
+                        </control>
+                    </catalog>
+                </x:expect>
+            </x:scenario>
+            <x:scenario label="referenced">
+                <x:context>
+                    <catalog id="worksheet">
+                        <metadata>
+                            <title>Catalog</title>
+                        </metadata>
+                        <param id="loose">
+                            <label>Loose parameter</label>
+                        </param>
+                        <control id="control_A">
+                            <title>Control A</title>
+                            <part>
+                                <p><insert type="param" id-ref="loose"/> goes here.</p>
+                            </part>
+                        </control>
+                    </catalog>
+                </x:context>
+                <x:expect label="referenced loose parameter is kept">
+                    <catalog id="worksheet">
+                        <metadata>
+                            <title>Catalog</title>
+                        </metadata>
+                        <param id="loose">
+                            <label>Loose parameter</label>
+                        </param>
+                        <control id="control_A">
+                            <title>Control A</title>
+                            <part>
+                                <p><insert type="param" id-ref="loose"/> goes here.</p>
+                            </part>
+                        </control>
+                    </catalog>
+                </x:expect>
+            </x:scenario>
+        </x:scenario>
     </x:scenario>
-    <x:scenario label="Loose parameter, referenced">
-        <x:context>
-            <catalog id="worksheet">
+
+    <x:scenario label="Tests for match=metadata template">
+        <x:scenario label="Metadata contents out of sequence">
+            <x:context>
                 <metadata>
-                    <title>Catalog</title>
+                    <remarks/>
+                    <responsible-party/>
+                    <party/>
+                    <location/>
+                    <role/>
+                    <link/>
+                    <prop/>
+                    <document-id/>
+                    <revisions/>
+                    <oscal-version/>
+                    <version/>
+                    <last-modified/>
+                    <published/>
+                    <title/>
                 </metadata>
-                <param id="loose">
-                    <label>Loose parameter</label>
-                </param>
-                <control id="control_A">
-                    <title>Control A</title>
-                    <part>
-                        <p><insert type="param" id-ref="loose"/> goes here.</p></part>
-                </control>
-            </catalog>
-        </x:context>
-        <x:expect label="referenced loose parameter is kept">
-            <catalog id="worksheet">
+            </x:context>
+            <x:expect label="Metadata with all children in correct sequence">
                 <metadata>
-                    <title>Catalog</title>
+                    <title/>
+                    <published/>
+                    <last-modified/>
+                    <version/>
+                    <oscal-version/>
+                    <revisions/>
+                    <document-id/>
+                    <prop/>
+                    <link/>
+                    <role/>
+                    <location/>
+                    <party/>
+                    <responsible-party/>
+                    <remarks/>
+                </metadata>                
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Metadata with multiple elements of same type">
+            <x:context>
+                <metadata>
+                    <title>Title 1</title>
+                    <title>Title 2</title>
+                    <published>2019-11-13T12:41:07.061-05:00</published>
+                    <last-modified>2019-11-13T12:41:07.061-05:00</last-modified>
+                    <published>2021-11-13T12:41:07.061-05:00</published>
+                    <last-modified>2021-11-13T12:41:07.061-05:00</last-modified>
+                    <version>1.0</version>
+                    <oscal-version>1.0.1</oscal-version>
+                    <version>1.1</version>
+                    <oscal-version>1.0.2</oscal-version>
+                    <revisions>
+                        <revision>
+                            <version>1.0</version>
+                        </revision>
+                    </revisions>
+                    <revisions>
+                        <revision>
+                            <version>1.1</version>
+                        </revision>
+                    </revisions>
+                    <remarks><p>Remark 1</p></remarks>
+                    <remarks><p>Remark 2</p></remarks>
                 </metadata>
-                <param id="loose">
-                    <label>Loose parameter</label>
-                </param>
-                <control id="control_A">
-                    <title>Control A</title>
-                    <part>
-                        <p><insert type="param" id-ref="loose"/> goes here.</p>
-                    </part>
-                </control>
-            </catalog>
-        </x:expect>
+            </x:context>
+            <x:expect label="Metadata with last instance of each child type that cannot occur multiple times">
+                <metadata>
+                    <title>Title 2</title>
+                    <published>2021-11-13T12:41:07.061-05:00</published>
+                    <last-modified>2021-11-13T12:41:07.061-05:00</last-modified>
+                    <version>1.1</version>
+                    <oscal-version>1.0.2</oscal-version>
+                    <revisions>
+                        <revision>
+                            <version>1.1</version>
+                        </revision>
+                    </revisions>
+                    <remarks><p>Remark 2</p></remarks>
+                </metadata>
+            </x:expect>
+        </x:scenario>
     </x:scenario>
-    <x:scenario label="Control contents re-ordered">
-        <x:context>
-            <catalog id="worksheet">
-                <metadata>
-                    <title>Catalog</title>
-                </metadata>
-                <control id="control_A">
-                    <title>Control A</title>
-                    <link href="file.xml"><text>A link</text></link>
-                    <prop name="somewhat">property</prop>
-                </control>
-            </catalog>
-        </x:context>
-        <x:expect label="in valid order">
-            <catalog id="worksheet">
-                <metadata>
-                    <title>Catalog</title>
-                </metadata>
-                <control id="control_A">
-                    <title>Control A</title>
-                    <prop name="somewhat">property</prop>
-                    <link href="file.xml"><text>A link</text></link>
-                </control>
-            </catalog>
-        </x:expect>
+
+    <x:scenario label="Tests for match=group template">
+        <x:scenario label="Group contents out of sequence, ">
+            <x:scenario label="link vs. prop">
+                <x:context select="//o:group">
+                    <catalog id="worksheet">
+                        <metadata>
+                            <title>Catalog</title>
+                        </metadata>
+                        <group id="group_A">
+                            <title>Group A</title>
+                            <link href="file.xml"><text>A link</text></link>
+                            <prop name="somewhat">property</prop>
+                        </group>
+                    </catalog>
+                </x:context>
+                <x:expect label="in valid order: link after prop">
+                    <group id="group_A">
+                        <title>Group A</title>
+                        <prop name="somewhat">property</prop>
+                        <link href="file.xml"><text>A link</text></link>
+                    </group>
+                </x:expect>
+            </x:scenario>
+            <x:scenario label="prop vs. link and part">
+                <x:context select="//o:group">
+                    <catalog id="abc">
+                        <group id="a123">
+                            <title>Group A</title>
+                            <link href="linkme.pdf"><text>Link Me</text></link>
+                            <prop name="rating" value="AAA"/>
+                            <part name="statement"><p>Statement</p></part>
+                            <prop name="due_date" value="2020-02-20"/>
+                        </group>
+                    </catalog>
+                </x:context>
+                <x:expect label="Link and part after prop">
+                    <group id="a123">
+                        <title>Group A</title>
+                        <prop name="rating" value="AAA"/>
+                        <prop name="due_date" value="2020-02-20"></prop>
+                        <link href="linkme.pdf"><text>Link Me</text></link>
+                        <part name="statement"><p>Statement</p></part>
+                    </group>
+                </x:expect>
+            </x:scenario>
+            <x:scenario label="All children out of sequence">
+                <x:context>
+                    <group id="a123">
+                        <group id="b456"/>
+                        <control id="a123.1"/>
+                        <part name="statement">
+                            <p><insert type="param" id-ref="param-X"/> goes here.</p>
+                        </part>
+                        <link href="linkme.pdf"><text>Link Me</text></link>
+                        <prop name="rating" value="AAA"/>
+                        <param id="param-X"><label>X</label></param>
+                        <title>Group A</title>
+                    </group>
+                </x:context>
+                <x:expect label="Group with all children in correct sequence">
+                    <group id="a123">
+                        <title>Group A</title>
+                        <param id="param-X">...</param>
+                        <prop name="rating" value="AAA"/>
+                        <link href="linkme.pdf">...</link>
+                        <part name="statement">...</part>
+                        <control id="a123.1"/>
+                        <group id="b456"/>
+                    </group>                    
+                </x:expect>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="Group with multiple titles">
+            <x:context>
+                <group id="a123">
+                    <title>Original title</title>
+                    <title>Revised title</title>
+                </group>
+            </x:context>
+            <x:expect label="Group with last title">
+                <group id="a123">
+                    <title>Revised title</title>
+                </group>
+            </x:expect>
+        </x:scenario>
     </x:scenario>
-    <x:scenario label="Superfluous back matter discarded">
-        <x:context>
-            <catalog id="worksheet">
-                <metadata>
-                    <title>Catalog</title>
-                </metadata>
-                <back-matter>
-                    <resource uuid="cit1">citation</resource>
-                </back-matter>
-            </catalog>
-        </x:context>
-        <x:expect label="discarding empty back-matter">
-            <catalog id="worksheet">
-                <metadata>
-                    <title>Catalog</title>
-                </metadata>
-            </catalog>
-        </x:expect>
-    </x:scenario>
-    <x:scenario label="Non-superfluous back matter retained">
-        <x:context>
-            <catalog id="worksheet">
-                <metadata>
-                    <title>Catalog</title>
-                </metadata>
-                <control>
-                    <title>Control A</title>
-                    <link href="#citA"><text>link to good citation</text></link>
-                </control>
-                <back-matter>
-                    <resource uuid="cit1">unclaimed citation</resource>
-                    <resource uuid="citA">good citation</resource>
-                </back-matter>
-            </catalog>
-        </x:context>
-        <x:expect label="keeping back-matter with a citation">
-            <catalog id="worksheet">
-                <metadata>
-                    <title>Catalog</title>
-                </metadata>
-                <control>
-                    <title>Control A</title>
-                    <link href="#citA"><text>link to good citation</text></link>
-                </control>
-                <back-matter>
-                    <resource uuid="citA">good citation</resource>
-                </back-matter>
-            </catalog>
-        </x:expect>
-    </x:scenario>
-    <x:scenario label="Restoring order of control contents">
-        <x:context>
-            <catalog id="abc">
+
+    <x:scenario label="Tests for match=control template">
+        <x:scenario label="Control contents out of sequence, ">
+            <x:scenario label="link vs. prop">
+                <x:context select="//o:control">
+                    <catalog id="worksheet">
+                        <metadata>
+                            <title>Catalog</title>
+                        </metadata>
+                        <control id="control_A">
+                            <title>Control A</title>
+                            <link href="file.xml"><text>A link</text></link>
+                            <prop name="somewhat">property</prop>
+                        </control>
+                    </catalog>
+                </x:context>
+                <x:expect label="in valid order: link after prop">
+                    <control id="control_A">
+                        <title>Control A</title>
+                        <prop name="somewhat">property</prop>
+                        <link href="file.xml"><text>A link</text></link>
+                    </control>
+                </x:expect>
+            </x:scenario>
+            <x:scenario label="prop vs. link and part">
+                <x:context select="//o:control">
+                    <catalog id="abc">
+                        <control id="a123">
+                            <title>Control A</title>
+                            <link href="linkme.pdf"><text>Link Me</text></link>
+                            <prop name="rating" value="AAA"/>
+                            <part name="statement"><p>Statement</p></part>
+                            <prop name="due_date" value="2020-02-20"/>
+                        </control>
+                    </catalog>
+                </x:context>
+                <x:expect label="Link and part after prop">
+                    <control id="a123">
+                        <title>Control A</title>
+                        <prop name="rating" value="AAA"/>
+                        <prop name="due_date" value="2020-02-20"></prop>
+                        <link href="linkme.pdf"><text>Link Me</text></link>
+                        <part name="statement"><p>Statement</p></part>
+                    </control>
+                </x:expect>
+            </x:scenario>
+            <x:scenario label="All children out of sequence">
+                <x:context>
+                    <control id="a123">
+                        <control id="a123.1"/>
+                        <part name="statement"><p>Statement</p></part>
+                        <link href="linkme.pdf"><text>Link Me</text></link>
+                        <prop name="rating" value="AAA"/>
+                        <param id="param-X"><label>X</label></param>
+                        <title>Control A</title>
+                    </control>
+                </x:context>
+                <x:expect label="Control with all children in correct sequence">
+                    <control id="a123">
+                        <title>Control A</title>
+                        <param id="param-X"><label>X</label></param>
+                        <prop name="rating" value="AAA"/>
+                        <link href="linkme.pdf"><text>Link Me</text></link>
+                        <part name="statement"><p>Statement</p></part>
+                        <control id="a123.1"/>
+                    </control>                    
+                </x:expect>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="Control with multiple titles">
+            <x:context>
                 <control id="a123">
-                    <title>Control A</title>
-                    <link href="linkme.pdf"><text>Link Me</text></link>
-                    <prop name="rating" value="AAA"/>
-                    <part name="statement"><p>Statement</p></part>
-                    <prop name="due_date" value="2020-02-20"/>
+                    <title>Original title</title>
+                    <title>First revision added during modify phase</title>
+                    <title>Second revision added during modify phase</title>
                 </control>
-            </catalog>
-        </x:context>
-        <x:expect label="Link and part after prop">
-            <catalog id="abc">
+            </x:context>
+            <x:expect label="Control with last title">
                 <control id="a123">
-                    <title>Control A</title>
-                    <prop name="rating" value="AAA"/>
-                    <prop name="due_date" value="2020-02-20"></prop>
-                    <link href="linkme.pdf"><text>Link Me</text></link>
-                    <part name="statement"><p>Statement</p></part>
+                    <title>Second revision added during modify phase</title>
                 </control>
-            </catalog>
-        </x:expect>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for catalog/param[...] | group/param[...] template">
+        <!-- The catalog/param case is tested at the catalog level in
+            the scenario labeled "Catalog with loose parameter as child, " -->
+        <x:scenario label="Unreferenced loose parameter as child of group">
+            <x:context select="//o:param">
+                <catalog id="worksheet">
+                    <group id="group1">
+                        <title>Group 1</title>
+                        <param id="loose-in-group1">
+                            <label>Loose parameter</label>
+                        </param>
+                        <control id="control_A">
+                            <title>Control A</title>
+                        </control>
+                    </group>
+                </catalog>
+            </x:context>
+            <x:expect label="Nothing because selected param is not referenced"
+                select="()"/>
+        </x:scenario>
+        <x:scenario label="Unreferenced loose parameter, where XSLT key is nonempty">
+            <x:context select="(//o:param)[1]">
+                <catalog id="worksheet">
+                    <group id="group1">
+                        <title>Group 1</title>
+                        <param id="loose1-in-group1">
+                            <label>Unreferenced parameter being tested</label>
+                        </param>
+                        <param id="loose2-in-group1">
+                            <label>Referenced parameter</label>
+                        </param>
+                        <control id="control_A">
+                            <title>Control A</title>
+                            <part>
+                                <p><insert type="param" id-ref="loose2-in-group1"/> goes here.</p>
+                            </part>
+                        </control>
+                    </group>
+                </catalog>
+            </x:context>
+            <x:expect label="Nothing because selected param is not referenced"
+                select="()"/>
+        </x:scenario>
+        <x:scenario label="Unreferenced loose parameter with prop name=keep value=always">
+            <x:context select="//o:param">
+                <catalog id="worksheet">
+                    <group id="group1">
+                        <title>Group 1</title>
+                        <param id="loose-in-group1">
+                            <prop name="keep" value="always"/>
+                            <label>Loose parameter</label>
+                        </param>
+                        <control id="control_A">
+                            <title>Control A</title>
+                        </control>
+                    </group>
+                </catalog>
+            </x:context>
+            <x:expect label="Copy of param, even though it is unreferenced">
+                <param id="loose-in-group1">
+                    <prop name="keep" value="always"/>
+                    <label>Loose parameter</label>
+                </param>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for match=back-matter template">
+        <x:scenario label="Superfluous back matter discarded">
+            <x:context select="//o:back-matter">
+                <catalog id="worksheet">
+                    <metadata>
+                        <title>Catalog</title>
+                    </metadata>
+                    <back-matter>
+                        <resource uuid="cit1">citation</resource>
+                    </back-matter>
+                </catalog>
+            </x:context>
+            <x:expect label="Nothing" select="()"/>
+        </x:scenario>
+        <x:scenario label="Back matter retained ">
+            <!-- This scenario relies on the combination of
+                a) match=back-matter template
+                b) nonmatching predicate expressions in the match=resource[...] template
+                c) match="* | @*" template -->
+            <x:scenario label="for cited resource">
+                <x:context select="//o:back-matter">
+                    <catalog id="worksheet">
+                        <metadata>
+                            <title>Catalog</title>
+                        </metadata>
+                        <control>
+                            <title>Control A</title>
+                            <link href="#citA"><text>link to good citation</text></link>
+                        </control>
+                        <back-matter>
+                            <resource uuid="cit1">unclaimed citation</resource>
+                            <resource uuid="citA">good citation</resource>
+                        </back-matter>
+                    </catalog>
+                </x:context>
+                <x:expect label="back-matter containing the cited resource">
+                    <back-matter>
+                        <resource uuid="citA">good citation</resource>
+                    </back-matter>
+                </x:expect>                
+            </x:scenario>
+            <x:scenario label="for resource with prop name=keep value=always">
+                <x:context select="//o:back-matter">
+                    <catalog id="worksheet">
+                        <control>
+                            <title>Control A</title>
+                        </control>
+                        <back-matter>
+                            <resource uuid="cit1">
+                                <prop name="keep" value="always"/>
+                            </resource>
+                            <resource uuid="cit2">unclaimed citation</resource>
+                        </back-matter>
+                    </catalog>
+                </x:context>
+                <x:expect label="back-matter containing the resource with special prop">
+                    <back-matter>
+                        <resource uuid="cit1">
+                            <prop name="keep" value="always"/>
+                        </resource>
+                    </back-matter>
+                </x:expect>
+            </x:scenario>
+        </x:scenario>
+    </x:scenario>
+    
+    <x:scenario label="Tests for match=resource[...] template">
+        <!-- A simple case is tested at the back-matter level in
+            the scenario labeled "Superfluous back matter discarded" -->
+        <x:scenario label="resource without citation or special prop, where XSLT key is nonempty">
+            <x:context select="(//o:resource)[1]">
+                <catalog id="worksheet">
+                    <metadata>
+                        <title>Catalog</title>
+                    </metadata>
+                    <control>
+                        <title>Control A</title>
+                        <link href="#citA"><text>link to good citation</text></link>
+                    </control>
+                    <back-matter>
+                        <resource uuid="cit1"><prop name="keep" value=""/></resource>
+                        <resource uuid="citA">good citation</resource>
+                    </back-matter>
+                </catalog>
+            </x:context>
+            <x:expect label="Nothing" select="()"/>
+        </x:scenario>
     </x:scenario>
 </x:description>


### PR DESCRIPTION
# Committer Notes

This pull request adds template- and function-level XSpec tests for the finish phase of the XSLT profile resolver. It also updates the underlying XSLT, mostly to align with the latest specification.

XSLT
- Remove template that provides link to source, because metadata phase accomplished that
- Add "[last()]" predicate when passing through elements that cannot appear twice
- Align with schema by passing through revisions, document-id, location, and  group/link but not control/annotation
- Align with schema for param insertions, `<insert type="param" id-ref="...">`
- Align with schema and spec for keeping items, `<prop name="keep" value="always">`

XSpec
- Add tests at the level of individual templates


### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
