### PR TITLE
Support additional control-origination props #784

### DIFF
--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -705,8 +705,8 @@
       <field ref="remarks" in-xml="WITH_WRAPPER"/>
     </model>
     <constraint>
-      <allowed-values target="prop/@name" allow-other="yes">
-        <enum value="control-origination">Identifies the source of the implemented control.</enum>
+      <allowed-values target="(.|statement|.//by-component)/prop/@name" allow-other="yes">
+        <enum value="control-origination">Identifies the source of the implemented control.  Any <code>control-origination</code> prop defined in a child context will override the parent value.</enum>
       </allowed-values>
       <allowed-values target="prop[@name='control-origination']/@value">
         <enum value="organization">The control is implemented by the organization owning the system, but is not specific to the system itself.</enum>


### PR DESCRIPTION
# Committer Notes

Based on the request in #784, extended the xpath to include control-origination props for:

```
implemented-requirement/prop
implemented-requirement/by-component/prop
implemented-requirement/statement/prop
implemented-requirement/statement/by-component/prop
```

The updated xpath selected the following paths from my test case:
```
" /system-security-plan[1]/control-implementation[1]/implemented-requirement[1]/prop[1]/@name",
" /system-security-plan[1]/control-implementation[1]/implemented-requirement[1]/prop[2]/@name",
" /system-security-plan[1]/control-implementation[1]/implemented-requirement[1]/prop[3]/@name",
" /system-security-plan[1]/control-implementation[1]/implemented-requirement[1]/statement[1]/prop[1]/@name",
" /system-security-plan[1]/control-implementation[1]/implemented-requirement[1]/statement[2]/by-component[1]/prop[1]/@name",
" /system-security-plan[1]/control-implementation[1]/implemented-requirement[2]/prop[1]/@name",
" /system-security-plan[1]/control-implementation[1]/implemented-requirement[2]/prop[2]/@name",
" /system-security-plan[1]/control-implementation[1]/implemented-requirement[2]/prop[3]/@name",
" /system-security-plan[1]/control-implementation[1]/implemented-requirement[2]/by-component[1]/prop[1]/@name",
```
A note was added that the child context will override the parent `control-origination`.
