### PR TITLE
Profile alter model adjustments

### DIFF
--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -307,7 +307,7 @@
                                     <formal-name>Addition</formal-name>
                                     <description>Specifies contents to be added into controls, in resolution</description>
                                     <group-as name="adds" in-json="ARRAY"/>
-                                    <define-flag name="position" as-type="token" default="">
+                                    <define-flag name="position" as-type="token" default="ending">
                                           <formal-name>Position</formal-name>
                                           <description>Where to add the new content with respect to the targeted element (beside it or inside it)</description>
                                           <constraint>

--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -258,9 +258,108 @@
                               </choice>
                         </model>
                   </define-assembly>
-                  <assembly ref="alter" max-occurs="unbounded">
+                  <define-assembly name="alter" max-occurs="unbounded">
+                        <formal-name>Alteration</formal-name>
+                        <description>An Alter element specifies changes to be made to an included control when a profile is resolved.</description>
                         <group-as name="alters" in-json="ARRAY"/>
-                  </assembly>
+                        <flag ref="control-id" required="yes"/>
+                        <model>
+                              <define-assembly name="remove" max-occurs="unbounded">
+                                    <formal-name>Removal</formal-name>
+                                    <description>Specifies objects to be removed from a control based on specific aspects of the object that must all match.</description>
+                                    <group-as name="removes" in-json="ARRAY"/>
+                                    <define-flag name="by-name" as-type="token">
+                                          <formal-name>Reference by (assigned) name</formal-name>
+                                          <description>Identify items to remove by matching their assigned name</description>
+                                    </define-flag>
+                                    <define-flag name="by-class" as-type="token">
+                                          <formal-name>Reference by class</formal-name>
+                                          <description>Identify items to remove by matching their <code>class</code>.</description>
+                                    </define-flag>
+                                    <define-flag name="by-id" as-type="token">
+                                          <formal-name>Reference by ID</formal-name>
+                                          <description>Identify items to remove indicated by their <code>id</code>.</description>
+                                    </define-flag>
+                                    <define-flag name="by-item-name" as-type="token">
+                                          <formal-name>Item Name Reference</formal-name>
+                                          <description>Identify items to remove by the name of the item's information element name, e.g. <code>title</code> or <code>prop</code></description>
+                                          <constraint>
+                                                <allowed-values>
+                                                      <enum value="param">A descendant parameter and all of its descendants.</enum>
+                                                      <enum value="prop">A descendant property and all of its descendants.</enum>
+                                                      <enum value="link">A descendant link and all of its descendants.</enum>
+                                                      <enum value="part">A descendant parameter and all of its descendants.</enum>
+                                                      <enum value="mapping">A descendant mapping and all of its descendants.</enum>
+                                                      <enum value="map">A descendant mapping entry (map) and all of its descendants.</enum>
+                                                </allowed-values>
+                                          </constraint>
+                                    </define-flag>
+                                    <define-flag name="by-ns" as-type="token">
+                                          <formal-name>Item Namespace Reference</formal-name>
+                                          <description>Identify items to remove by the item's <code>ns</code>, which is the namespace associated with a <code>part</code>, or <code>prop</code>.</description>
+                                    </define-flag>
+                                    <remarks>
+                                          <p>Use <code>by-name</code>, <code>by-class</code>, <code>by-id</code> or <code>by-item-name</code> to indicate class tokens or ID reference, or the formal name, of the component to be removed or erased from a control, when a catalog is resolved. The control affected is indicated by the pointer on the removal's parent (containing) <code>alter</code> element.</p>
+                                          <p>To change an element, use <code>remove</code> to remove the element, then <code>add</code> to add it back again with changes.</p>
+                                    </remarks>
+                              </define-assembly>
+                              <define-assembly name="add" max-occurs="unbounded">
+                                    <formal-name>Addition</formal-name>
+                                    <description>Specifies contents to be added into controls, in resolution</description>
+                                    <group-as name="adds" in-json="ARRAY"/>
+                                    <define-flag name="position" as-type="token" default="">
+                                          <formal-name>Position</formal-name>
+                                          <description>Where to add the new content with respect to the targeted element (beside it or inside it)</description>
+                                          <constraint>
+                                                <allowed-values>
+                                                      <enum value="before">Preceding the by-id target</enum>
+                                                      <enum value="after">Following the by-id target</enum>
+                                                      <enum value="starting">Inside the control or by-id target, at the start</enum>
+                                                      <enum value="ending">Inside the control or by-id target, at the end</enum>
+                                                </allowed-values>
+                                          </constraint>
+                                    </define-flag>
+                                    <define-flag name="by-id" as-type="token">
+                                          <formal-name>Reference by ID</formal-name>
+                                          <description>Target location of the addition.</description>
+                                    </define-flag>
+                                    <model>
+                                          <define-field name="title" as-type="markup-line">
+                                                <formal-name>Title Change</formal-name>
+                                                <description>A name given to the control, which may be used by a tool for display and navigation.</description>
+                                          </define-field>
+                                          <assembly ref="parameter" max-occurs="unbounded">
+                                                <!-- CHANGED: "parameters" to "params" -->
+                                                <group-as name="params" in-json="ARRAY"/>
+                                          </assembly>
+                                          <assembly ref="property" max-occurs="unbounded">
+                                                <group-as name="props" in-json="ARRAY"/>
+                                          </assembly>
+                                          <assembly ref="link" max-occurs="unbounded">
+                                                <group-as name="links" in-json="ARRAY"/>
+                                          </assembly>
+                                          <assembly ref="part" max-occurs="unbounded">
+                                                <group-as name="parts" in-json="ARRAY"/>
+                                          </assembly>
+                                    </model>
+                                    <constraint>
+                                          <!-- CHANGE: added allowed values for a property/@name -->
+                                          <allowed-values target="prop/@name" allow-other="yes">
+                                                &allowed-values-control-group-property-name;
+                                          </allowed-values>
+                                    </constraint>
+                                    <remarks>
+                                          <p>When no <code>by-id</code> is given, the addition is inserted into the control targeted by the alteration at the start or end as indicated by <code>position</code>. Only <code>position</code> values of "starting" or "ending" are permitted when there is no <code>by-id</code>.</p>
+                                          <p><code>by-id</code>, when given, should indicate, by its ID, an element inside the control to serve as the anchor point for the addition. In this case, <code>position</code> value may be any of the permitted values.</p>
+                                    </remarks>
+                              </define-assembly>
+                        </model>
+                        <remarks>
+                              <p>Use <code>@control-id</code> to indicate the scope of alteration.</p>
+                              <p>It is an error for two <code>alter</code> elements to apply to the same control. In practice, multiple alterations can be applied (together), but it creates confusion.</p>
+                              <p>At present, no provision is made for altering many controls at once (for example, to systematically remove properties or add global properties); extending this element to match multiple control IDs could provide for this.</p>
+                        </remarks>
+                  </define-assembly>
             </model>
             <constraint>
                   <is-unique id="unique-profile-modify-set-parameter" target="set-parameter">
