### PR TITLE
Profile resolver: Follow keep instruction for back-matter resources

### DIFF
--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-merge.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-merge.xsl
@@ -110,10 +110,18 @@
             <back-matter>
                 <!-- Using combination logic on back matter elements. -->
                 <xsl:for-each-group select="back-matter/* | selection/back-matter/*" group-by="(@opr:id,@uuid,generate-id())[1]">
+                    <xsl:variable name="last" as="element(resource)" select="current-group()[last()]"/>
+                    <!-- The final phase needs the ability to keep unreferenced
+                            back matter items based on keep instructions, so the merge
+                            phase must preserve these items. -->
+                    <xsl:variable name="keepers" as="element(resource)*"
+                        select="current-group()[child::prop[@name='keep' and @value='always']]"/>
                     <xsl:call-template name="combine-elements">
-                        <!-- Take last one in group because of spec
-                            requirement id="req-backmatter-dupe". -->
-                        <xsl:with-param name="who" select="current-group()[last()]" as="element(resource)"/>
+                        <!-- Take last one in group because of spec requirement
+                            id="req-backmatter-dupe". -->
+                        <!-- Take last item with keep instruction, because
+                            of spec requirement id="req-backmatter-keep". -->
+                        <xsl:with-param name="who" select="$keepers[last()] | $last" as="element(resource)+"/>
                     </xsl:call-template>
                 </xsl:for-each-group>
             </back-matter>

--- a/src/utils/util/resolver-pipeline/testing/3_merged/merge.xspec
+++ b/src/utils/util/resolver-pipeline/testing/3_merged/merge.xspec
@@ -494,6 +494,127 @@
                 </back-matter>
             </x:expect>
         </x:scenario>
+        <x:scenario label="Testing keep instructions: Three resources with same uuid, where">
+            <x:scenario label="1st has keep instruction and others do not">
+                <x:context>
+                    <catalog>
+                        <selection uuid="xyz-tiny_catalog">
+                            <control id="x1"><title>Control X1</title></control>
+                            <back-matter>
+                                <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                                    <title>Ref BBB, first</title>
+                                    <prop name="keep" value="always"/>
+                                </resource>
+                            </back-matter>
+                        </selection>
+                        <selection uuid="xyz-tiny_catalog2">
+                            <control id="x2"><title>Control X2</title></control>
+                            <back-matter>
+                                <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                                    <title>Ref BBB, second</title>
+                                </resource>
+                            </back-matter>
+                        </selection>
+                        <back-matter>
+                            <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                                <title>Ref BBB, third</title>
+                            </resource>
+                        </back-matter>
+                    </catalog>
+                </x:context>
+                <x:call template="combine-back-matter"/>
+                <x:expect label="back-matter with 1st and 3rd items. 2nd item was superseded by 3rd item.">
+                    <back-matter>
+                        <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                            <title>Ref BBB, first</title>
+                            <prop name="keep" value="always"/>
+                        </resource>
+                        <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                            <title>Ref BBB, third</title>
+                        </resource>
+                    </back-matter>
+                </x:expect>
+            </x:scenario>
+            <x:scenario label="1st and 3rd have keep instruction and 2nd does not">
+                <x:context>
+                    <catalog>
+                        <selection uuid="xyz-tiny_catalog">
+                            <control id="x1"><title>Control X1</title></control>
+                            <back-matter>
+                                <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                                    <title>Ref BBB, first</title>
+                                    <prop name="keep" value="always"/>
+                                </resource>
+                            </back-matter>
+                        </selection>
+                        <selection uuid="xyz-tiny_catalog2">
+                            <control id="x2"><title>Control X2</title></control>
+                            <back-matter>
+                                <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                                    <title>Ref BBB, second</title>
+                                </resource>
+                            </back-matter>
+                        </selection>
+                        <back-matter>
+                            <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                                <title>Ref BBB, third</title>
+                                <prop name="keep" value="always"/>
+                            </resource>
+                        </back-matter>
+                    </catalog>
+                </x:context>
+                <x:call template="combine-back-matter"/>
+                <x:expect label="back-matter with last item only.">
+                    <back-matter>
+                        <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                            <title>Ref BBB, third</title>
+                            <prop name="keep" value="always"/>
+                        </resource>
+                    </back-matter>
+                </x:expect>
+            </x:scenario>
+            <x:scenario label="1st and 2nd have keep instruction and 3rd does not">
+                <x:context>
+                    <catalog>
+                        <selection uuid="xyz-tiny_catalog">
+                            <control id="x1"><title>Control X1</title></control>
+                            <back-matter>
+                                <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                                    <title>Ref BBB, first</title>
+                                    <prop name="keep" value="always"/>
+                                </resource>
+                            </back-matter>
+                        </selection>
+                        <selection uuid="xyz-tiny_catalog2">
+                            <control id="x2"><title>Control X2</title></control>
+                            <back-matter>
+                                <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                                    <title>Ref BBB, second</title>
+                                    <prop name="keep" value="always"/>
+                                </resource>
+                            </back-matter>
+                        </selection>
+                        <back-matter>
+                            <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                                <title>Ref BBB, third</title>
+                            </resource>
+                        </back-matter>
+                    </catalog>
+                </x:context>
+                <x:call template="combine-back-matter"/>
+                <x:expect label="back-matter with 2nd and 3rd items. 1st item was superseded by 2nd item.">
+                    <back-matter>
+                        <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                            <title>Ref BBB, second</title>
+                            <prop name="keep" value="always"/>
+                        </resource>
+                        <resource uuid="0050231f-4fd0-43d6-8fa0-431367cd83e2">
+                            <title>Ref BBB, third</title>
+                        </resource>
+                    </back-matter>
+                </x:expect>
+            </x:scenario>
+        </x:scenario>
         <x:scenario label="No back matter in input context">
             <x:context>
                 <catalog>


### PR DESCRIPTION
If a back-matter resource has a keep instruction, the spec
requirement "req-backmatter-keep" says not to replace the
resource unless a later one also has a keep instruction.

# Committer Notes

This pull request fixes a bug I noticed while working on #1377. If the merge phase replaces a resource having a child element `<prop name="keep" value="always"/>` with a resource that does not, then the finish phase cannot follow the specification's requirement "req-backmatter-keep".

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
