### PR TITLE
Add back specifying author for GHA commits

### DIFF
--- a/.github/workflows/workflow-generate-metaschema-resources.yml
+++ b/.github/workflows/workflow-generate-metaschema-resources.yml
@@ -134,4 +134,7 @@ jobs:
         repository: ${{ env.CHECKOUT_PATH }}
         file_pattern: xml json
         skip_dirty_check: false
+        commit_user_name: OSCAL GitHub Actions Bot
+        commit_user_email: oscal@nist.gov
+        commit_author: OSCAL GitHub Actions Bot <oscal@nist.gov>
         commit_message: Publishing generated metaschema resources [ci skip]

--- a/.github/workflows/workflow-generate-website-reference.yml
+++ b/.github/workflows/workflow-generate-website-reference.yml
@@ -158,4 +158,7 @@ jobs:
         file_pattern: docs
         # push_options: --force-with-lease
         skip_dirty_check: false
+        commit_user_name: OSCAL GitHub Actions Bot
+        commit_user_email: oscal@nist.gov
+        commit_author: OSCAL GitHub Actions Bot <oscal@nist.gov>
         commit_message: Pushing generated website pages [ci skip]

--- a/.github/workflows/workflow-generate-website.yml
+++ b/.github/workflows/workflow-generate-website.yml
@@ -175,4 +175,7 @@ jobs:
         enable_jekyll: false
         publish_dir: ./docs/public
         publish_branch: nist-pages
+        commit_user_name: OSCAL GitHub Actions Bot
+        commit_user_email: oscal@nist.gov
+        commit_author: OSCAL GitHub Actions Bot <oscal@nist.gov>
         commit_message: Deploying website [ci deploy skip]


### PR DESCRIPTION
# Committer Notes

For Metaschema generation, reference model docs, and website generation, we removed prior consistent use of a GitHub Actions Bot user, as opposed to the default. This made artifact auto-commits harder to notice in the git log and GitHub UI.

This may partially satisfy usnistgov/OSCAL#1448.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
