### PR TITLE
Added `--exclude-mail` arg to linkchecker workflow (cherry-picked into `develop`)

### DIFF
--- a/.github/workflows/workflow-validate-website-content.yml
+++ b/.github/workflows/workflow-validate-website-content.yml
@@ -35,7 +35,7 @@ jobs:
       id: linkchecker
       uses: lycheeverse/lychee-action@4a5af7cd2958a2282cefbd9c10f63bdb89982d76
       with:
-        args: --exclude-file ./build/config/.lycheeignore --verbose --no-progress --accept 200,206,429 './published/**/*.html'
+        args: --exclude-file ./build/config/.lycheeignore --verbose --no-progress --accept 200,206,429 './published/**/*.html' --exclude-mail
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create issue if bad links detected


### PR DESCRIPTION
Co-authored-by: AJ Stein <alexander.stein@nist.gov>

Cherry-pick the commit from PR #1507 to merge into main

# Committer Notes

{Please provide a brief description of what this PR accomplishes. Be sure to reference any issues addressed. If the PR is a work-in-progress submitted for early review, please include [WIP] at the beginning of the title or mark the PR as DRAFT.}

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