@@ -326,105 +425,6 @@
             </model>
             <remarks>
                   <p>If <code>with-child-controls</code> is <q>yes</q> on the call to a control, no sibling <code>call</code>elements need to be used to call any controls appearing within it. Since generally, this is how control enhancements are represented (as controls within controls), this provides a way to include controls with all their dependent controls (enhancements) without having to call them individually.</p>
-            </remarks>
-      </define-assembly>
-      <define-assembly name="alter">
-            <formal-name>Alteration</formal-name>
-            <description>An Alter element specifies changes to be made to an included control when a profile is resolved.</description>
-            <flag ref="control-id" required="yes"/>
-            <model>
-                  <assembly ref="remove" max-occurs="unbounded">
-                        <group-as name="removes" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="add" max-occurs="unbounded">
-                        <group-as name="adds" in-json="ARRAY"/>
-                  </assembly>
-            </model>
-            <remarks>
-                  <p>Use <code>@control-id</code> to indicate the scope of alteration.</p>
-                  <p>It is an error for two <code>alter</code> elements to apply to the same control. In practice, multiple alterations can be applied (together), but it creates confusion.</p>
-                  <p>At present, no provision is made for altering many controls at once (for example, to systematically remove properties or add global properties); extending this element to match multiple control IDs could provide for this.</p>
-            </remarks>
-      </define-assembly>
-      <define-assembly name="remove">
-            <formal-name>Removal</formal-name>
-            <description>Specifies objects to be removed from a control based on specific aspects of the object that must all match.</description>
-            <define-flag name="by-name" as-type="token">
-                  <formal-name>Reference by (assigned) name</formal-name>
-                  <description>Identify items to remove by matching their assigned name</description>
-            </define-flag>
-            <define-flag name="by-class" as-type="token">
-                  <formal-name>Reference by class</formal-name>
-                  <description>Identify items to remove by matching their <code>class</code>.</description>
-            </define-flag>
-            <define-flag name="by-id" as-type="token">
-                  <formal-name>Reference by ID</formal-name>
-                  <description>Identify items to remove indicated by their <code>id</code>.</description>
-            </define-flag>
-            <define-flag name="by-item-name" as-type="token">
-                  <formal-name>Item Name Reference</formal-name>
-                  <description>Identify items to remove by the name of the item's information element name, e.g. <code>title</code> or <code>prop</code></description>
-            </define-flag>
-            <define-flag name="by-ns" as-type="token">
-                  <formal-name>Item Namespace Reference</formal-name>
-                  <description>Identify items to remove by the item's <code>ns</code>, which is the namespace associated with a <code>part</code>, or <code>prop</code>.</description>
-            </define-flag>
-            <model>
-                  <field ref="remarks" in-xml="WITH_WRAPPER"/>
-            </model>
-            <remarks>
-                  <p>Use <code>name-ref</code>, <code>class-ref</code>, <code>id-ref</code> or <code>generic-identifier</code> to indicate class tokens or ID reference, or the formal name, of the component to be removed or erased from a control, when a catalog is resolved. The control affected is indicated by the pointer on the removal's parent (containing) <code>alter</code> element.</p>
-                  <p>To change an element, use <code>remove</code> to remove the element, then <code>add</code> to add it back again with changes.</p>
-            </remarks>
-      </define-assembly>
-      <define-assembly name="add">
-            <formal-name>Addition</formal-name>
-            <description>Specifies contents to be added into controls, in resolution</description>
-            <define-flag name="position" as-type="token">
-                  <formal-name>Position</formal-name>
-                  <description>Where to add the new content with respect to the targeted element (beside it or inside it)</description>
-                  <constraint>
-                        <allowed-values>
-                              <enum value="before">Preceding the id-ref target</enum>
-                              <enum value="after">Following the id-ref target</enum>
-                              <enum value="starting">Inside the control or id-ref target, at the start</enum>
-                              <enum value="ending">Inside the control or id-ref target, at the end</enum>
-                        </allowed-values>
-                  </constraint>
-            </define-flag>
-            <define-flag name="by-id" as-type="token">
-                  <formal-name>Reference by ID</formal-name>
-                  <description>Target location of the addition.</description>
-            </define-flag>
-            <model>
-                  <define-field name="title" as-type="markup-line">
-                        <formal-name>Title Change</formal-name>
-                        <description>A name given to the control, which may be used by a tool for display and navigation.</description>
-                  </define-field>
-                  <assembly ref="parameter" max-occurs="unbounded">
-                        <!-- CHANGED: "parameters" to "params" -->
-                        <group-as name="params" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="property" max-occurs="unbounded">
-                        <group-as name="props" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="link" max-occurs="unbounded">
-                        <group-as name="links" in-json="ARRAY"/>
-                  </assembly>
-                  <assembly ref="part" max-occurs="unbounded">
-                        <group-as name="parts" in-json="ARRAY"/>
-                  </assembly>
-                  <field ref="remarks" in-xml="WITH_WRAPPER"/>
-            </model>
-            <constraint>
-                  <!-- CHANGE: added allowed values for a property/@name -->
-                  <allowed-values target="prop/@name" allow-other="yes">
-            &allowed-values-control-group-property-name;
-                  </allowed-values>
-            </constraint>
-            <remarks>
-                  <p>When no <code>id-ref</code> is given, the addition is inserted into the control targeted by the alteration at the start or end as indicated by <code>position</code>. Only <code>position</code> values of "starting" or "ending" are permitted when there is no <code>id-ref</code>.</p>
-                  <p><code>id-ref</code>, when given, should indicate, by its ID, an element inside the control to serve as the anchor point for the addition. In this case, <code>position</code> value may be any of the permitted values.</p>
             </remarks>
       </define-assembly>
       <define-flag as-type="token" name="with-child-controls">

