### PR TITLE
Update outdated links in Markdown files tripping link checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The NIST team is also maintaining **OSCAL content** that is updated to the lates
 
 - The [NIST SP 800-53 revision 5 catalog](https://github.com/usnistgov/oscal-content/tree/main/nist.gov/SP800-53/rev5) and the security and privacy [NIST SP 800-53B baselines](https://github.com/usnistgov/oscal-content/tree/main/nist.gov/SP800-53/rev5).
 - The [NIST SP 800-53 revision 4 catalog](https://github.com/usnistgov/oscal-content/tree/main/nist.gov/SP800-53/rev4) and the [three NIST SP 800-53 revision 4 baselines](https://github.com/usnistgov/oscal-content/tree/main/nist.gov/SP800-53/rev4).
-- The [FedRAMP SP 800-53 revision 4 baselines](https://github.com/GSA/fedramp-automation/tree/master/dist/content/baselines/rev4).
+- The [FedRAMP SP 800-53 revision 4 baselines](https://github.com/GSA/fedramp-automation/tree/master/dist/content/rev4/baselines).
 
 All of this OSCAL content is provided in XML, JSON and YAML formats.
 

--- a/content/fedramp.gov/README.md
+++ b/content/fedramp.gov/README.md
@@ -1,3 +1,3 @@
 # Content Moved
 
-All OSCAL FedRAMP content files have been moved to the [OSCAL content GitHub repository](https://github.com/GSA/fedramp-automation/tree/master/dist/content/baselines).
+All OSCAL FedRAMP content files have been moved to the [OSCAL content GitHub repository](https://github.com/GSA/fedramp-automation/tree/master/dist/content/rev4/baselines).


### PR DESCRIPTION
# Committer Notes

Update FedRAMP GH links to updated paths, fixes usnistgov/OSCAL#1523.

See last nightly link checker run for more details via URL below.

https://github.com/usnistgov/OSCAL/actions/runs/3359592310/jobs/5567773731

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- ~Have you added an explanation of what your changes do and why you'd like us to include them?~
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
