### PR TITLE
Add assessment-assets assembly to POAM model. #1291

### DIFF
--- a/src/metaschema/oscal_poam_metaschema.xml
+++ b/src/metaschema/oscal_poam_metaschema.xml
@@ -72,6 +72,12 @@
                     <p>Used to add any inventory-items, not defined via the System Security Plan (AR-&gt;AP-&gt;SSP)</p>
                 </remarks>
             </assembly>
+            <!-- CHANGED: added to specify components and assessment-platforms from the assessment -->
+            <assembly ref="assessment-assets" min-occurs="0" max-occurs="1">
+                <remarks>
+                    <p>Specifies components or assessment-platforms used in the assessment.</p>
+                </remarks>
+            </assembly>            
             <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
         </model>
         <constraint>


### PR DESCRIPTION
Added assembly to support assessment assets.  
(Model already imports from `oscal_assessment-common_metaschema.xml`)

Expected model change:
```
plan-of-action-and-milestones:
  local-definitions [0 or 1]: {
    components [0 or 1]: [ … ],
    inventory-items [0 or 1]: [ … ],
+   assessment-assets [0 or 1]: [ … ],
    remarks [0 or 1]: markup-multiline,
  },
```