### PR TITLE
Corrected mapping `id-ref` documentation

### DIFF
--- a/src/metaschema/oscal_mapping-common_metaschema.xml
+++ b/src/metaschema/oscal_mapping-common_metaschema.xml
@@ -73,8 +73,8 @@
             </constraint>
         </define-flag>
         <define-flag name="id-ref" as-type="string" required="yes">
-            <formal-name>Subject Type</formal-name>
-            <description>The semantic type of the subject.</description>
+            <formal-name>Subject Identifier Reference</formal-name>
+            <description>A reference to an identified subject that is of the specified <code>type</code>.</description>
         </define-flag>
         <model>
             <assembly ref="property" max-occurs="unbounded">


### PR DESCRIPTION
# Committer Notes

Fixed a documentation error caused by copy-and-paste in the mapping model.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~~[ ] Have you written new tests for your core changes, as applicable?~~
- ~~[ ] Have you included examples of how to use your new feature(s)?~~
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
