### PR TITLE
Profile resolver bug fix for selected children of unselected parent

### DIFF
--- a/src/specifications/profile-resolution/profile-resolution-examples/catalogs/abc-multiple-children_catalog.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/catalogs/abc-multiple-children_catalog.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../example-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- Modified by conversion XSLT 2021-04-05T11:12:31.584-04:00 - RC2 OSCAL becomes RC3 OSCAL -->
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         uuid="6c5149e8-f3a6-437c-8035-025e9b5fc0bf"
+         xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 ../../../../../xml/schema/oscal_catalog_schema.xsd">
+   <metadata>
+      <title>Alphabet Catalog</title>
+      <last-modified>2020-05-30T14:51:41.185-04:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0-rc2</oscal-version>
+   </metadata>
+   <control id="a1">
+      <title>Control A1</title>
+      <prop name="label" value="first"/>
+      <part name="statement" id="a1-stmt">
+         <p>A1 ccccc cccccccccccccc.</p>
+      </part>
+      <control id="a1.a">
+         <title>Control A1-A</title>
+         <prop name="label" value="second"/>
+         <part name="statement" id="a1.a-stmt">
+            <p>A1 A ccccc cccccccccccccc.</p>
+         </part>
+      </control>
+      <control id="a1.b">
+         <title>Control A1-B</title>
+         <prop name="label" value="third"/>
+         <part name="statement" id="a1.b-stmt">
+            <p>A1 B ccccc cccccccccccccc.</p>
+         </part>
+      </control>
+      <control id="a1.c">
+         <title>Control A1-C</title>
+         <prop name="label" value="fourth"/>
+         <part name="statement" id="a1.c-stmt">
+            <p>A1 C ccccc cccccccccccccc.</p>
+         </part>
+      </control>
+   </control>
+</catalog>

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/without-parent_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/without-parent_profile_RESOLVED.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="00000000-0000-4000-B000-000000000000">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2022-12-26T16:13:57.7747599-05:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0</oscal-version>
+      <prop name="resolution-tool" value="some value"/>
+      <link rel="source-profile" href="../without-parent_profile.xml"/>
+   </metadata>
+   <control id="a1">
+      <title>Control A1</title>
+      <prop name="label" value="first"/>
+      <part name="statement" id="a1-stmt">
+         <p>A1 ccccc cccccccccccccc.</p>
+      </part>
+   </control>
+   <control id="a1.a">
+      <title>Control A1-A</title>
+      <prop name="label" value="second"/>
+      <part name="statement" id="a1.a-stmt">
+         <p>A1 A ccccc cccccccccccccc.</p>
+      </part>
+   </control>
+   <control id="a1.c">
+      <title>Control A1-C</title>
+      <prop name="label" value="fourth"/>
+      <part name="statement" id="a1.c-stmt">
+         <p>A1 C ccccc cccccccccccccc.</p>
+      </part>
+   </control>
+</catalog>

--- a/src/specifications/profile-resolution/profile-resolution-examples/without-parent_profile.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/without-parent_profile.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../example-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- Modified by conversion XSLT 2021-04-05T11:22:07.701-04:00 - RC2 OSCAL becomes RC3 OSCAL -->
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="cb1ec926-3441-458f-8cce-ea11308c9d37">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2020-05-30T14:39:35.84-04:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0</oscal-version>
+   </metadata>
+   <import href="catalogs/abc-multiple-children_catalog.xml">
+      <include-controls  with-parent-controls="no">
+         <with-id>a1.a</with-id>
+         <with-id>a1.c</with-id>
+      </include-controls>
+   </import>
+</profile>

--- a/src/utils/resolver-pipeline/select-or-custom-merge.xsl
+++ b/src/utils/resolver-pipeline/select-or-custom-merge.xsl
@@ -11,8 +11,9 @@
 
     <xsl:include href="oscal-profile-resolve-functions.xsl"/>
 
-    <!-- A control is included if it is selected by the provided import instruction -->
-    <xsl:template match="control" mode="o:select" as="element(o:control)?">
+    <!-- A control is included if it is selected by the provided import instruction. -->
+    <!-- Also, for a nonselected control, this template can return selected children. -->
+    <xsl:template match="control" mode="o:select" as="element(o:control)*">
         <xsl:param name="import-instruction" tunnel="yes" required="yes"/>
         <xsl:choose>
             <xsl:when test="o:selects($import-instruction,.)">
@@ -20,12 +21,12 @@
                     <xsl:call-template name="add-process-id"/>
                     <xsl:apply-templates mode="#current" select="node() | @*"/>
                 </xsl:copy>
-           </xsl:when>
-           <xsl:otherwise>
-               <!-- Visit child controls in case they are selected using
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- Visit child controls in case they are selected using
                    with-parent-controls="no". -->
-               <xsl:apply-templates mode="#current" select="control"/>
-           </xsl:otherwise>
+                <xsl:apply-templates mode="#current" select="control"/>
+            </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
 

--- a/src/utils/resolver-pipeline/testing/1_selected/select.xspec
+++ b/src/utils/resolver-pipeline/testing/1_selected/select.xspec
@@ -700,6 +700,20 @@
             </x:context>
             <x:expect label="Nothing" select="()"/>
         </x:scenario>
+        <x:scenario label="Control is not selected but its child controls are selected">
+            <!--Below, $import-instruction is an <import> element that
+                selects children a1.a and a1.c of the control with id="a1",
+                and the context node has id="a1". -->
+            <x:context mode="o:select"
+                select="doc($ov:filedir || '/catalogs/abc-multiple-children_catalog.xml')//o:control[@id='a1']">
+                <x:param name="import-instruction" tunnel="yes"
+                    select="(doc($ov:filedir || '/without-parent_profile.xml')//o:import)[1]"/>
+            </x:context>
+            <x:expect label="Copy of selected child control elements with opr:id inserted">
+                <control id="a1.a" opr:id="...">...</control>
+                <control id="a1.c" opr:id="...">...</control>
+            </x:expect>
+        </x:scenario>
     </x:scenario>
 
     <x:scenario label="Tests for match='param' mode='o:select' template">


### PR DESCRIPTION
# Committer Notes
This PR fixes a profile resolver bug I noticed, where a certain XSLT template needs to declare its return data type `as="element(o:control)*"` instead of `as="element(o:control)?"`. An unselected parent can have multiple children that are selected, so the data type must accommodate multiple elements.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.