--- a/src/specifications/profile-resolution/profile-resolution-examples/catalogs/abc-simple_catalog.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/catalogs/abc-simple_catalog.xml
@@ -20,7 +20,7 @@
          </param>
          <prop name="label" value="first"/>
          <part name="statement" id="a1-stmt">
-            <p>A1 aaaaa aaaaaaaaaa</p>
+            <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
          </part>
       </control>
       <control id="a2">
@@ -37,7 +37,7 @@
          </param>
          <prop name="label" value="third"/>
          <part name="statement" id="a3-stmt">
-            <p>A3 aaaaa aaaaaaaaaa</p>
+            <p>A3 aaaaa <insert type="param" id-ref="a3_prm1"/> aaaaaaaaaa</p>
          </part>
       </control>
    </group>

--- a/src/specifications/profile-resolution/profile-resolution-examples/modify-adds_profile.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/modify-adds_profile.xml
@@ -34,16 +34,35 @@
             </description>
          </constraint>
       </set-parameter>
-      <alter control-id="a1">
+      <alter control-id="a1"><!-- OK control -->
          <add position="starting" by-id="a1">
             <prop name="CORE" ns="https://fedramp.gov/ns/oscal" value="core"/>
          </add>
-         <add position="starting" by-id="a1-stmt">
+         <add position="starting" by-id="a1_prm1"><!-- OK parameter -->
+            <prop name="annotated" ns="https://fedramp.gov/ns/oscal" value="param-prop"/>
+         </add>
+         <add position="before" by-id="a1_prm1"><!-- parameter child -->
+         	<param id="new_prm">
+         	   <prop name="annotated" ns="https://fedramp.gov/ns/oscal" value="new-param"/>
+         	   <label>A1 Parameter New</label>
+         	</param>
+         </add>
+         <add position="starting" by-id="a1-stmt"><!-- part -->
             <prop name="conformity"
                   ns="https://fedramp.gov/ns/oscal"
                   value="assessment-objective"/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
          </add>
