### PR TITLE
Fix expected content of resolving merge-keep_profile.xml

### DIFF
--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/merge-keep_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/merge-keep_profile_RESOLVED.xml
@@ -14,14 +14,14 @@
       <param id="a1_prm1">
          <label>A1 Parameter 1</label>
       </param>
-      <prop name="place" value="first"/>
+      <prop name="label" value="first"/>
       <part name="statement" id="a1-stmt">
-         <p>A1 aaaaa aaaaaaaaaa</p>
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
       </part>
    </control>
    <control id="b1">
       <title>Control B1</title>
-      <prop name="place" value="fourth"/>
+      <prop name="label" value="fourth"/>
       <part name="statement" id="b1-stmt">
          <p>B1 bbbb bbbbbbb.</p>
       </part>
@@ -31,14 +31,14 @@
       <param id="a1_prm1">
          <label>A1 Parameter 1</label>
       </param>
-      <prop name="place" value="first"/>
+      <prop name="label" value="first"/>
       <part name="statement" id="a1-stmt">
-         <p>A1 aaaaa aaaaaaaaaa</p>
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
       </part>
    </control>
    <control id="b1">
       <title>Control B1</title>
-      <prop name="place" value="fourth"/>
+      <prop name="label" value="fourth"/>
       <part name="statement" id="b1-stmt">
          <p>B1 bbbb bbbbbbb.</p>
       </part>


### PR DESCRIPTION
# Committer Notes

This pull request fixes one of the expected output files in the set of sample profiles. Based on the content of the catalog whose controls are being imported, the prop names should be "label" instead of "place" and the a1 statement paragraph should include `<insert>`.

I also noticed a debugging message I had left in the XSLT profile resolver code inadvertently with #1321, so I'm removing that message.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
