### PR TITLE
Fix CDEF Tutorial Link in CDEF Layers Overview Page

### DIFF
--- a/docs/content/concepts/layer/implementation/component-definition/_index.md
+++ b/docs/content/concepts/layer/implementation/component-definition/_index.md
@@ -100,7 +100,7 @@ OSCAL is designed to allow capture relevant details related to independent valid
 
 The following tutorials are provided that are related to the component definition model.
 
-- [Creating a Component Definition](/learn/tutorials/component-definition/): Covers creating a basic OSCAL component definition for a software product.
+- [Creating a Component Definition](/learn/tutorials/simple-component-definition/): Covers creating a basic OSCAL component definition for a software product.
 - [Representing Test Validation Information](/learn/tutorials/validation-modeling/): Explains how to represent test validation information (e.g., FIPS-140-2) for a component in an OSCAL component definition.
 
 ## Content Examples


### PR DESCRIPTION
# Committer Notes

Fix cdef tutorial URL for usnistgov/OSCAL#1557.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- ~Have you added an explanation of what your changes do and why you'd like us to include them?~
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