+         <add position="after" by-id="a1-stmt"><!-- part child -->
+         	<part name="statement" id="new-part">
+         	   <p>A1 bbbbb <insert type="param" id-ref="new_prm"/> bbbbb</p>
+         	</part>
+         </add>
+         <add position="ending" by-id="a1-stmt"><!-- part child -->
+            <part name="statement" id="new-part2">
+	           <p>A1 ccc <insert type="param" id-ref="new_prm"/> ccc</p>
+	        </part>
+	     </add>
       </alter>
    </modify>
    <back-matter>

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/base-test_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/base-test_profile_RESOLVED.xml
@@ -11,9 +11,12 @@
    </metadata>
    <control id="a1">
       <title>Control A1</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
       <prop name="label" value="first"/>
       <part name="statement" id="a1-stmt">
-         <p>A1 aaaaa aaaaaaaaaa</p>
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
       </part>
    </control>
    <control id="b1">

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/base2-test_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/base2-test_profile_RESOLVED.xml
@@ -11,9 +11,12 @@
    </metadata>
    <control id="a1">
       <title>Control A1</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
       <prop name="label" value="first"/>
       <part name="statement" id="a1-stmt">
-         <p>A1 aaaaa aaaaaaaaaa</p>
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
       </part>
    </control>
    <control id="b1">

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/exclude-call-test_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/exclude-call-test_profile_RESOLVED.xml
@@ -18,9 +18,12 @@
    </control>
    <control id="a3">
       <title>Control A3</title>
+      <param id="a3_prm1">
+         <label>A3 Parameter 1</label>
+      </param>
       <prop name="label" value="third"/>
       <part name="statement" id="a3-stmt">
-         <p>A3 aaaaa aaaaaaaaaa</p>
+         <p>A3 aaaaa <insert type="param" id-ref="a3_prm1"/> aaaaaaaaaa</p>
       </part>
    </control>
    <control id="b1">

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/import-twice_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/import-twice_profile_RESOLVED.xml
@@ -11,9 +11,12 @@
    </metadata>
    <control id="a1">
       <title>Control A1</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
       <prop name="label" value="first"/>
       <part name="statement" id="a1-stmt">
-         <p>A1 aaaaa aaaaaaaaaa</p>
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
       </part>
    </control>
    <control id="b1">

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/include-call-with-children-test_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/include-call-with-children-test_profile_RESOLVED.xml
@@ -11,9 +11,12 @@
    </metadata>
    <control id="a1">
       <title>Control A1</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
       <prop name="label" value="first"/>
       <part name="statement" id="a1-stmt">
-         <p>A1 aaaaa aaaaaaaaaa</p>
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
       </part>
    </control>
    <control id="b1">

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/merge-implicit-keep_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/merge-implicit-keep_profile_RESOLVED.xml
@@ -11,9 +11,12 @@
    </metadata>
    <control id="a1">
       <title>Control A1</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
       <prop name="label" value="first"/>
       <part name="statement" id="a1-stmt">
-         <p>A1 aaaaa aaaaaaaaaa</p>
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
       </part>
    </control>
    <control id="b1">
@@ -25,9 +28,12 @@
    </control>
    <control id="a1">
       <title>Control A1</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
       <prop name="label" value="first"/>
       <part name="statement" id="a1-stmt">
-         <p>A1 aaaaa aaaaaaaaaa</p>
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
       </part>
    </control>
    <control id="b1">

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/modify-adds_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/modify-adds_profile_RESOLVED.xml
@@ -13,7 +13,12 @@
       <title>Group A of C</title>
       <control id="a1">
          <title>Control A1</title>
+         <param id="new_prm">
+            <prop name="annotated" ns="https://fedramp.gov/ns/oscal" value="new-param"/>
+            <label>A1 Parameter New</label>
+       	 </param>
          <param id="a1_prm1">
+            <prop name="annotated" ns="https://fedramp.gov/ns/oscal" value="param-prop"/>
             <label>A1 Parameter 1</label>
             <constraint>
                <description>
@@ -22,13 +27,19 @@
             </constraint>
          </param>
          <prop name="CORE" ns="https://fedramp.gov/ns/oscal" value="core"/>
-         <prop name="place" value="first"/>
+         <prop name="label" value="first"/>
          <part name="statement" id="a1-stmt">
             <prop name="conformity"
                   ns="https://fedramp.gov/ns/oscal"
                   value="assessment-objective"/>
             <prop name="method" class="fedramp" value="EXAMINE"/>
-            <p>A1 aaaaa aaaaaaaaaa</p>
+            <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
+            <part name="statement" id="new-part2">
+	           <p>A1 ccc <insert type="param" id-ref="new_prm"/> ccc</p>
+	        </part>
+         </part>
+         <part name="statement" id="new-part">
+            <p>A1 bbbbb <insert type="param" id-ref="new_prm"/> bbbbb</p>
          </part>
       </control>
       <control id="a3">
@@ -41,9 +52,9 @@
                </description>
             </constraint>
          </param>
-         <prop name="place" value="third"/>
+         <prop name="label" value="third"/>
          <part name="statement" id="a3-stmt">
-            <p>A3 aaaaa aaaaaaaaaa</p>
+            <p>A3 aaaaa <insert type="param" id-ref="a3_prm1"/> aaaaaaaaaa</p>
          </part>
       </control>
    </group>

--- a/src/specifications/profile-resolution/profile-resolution-specml.xml
+++ b/src/specifications/profile-resolution/profile-resolution-specml.xml
@@ -1055,9 +1055,9 @@ intermediate:
           <p><req level="must" id="req-modify-set-param-objects1">For the following objects inside the source: class, depends-on, label, usage, values, select; the object MUST be copied into the target from the source, first removing any existing objects with the same name.</req></p>
         </li>
         <li>
-          <p><req level="must" id="req-modify-set-param-objects2">For the following objects inside the source: props, <src>links</src>, <src>constraints</src>, <src>guidelines</src>; the contents of the object MUST be added to the contents of the target object of the same name. If no such object exists in the target, it is created.</req></p>
+          <p><req level="must" id="req-modify-set-param-objects2">For the following objects inside the source: <src>prop</src>, <src>link</src>, <src>constraint</src>, <src>guideline</src>; the contents of the object MUST be added to the contents of the target object of the same name. If no such object exists in the target, it is created.</req></p>
         </li>
-        <li> <p><req level="must" id="req-modify-set-param-objects3">For the following objects inside the source: <src>prop</src>, <src>link</src>; the object MUST be copied into the target from the source, first removing any existing objects with the same distinctive ID. (<xref rid="id"></xref>).</req></p></li>
+        <li> <p><req level="must" id="req-modify-set-param-objects3">For the following objects inside the source: <src>prop</src>, <src>link</src>; the object MUST be copied into the target from the source, first removing any existing objects with the same distinctive ID. (<xref rid="id"/>).</req></p></li>
         <li>
           <p><req level="must" id="req-modify-param-multi">If more than one
             <src>set-parameter</src> directive is given for the same parameter, all MUST BE applied, in the sequence given in the profile.</req>


### PR DESCRIPTION


# Committer Notes

Work towards addressing usnistgov/liboscal-java#46.

- Adjusted the profile metaschema to refactor the alter assemblies in a backwards-compatible way.

  - Enumerated the set of target item types for remove.
  - Fixed references to use current `by-` syntax.
- Adjusted unit tests to support better add/remove testing.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
