### PR TITLE
Profiler resolver support for importing another profile

### DIFF
--- a/src/specifications/profile-resolution/profile-resolution-examples/import-profile2_profile.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/import-profile2_profile.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../example-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- Modified by conversion XSLT 2021-04-05T11:22:09.051-04:00 - RC2 OSCAL becomes RC3 OSCAL -->
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="d36cab7c-4973-465a-b79f-6d26420fcf11">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2020-05-30T14:39:42.758-04:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0</oscal-version>
+   </metadata>
+   <import href="base-test_profile.xml">
+      <include-controls>
+         <with-id>a1</with-id>
+         <with-id>b1</with-id>
+         <with-id>c1</with-id>
+      </include-controls>
+   </import>
+   <modify>
+      <alter control-id="a1">
+         <add position="starting">
+            <prop name="target_child" ns="https://fedramp.gov/ns/oscal" value="starting"/>
+         </add>
+      </alter>
+   </modify>
+</profile>

--- a/src/specifications/profile-resolution/profile-resolution-examples/import-profile_profile.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/import-profile_profile.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../example-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- Modified by conversion XSLT 2021-04-05T11:22:09.051-04:00 - RC2 OSCAL becomes RC3 OSCAL -->
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="d36cab7c-4973-465a-b79f-6d26420fcf11">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2020-05-30T14:39:42.758-04:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0</oscal-version>
+   </metadata>
+   <import href="import-profile2_profile.xml">
+      <include-controls>
+         <with-id>a1</with-id>
+         <with-id>c1</with-id>
+      </include-controls>
+   </import>
+   <modify>
+      <alter control-id="a1">
+         <add position="starting">
+            <prop name="another_target_child" ns="https://fedramp.gov/ns/oscal" value="starting"/>
+         </add>
+      </alter>
+   </modify>
+</profile>

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/import-profile2_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/import-profile2_profile_RESOLVED.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="00000000-0000-4000-B000-000000000000">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2022-12-03T20:30:33.7568343-05:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0</oscal-version>
+      <prop name="resolution-tool" value="some value"/>
+      <link rel="source-profile" href="../import-profile2_profile.xml"/>
+   </metadata>
+   <control id="a1">
+      <title>Control A1</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
+      <prop name="target_child"
+            ns="https://fedramp.gov/ns/oscal"
+            value="starting"/>
+      <prop name="label" value="first"/>
+      <part name="statement" id="a1-stmt">
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
+      </part>
+   </control>
+   <control id="b1">
+      <title>Control B1</title>
+      <prop name="label" value="fourth"/>
+      <part name="statement" id="b1-stmt">
+         <p>B1 bbbb bbbbbbb.</p>
+      </part>
+   </control>
+   <control id="c1">
+      <title>Control C1</title>
+      <prop name="label" value="seventh"/>
+      <part name="statement" id="c1-stmt">
+         <p>C1 ccccc ccc ccccccccccccccccc.</p>
+      </part>
+   </control>
+</catalog>

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/import-profile_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/import-profile_profile_RESOLVED.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="00000000-0000-4000-B000-000000000000">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2022-12-03T20:30:29.3084831-05:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0</oscal-version>
+      <prop name="resolution-tool" value="some value"/>
+      <link rel="source-profile" href="../import-profile_profile.xml"/>
+   </metadata>
+   <control id="a1">
+      <title>Control A1</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
+      <prop name="another_target_child"
+            ns="https://fedramp.gov/ns/oscal"
+            value="starting"/>
+      <prop name="target_child"
+            ns="https://fedramp.gov/ns/oscal"
+            value="starting"/>
+      <prop name="label" value="first"/>
+      <part name="statement" id="a1-stmt">
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
+      </part>
+   </control>
+   <control id="c1">
+      <title>Control C1</title>
+      <prop name="label" value="seventh"/>
+      <part name="statement" id="c1-stmt">
+         <p>C1 ccccc ccc ccccccccccccccccc.</p>
+      </part>
+   </control>
+</catalog>

--- a/src/utils/resolver-pipeline/oscal-profile-RESOLVE.xsl
+++ b/src/utils/resolver-pipeline/oscal-profile-RESOLVE.xsl
@@ -50,6 +50,7 @@
     <xsl:variable name="louder" select="$trace = 'on'"/>
 
     <xsl:variable name="home" select="/"/>
+    <xsl:variable name="home-filename" select="$home/base-uri() => replace('.*/','')"/>
 
     <!-- If true, do not record profile URI in output catalog's source-profile
         metadata, due to privacy or security concerns. -->
@@ -72,7 +73,7 @@
              Each represents a stage in processing.
              The result of each processing step is passed to the next step as its input, until no steps are left. -->
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="yes"> RESOLVING PROFILE { base-uri($source) } </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="yes">RESOLVING PROFILE { document-uri($source) } </xsl:with-param>
         </xsl:call-template>
         <xsl:iterate select="$transformation-sequence/*">
             <xsl:param name="doc" select="$source" as="document-node()"/>
@@ -106,7 +107,7 @@
         <xsl:param name="sourcedoc" as="document-node()"/>
         <xsl:variable name="xslt-spec" select="."/>
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true">Start of step { count(.|preceding-sibling::*) }: XSLT { $xslt-spec }, document {$home/base-uri() => replace('.*/','')} ... </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="true">Step { count(.|preceding-sibling::*) } start : document { $home-filename }, XSLT { $xslt-spec }</xsl:with-param>
         </xsl:call-template>
         <xsl:variable name="runtime-params" as="map(xs:QName,item()*)">
             <xsl:map>
@@ -136,7 +137,7 @@
              https://www.w3.org/TR/xpath-functions-31/#func-transform -->
         <xsl:sequence select="transform($runtime)?output"/>
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true">End of step { count(.|preceding-sibling::*) }: XSLT { $xslt-spec }, document {$home/base-uri() => replace('.*/','')} ... </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="true">Step { count(.|preceding-sibling::*) } end   : document { $home-filename }, XSLT { $xslt-spec }</xsl:with-param>
         </xsl:call-template>
     </xsl:template>
 
@@ -145,7 +146,7 @@
     <xsl:template mode="opr:execute" match="opr:terminate-if-severe-errors">
         <xsl:param name="sourcedoc" as="document-node()"/>
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true">Applying step { count(.|preceding-sibling::*) }: checking for severe errors ... </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="true">Step { count(.|preceding-sibling::*) }       : document { $home-filename }, check for severe errors</xsl:with-param>
         </xsl:call-template>
         <xsl:for-each select="$sourcedoc/descendant::processing-instruction('message-handler')[starts-with(.,$terminating-message)]">
             <xsl:message terminate="yes" expand-text="yes">{.}</xsl:message>
@@ -158,8 +159,7 @@
     <xsl:template mode="opr:execute" match="opr:finalize">
         <xsl:param name="sourcedoc" as="document-node()"/>
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true">Applying step {
-                count(.|preceding-sibling::*) }: finalize ... </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="true">Step { count(.|preceding-sibling::*) }       : document { $home-filename }, finalize</xsl:with-param>
         </xsl:call-template>
 
         <xsl:apply-templates select="$sourcedoc" mode="opr:finalize"/>
@@ -169,7 +169,7 @@
     <xsl:template mode="opr:execute" match="*">
         <xsl:param name="sourcedoc" as="document-node()"/>
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true"> ... applied step { count(.|preceding-sibling::*) }: { name() } ...</xsl:with-param>
+            <xsl:with-param name="msg" expand-text="true">Step { count(.|preceding-sibling::*) } : { name() }</xsl:with-param>
         </xsl:call-template>
                 <xsl:sequence select="$sourcedoc"/>
     </xsl:template>

--- a/src/utils/resolver-pipeline/oscal-profile-resolve-select.xsl
+++ b/src/utils/resolver-pipeline/oscal-profile-resolve-select.xsl
@@ -18,6 +18,11 @@
 
     <!--<xsl:param name="profile-origin-uri"   required="yes" as="xs:anyURI"/>-->
     <xsl:param name="uri-stack-in" select="()" as="xs:anyURI*"/>
+    
+    <!-- Receive $trace from oscal-profile-RESOLVE.xsl so that we can pass it
+        back if calling oscal-profile-RESOLVE.xsl recursively when importing
+        a profile. -->
+    <xsl:param name="trace" as="xs:string">off</xsl:param>
 
 <!-- The default processing is to pass everything through.
      Note: The source catalog includes other contents besides selected controls
@@ -45,32 +50,55 @@
         </xsl:copy>
     </xsl:template>
 
-<!-- We reach a profile document in mode o:select only by way of an import/@href (see below)
-     when we do, we have to see to it that we haven't already been called; if
+<!-- We reach a profile document in mode o:select only by way of an import/@href (see below).
+     When we do, we have to see to it that we haven't already been called; if
      not, we execute the Ourobouros function, which calls the parent wrapper RESOLVE pipeline
      to return a catalog. -->
     <xsl:template match="profile" mode="o:select">
-        <xsl:param name="uri-stack" tunnel="yes" select="()"/>
-        <!-- $uri-stack contains an import call stack trace from the point of entry -->
-        <xsl:variable name="uri-here" select="base-uri(.)"/>
-        <xsl:if test="not($uri-here = $uri-stack)">
-          <!--<xsl:sequence select="o:resolve-profile(.,$uri-stack)"/>-->
-            <xsl:copy copy-namespaces="no">
-                <opr:warning>
-                    <xsl:text>profile '</xsl:text>
-                    <xsl:value-of select="$uri-here"/>
-                    <xsl:text>' picked up - and dropped - on import - we do only catalogs so far</xsl:text>
-                </opr:warning>
-                <!--<xsl:apply-templates mode="o:select" select="node() | @*">
-                    <xsl:with-param name="uri-stack" tunnel="yes" select="$uri-stack,$uri-here"/>
-                </xsl:apply-templates>-->
-            </xsl:copy>
-        </xsl:if>
+        <xsl:param name="uri-stack" tunnel="yes" as="xs:anyURI*" select="()"/>
+        <!-- $uri-stack contains an import call stack trace from the point of entry.
+            For instance, if C:/profile1.xml imports C:/profile2.xml, which in turn imports
+            C:/profile3.xml, and we reach this template on document C:/profile3.xml,
+            then uri-stack is ('file:/C:/profile1.xml', 'file:/C:/profile2.xml').-->
 
+        <!-- If debugging makes it desirable to see the import instruction in effect
+            when this template is called, make it accessible by uncommenting xsl:param:
+        <xsl:param name="import-instruction" tunnel="yes"/>
+        -->
+
+        <xsl:variable name="uri-here" as="xs:anyURI?" select="base-uri(.)"/>
+        <xsl:choose>
+            <xsl:when test="($uri-here = $uri-stack)">
+                <!-- If $uri-here is in the $uri-stack sequence, it means we have been here before.
+                    Return PI indicating terminating error and do not call oscal-profile-RESOLVE.xsl.
+                    We don't terminate immediately, though.
+                -->
+                <xsl:call-template name="mh:message-handler">
+                    <xsl:with-param name="message-type" select="'Error'"/>
+                    <xsl:with-param name="text" expand-text="yes">Circular reference to profile '{$uri-here
+                        }'. Stack: {string-join($uri-stack,'; ')}.</xsl:with-param>
+                    <xsl:with-param name="terminate" select="true()"/>
+                </xsl:call-template>                
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="mh:message-handler">
+                    <xsl:with-param name="message-type" select="'Info'"/>
+                    <xsl:with-param name="text" expand-text="yes">Resolving imported profile '{$uri-here
+                        }'.</xsl:with-param>
+                </xsl:call-template>
+                <xsl:variable name="resolved-profile" select="o:resolve-profile(.,$uri-stack)"/>
+                <xsl:apply-templates mode="o:select" select="$resolved-profile/o:catalog">
+                    <!-- When selecting from resolved profile, add this document's URI to end of
+                        $uri-stack sequence. -->
+                    <xsl:with-param name="uri-stack" tunnel="yes" select="($uri-stack,$uri-here)"/>
+                </xsl:apply-templates>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <xsl:template match="catalog" mode="o:select">
-        <selection opr:src="{base-uri(root())}">
+        <xsl:param name="uri-stack" tunnel="yes" as="xs:anyURI*" select="()"/>
+        <selection opr:src="{if (exists($uri-stack)) then $uri-stack[last()] else document-uri(root())}">
             <xsl:copy-of select="@* except @xsi:*" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
             <xsl:apply-templates mode="#current"/>
         </selection>
@@ -108,12 +136,28 @@
 
 <!-- OSCAL issue        -->
         <xsl:variable name="linked-resource" select="key('cross-reference',@href)"/>
-        <xsl:apply-templates select="$linked-resource" mode="o:import">
-            <xsl:with-param name="import-instruction" select="." tunnel="yes"/>
-        </xsl:apply-templates>
-        <xsl:apply-templates mode="#current" select="o:resource-or-error(@href)">
-            <xsl:with-param name="import-instruction" select="." tunnel="yes"/>
-        </xsl:apply-templates>
+        <xsl:variable name="importing-linked-resource">
+            <xsl:apply-templates select="$linked-resource" mode="o:import">
+                <xsl:with-param name="import-instruction" select="." tunnel="yes"/>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <xsl:variable name="selecting-resource">
+            <xsl:apply-templates mode="#current" select="o:resource-or-error(@href)">
+                <xsl:with-param name="import-instruction" select="." tunnel="yes"/>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <xsl:variable name="terminating-errors" as="processing-instruction('message-handler')*"
+            select="($importing-linked-resource,$selecting-resource)/
+            descendant::processing-instruction('message-handler')[starts-with(.,'Terminating ')]"/>
+        <xsl:choose>
+            <xsl:when test="exists($terminating-errors)">
+                <xsl:sequence select="$terminating-errors"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="$importing-linked-resource"/>
+                <xsl:sequence select="$selecting-resource"/>                
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <!-- We want a group even if there is nothing to put in it, for potential merging downstream  -->
@@ -159,12 +203,13 @@
 
     <xsl:function name="o:resolve-profile">
         <xsl:param name="profile" as="element(profile)"/>
-        <xsl:param name="uri-stack" as="xs:anyURI*"/>
+        <xsl:param name="uri-stack" as="xs:anyURI*"/><!-- prior stack, not including URI of $profile -->
         <xsl:variable name="runtime-params" as="map(xs:QName,item()*)">
             <xsl:map>
                 <xsl:map-entry key="QName('','profile-origin-uri')" select="base-uri($profile)"/>
                 <xsl:map-entry key="QName('','path-to-source')"     select="'.'"/>
-                <xsl:map-entry key="QName('','uri-stack-in')"       select="$uri-stack"/>
+                <xsl:map-entry key="QName('','uri-stack')"          select="$uri-stack"/>
+                <xsl:map-entry key="QName('','trace')"              select="$trace"/>
             </xsl:map>
         </xsl:variable>
         <xsl:variable name="runtime" as="map(xs:string, item())">
@@ -180,9 +225,7 @@
              unless a base output URI is given
              https://www.w3.org/TR/xpath-functions-31/#func-transform -->
         <xsl:sequence select="transform($runtime)?output"/>
-        <!--<xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true"> ... applied step { count(.|preceding-sibling::*) }: XSLT { $xslt-spec } ... </xsl:with-param>
-        </xsl:call-template>-->
+
     </xsl:function>
 
 

--- a/src/utils/resolver-pipeline/testing/1_selected/select.xspec
+++ b/src/utils/resolver-pipeline/testing/1_selected/select.xspec
@@ -486,25 +486,88 @@
     </x:scenario>
 
     <x:scenario label="Tests for match='profile' mode='o:select' template">
-        <!-- Tests for this template are incomplete. When it is decided whether to keep this
-            approach, we can add more test scenarios.-->
-        <x:scenario label="Profile that calls itself" catch="yes" pending="Returns nothing now">
-            <x:context mode="o:select" select="doc($ov:filedir || '/base-test_profile.xml')/o:profile">
-                <x:param name="uri-stack" tunnel="yes"
-                    select="xs:anyURI($ov:filedir || '/base-test_profile.xml')"/>
-            </x:context>
-            <x:expect label="Fatal XSLT error due to circular reference"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+        <x:scenario label="Tests for circularity error checking: circular_profile.xml > home_profile.xml > circular_profile.xml; ">
+            <x:scenario label="Template context is home_profile.xml, coming from circular_profile.xml" catch="yes">
+                <x:context mode="o:select" select="doc($ov:filedir || '/home_profile.xml')/o:profile">
+                    <x:param name="uri-stack" tunnel="yes"
+                        select="xs:anyURI($ov:filedir || '/circular_profile.xml')"/>
+                </x:context>
+                <!-- Calling oscal-profile-RESOLVE.xsl causes a terminating error, not only a PI representing a terminating error. -->
+                <x:expect label="Fatal XSLT error due to circular reference"
+                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:variable name="error-message" select="$x:result('err')('value')/string()" as="xs:string?"/>
+                <x:expect label="Error message mentions circularity"
+                    test="contains($error-message, 'Terminating Error: Circular reference to profile ')"/>
+                <x:expect label="Problematic import is circular_profile.xml"
+                    test="matches($error-message, 'reference to profile .*/circular_profile\.xml.+Stack:')"/>
+                <x:expect label="Stack of profiles is circular_profile.xml followed by home_profile.xml"
+                    test="matches($error-message, 'Stack: .*/circular_profile\.xml.+/home_profile\.xml')"/>
+            </x:scenario>
+            <x:scenario label="Template context is circular_profile.xml, coming from home_profile.xml" catch="yes">
+                <x:context mode="o:select" select="doc($ov:filedir || '/circular_profile.xml')/o:profile">
+                    <x:param name="uri-stack" tunnel="yes"
+                        select="xs:anyURI($ov:filedir || '/home_profile.xml')"/>
+                </x:context>
+                <x:expect label="Fatal XSLT error due to circular reference"
+                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:variable name="error-message" select="$x:result('err')('value')/string()" as="xs:string?"/>
+                <x:expect label="Error message mentions circularity"
+                    test="contains($error-message, 'Terminating Error: Circular reference to profile ')"/>
+                <x:expect label="Problematic import is home_profile.xml"
+                    test="matches($error-message, 'reference to profile .*/home_profile\.xml.+Stack:')"/>
+                <x:expect label="Stack of profiles is home_profile.xml followed by circular_profile.xml"
+                    test="matches($error-message, 'Stack: .*/home_profile\.xml.+/circular_profile\.xml')"/>
+            </x:scenario>
         </x:scenario>
-        <x:scenario label="Profile that calls a distinct profile"
-            pending="Not implemented yet; revisit later">
-            <x:context mode="o:select" select="doc($ov:filedir || '/base2-test_profile.xml')/o:profile">
-                <x:param name="uri-stack" tunnel="yes"
-                    select="xs:anyURI($ov:filedir || '/base-test_profile.xml')"/>
-            </x:context>
-            <x:expect label="Catalog">
-                <catalog uuid="...">...</catalog>
-            </x:expect>
+        <x:scenario label="Tests for profiles that import distinct profiles: import-profile_profile.xml > import-profile2_profile.xml > base-test_profile.xml; ">
+            <x:scenario label="Template context is import-profile2_profile.xml, coming from import-profile_profile.xml">
+                <!-- import-profile2_profile.xml is the profile we're trying to import, from import-profile_profile.xml. -->
+                <x:context mode="o:select" select="doc($ov:filedir || '/import-profile2_profile.xml')/o:profile">
+                    <x:param name="uri-stack" tunnel="yes"
+                        select="xs:anyURI($ov:filedir || '/import-profile_profile.xml')"/>
+                    <!-- The import instruction tunnel parameter is from the profile
+                        we're coming from, not the profile we're about to import. -->
+                    <x:param name="import-instruction" tunnel="yes"
+                        select="doc($ov:filedir || '/import-profile_profile.xml')/o:profile/o:import"/>
+                </x:context>
+                <x:expect label="selection element, as when importing the catalog that results from resolving import-profile2_profile.xml"
+                    test="*">
+                    <selection opr:src="..." uuid="...">...</selection>
+                </x:expect>
+                <x:expect label="PI indicating recursion"
+                    test="exists(processing-instruction('message-handler')[starts-with(.,'Info: Resolving imported profile')])"/>
+                <x:expect label="The controls included in import-profile2_profile.xml that are also included by import-profile1_profile.xml: a1 and c1"
+                    test="$x:result/descendant::o:control/@id/string()"
+                    select="('a1','c1')"/>
+                <x:expect label="Control a1 has props from import-profile2_profile.xml and the catalog"
+                    test="$x:result/descendant::o:control[@id='a1']/o:prop/@name/string()"
+                    select="('target_child','label')"/>
+            </x:scenario>
+            <x:scenario label="Template context is base-test_profile.xml, coming from import-profile2_profile.xml">
+                <x:context mode="o:select" select="doc($ov:filedir || '/base-test_profile.xml')/o:profile">
+                    <x:param name="uri-stack" tunnel="yes"
+                        select="(
+                        )"/>
+                    <!-- The import instruction tunnel parameter is from the profile
+                        we're coming from, not the profile we're about to import. -->
+                    <x:param name="import-instruction" tunnel="yes"
+                        select="doc($ov:filedir || '/import-profile2_profile.xml')/o:profile/o:import"/>
+                </x:context>
+                <x:expect label="selection element, as when importing the catalog that results from resolving base-test_profile.xml"
+                    test="*">
+                    <selection opr:src="..." uuid="...">...</selection>
+                </x:expect>
+                <x:expect label="PI indicating recursion"
+                    test="exists(processing-instruction('message-handler')[starts-with(.,'Info: Resolving imported profile')])"/>
+                <x:expect label="The controls included in base-test_profile.xml that are also included by import-profile2_profile.xml: a1, b1, and c1"
+                    test="$x:result/descendant::o:control/@id/string()"
+                    select="('a1','b1','c1')"/>
+                <!-- Note about the next x:expect element: A top-level test would see the prop that import-profile2_profile.xml
+                    adds (target_child). However, it is not in the output of this template call, so this scenario does not see it. -->
+                <x:expect label="Control a1 has the prop from the catalog (base-test_profile.xml didn't add any)"
+                    test="$x:result/descendant::o:control[@id='a1']/o:prop/@name/string()"
+                    select="('label')"/>
+            </x:scenario>
         </x:scenario>
     </x:scenario>
 
@@ -605,16 +668,21 @@
             <x:expect label="Fatal XSLT error"
                 test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
         </x:scenario>
-        <x:scenario label="Error case: Resource reference is circular" catch="yes" pending="XSLT needs to catch up to spec">
-            <x:context mode="o:select"
-                select="(doc($ov:filedir || '/circular_profile.xml')//o:import)[1]"/>
-            <x:expect label="Fatal XSLT error"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
-        </x:scenario>
-        <x:scenario label="Error case: href is not castable as xs:anyURI" catch="yes">
+        <x:scenario label="Error case: href is not castable as xs:anyURI">
             <x:context mode="o:select"><import/></x:context>
             <x:expect label="Fatal XSLT error"
                 test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+        </x:scenario>
+        <x:scenario label="Error case: Resource reference is circular" catch="yes">
+            <x:context mode="o:select"
+                select="(doc($ov:filedir || '/circular_profile.xml')//o:import)[1]"/>
+            <!-- Calling oscal-profile-RESOLVE.xsl downstream from this template causes a
+                terminating error, not only a PI representing a terminating error. -->
+            <x:expect label="Fatal XSLT error due to circular reference"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+            <x:variable name="error-message" select="$x:result('err')('value')/string()" as="xs:string?"/>
+            <x:expect label="Error message mentions circularity"
+                test="contains($error-message, 'Terminating Error: Circular reference to profile ')"/>
         </x:scenario>
     </x:scenario>
 
@@ -1511,21 +1579,46 @@
         </x:scenario>
     </x:scenario>
     
-    <x:scenario label="Tests for o:resolve-profile function" pending="incomplete">
-        <!-- Intended for the case where an profile imports another profile,
-            this function is not in use yet. For now, just test that the
-            function can run. When it is decided whether to keep this
-            approach, we can add more test scenarios. -->
-        <x:scenario label="Sanity check">
+    <x:scenario label="Tests for o:resolve-profile function">
+        <x:scenario label="Sanity check: Resolve base-test_profile.xml as if importing from import-profile2_profile.xml">
             <x:call function="o:resolve-profile">
-                <x:param name="profile">
-                    <o:profile href="{$ov:filedir}/base-test_profile.xml"/>
-                </x:param>
-                <x:param name="uri-stack" select="xs:anyURI($ov:filedir || '/base-test_profile.xml')"/>
+                <x:param name="profile" select="doc($ov:filedir || '/base-test_profile.xml')/o:profile"/>
+                <x:param name="uri-stack" select="xs:anyURI($ov:filedir || '/import-profile2_profile.xml')"/>
             </x:call>
-            <x:expect label="Catalog">
+            <x:expect label="Catalog" test="/o:catalog">
                 <catalog uuid="...">...</catalog>
             </x:expect>
+            <x:expect label="Catalog contains the controls included in base-test_profile.xml, including child controls"
+                test="$x:result/descendant::o:control/@id/string()"
+                select="('a1','b1','c1','c3','c3.a','c3.a-1')"/>
+        </x:scenario>
+        <x:scenario label="Resolve base-test_profile.xml as if importing from import-profile1_profile.xml">
+            <x:call function="o:resolve-profile">
+                <x:param name="profile" select="doc($ov:filedir || '/base-test_profile.xml')/o:profile"/>
+                <x:param name="uri-stack" select="(
+                    xs:anyURI($ov:filedir || '/import-profile1_profile.xml'),
+                    xs:anyURI($ov:filedir || '/import-profile2_profile.xml')
+                    )"/>
+            </x:call>
+            <x:expect label="Catalog" test="/o:catalog">
+                <catalog uuid="...">...</catalog>
+            </x:expect>
+            <x:expect label="Catalog contains the controls included in base-test_profile.xml, including child controls"
+                test="$x:result/descendant::o:control/@id/string()"
+                select="('a1','b1','c1','c3','c3.a','c3.a-1')"/>
+        </x:scenario>
+        <x:scenario label="Resolve circular_profile.xml as if importing from home_profile.xml" catch="yes">
+            <x:call function="o:resolve-profile">
+                <x:param name="profile" select="doc($ov:filedir || '/circular_profile.xml')/o:profile"/>
+                <x:param name="uri-stack" select="xs:anyURI($ov:filedir || '/home_profile.xml')"/>
+            </x:call>
+            <x:expect label="Fatal XSLT error due to circular reference"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+            <x:variable name="error-message" select="$x:result('err')('value')/string()" as="xs:string?"/>
+            <x:expect label="Error message mentions circularity"
+                test="contains($error-message, 'Terminating Error: Circular reference to profile ')"/>
+            <x:expect label="Problematic import is home_profile.xml"
+                test="matches($error-message, 'reference to profile .*/home_profile\.xml.+Stack:')"/>
         </x:scenario>
     </x:scenario>
 </x:description>

--- a/src/utils/resolver-pipeline/testing/2_metadata/metadata.xspec
+++ b/src/utils/resolver-pipeline/testing/2_metadata/metadata.xspec
@@ -252,8 +252,8 @@
                         </selection>
                     </profile>
                 </x:context>
-                <x:expect label="Error"
-                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:expect label="oscal-version containing PI indicating a terminating error"
+                    test="exists($x:result/self::o:oscal-version/processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
             <x:scenario label="Most recent version is in profile metadata">
                 <x:context select="/o:profile/o:metadata/o:oscal-version">
@@ -289,16 +289,16 @@
                     <x:param name="source" select="'1.0.0'"/>
                     <x:param name="imported" select="('1.0.0','1.0.1')"/>
                 </x:call>
-                <x:expect label="Error"
-                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:expect label="PI indicating a terminating error"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
             <x:scenario label="Imported document has a newer pre-release identifier" catch="yes">
                 <x:call function="opr:oscal-version">
                     <x:param name="source" select="'1.0.1-rc1'"/>
                     <x:param name="imported" select="('1.0.0','1.0.1-rc2')"/>
                 </x:call>
-                <x:expect label="Error"
-                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:expect label="PI indicating a terminating error"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
         </x:scenario>
         <x:scenario label="Different major version">
@@ -314,8 +314,8 @@
                     <x:param name="source" select="'1.37.40'"/>
                     <x:param name="imported" select="('2.0','1.0.1')"/>
                 </x:call>
-                <x:expect label="Error"
-                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:expect label="PI indicating a terminating error"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
         </x:scenario>
     </x:scenario>

--- a/src/utils/resolver-pipeline/testing/5_finished/finish.xspec
+++ b/src/utils/resolver-pipeline/testing/5_finished/finish.xspec
@@ -21,6 +21,170 @@
         </x:scenario>
     </x:scenario>
 
+    <x:scenario label="Tests for mode=all-or-last-only template">
+        <x:scenario label="Element that can occur with any multiplicity">
+            <x:context mode="all-or-last-only" select="(//o:link)[2]">
+                <parent>
+                    <link href="target1"/>
+                    <link href="target2"/>
+                    <link href="target3"/>
+                </parent>
+            </x:context>
+            <x:expect label="Copy of element, regardless of multiplicity or position">
+                <link href="target2"/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Non-OSCAL element">
+            <x:context mode="all-or-last-only" select="(//opr:title)[2]">
+                <parent>
+                    <opr:title>A</opr:title>
+                    <opr:title>B</opr:title>
+                    <opr:title>C</opr:title>
+                </parent>
+            </x:context>
+            <x:expect label="Copy of element, regardless of multiplicity or position">
+                <opr:title>B</opr:title>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Element that can occur at most once, ">
+            <x:variable name="ov:context-parent">
+                <parent>
+                    <title>Original</title>
+                    <title>Intermediate replacement</title>
+                    <title>Another intermediate replacement</title>
+                    <title>Last replacement</title>
+                </parent>
+            </x:variable>
+            <x:scenario label="first of four instances">
+                <x:context mode="all-or-last-only" select="($ov:context-parent//o:title)[1]"/>
+                <x:expect label="Nothing; the warning will come from the next to last instance, and the copy will come from the last instance"
+                select="()"/>
+            </x:scenario>
+            <x:scenario label="second of four instances">
+                <x:context mode="all-or-last-only" select="($ov:context-parent//o:title)[2]"/>
+                <x:expect label="Nothing; the warning will come from the next to last instance, and the copy will come from the last instance"
+                    select="()"/>
+            </x:scenario>
+            <x:scenario label="next to last instance">
+                <x:context mode="all-or-last-only" select="($ov:context-parent//o:title)[last()-1]"/>
+                <x:expect label="PI for warning about extra title"
+                    test="$x:result/self::processing-instruction('message-handler')">
+                    <?message-handler Warning: Found 4 elements of type <title>. Only the last will be present in result.?>
+                </x:expect>
+                <x:expect label="No elements" test="empty($x:result/self::element())"/>
+            </x:scenario>
+            <x:scenario label="last instance">
+                <x:context mode="all-or-last-only" select="($ov:context-parent//o:title)[last()]"/>
+                <x:expect label="Copy of element">
+                    <title>Last replacement</title>
+                </x:expect>
+                <x:expect label="No PI for warning or error" test="empty($x:result/self::processing-instruction())"/>
+            </x:scenario>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for name=process-expected-child-elements template">
+        <x:scenario label="Child elements out of sequence, extraneous elements, and extra title">
+            <x:context>
+                <parent>
+                    <param id="param-A.a">
+                        <label>A.a parameter</label>
+                        <value>A.a value</value>
+                    </param>
+                    <published/>
+                    <prop name="label" value="1st"/>
+                    <title>Original</title>
+                    <prop name="label" value="2nd"/>
+                    <title>Replacement</title>
+                    <param id="param-B.b">
+                        <label>B.b parameter</label>
+                        <value>B.b value</value>
+                    </param>
+                    <opr:title>Non-OSCAL Title</opr:title>
+                </parent>
+            </x:context>
+            <x:call template="process-expected-child-elements">
+                <x:param name="expected-child-element-names"
+                    select="('title','param','prop')"/>
+            </x:call>
+            <x:expect label="One title, all params, all props, and no other elements" test="element()">
+                <title>Replacement</title>
+                <param id="param-A.a">
+                    <label>A.a parameter</label>
+                    <value>A.a value</value>
+                </param>
+                <param id="param-B.b">
+                    <label>B.b parameter</label>
+                    <value>B.b value</value>
+                </param>
+                <prop name="label" value="1st"/>
+                <prop name="label" value="2nd"/>
+            </x:expect>
+            <x:expect label="PI for warning about extra OSCAL-namespace title" test="/processing-instruction('message-handler')">
+                <?message-handler Warning: Found 2 elements of type <title>. Only the last will be present in result.?>
+            </x:expect>
+            <!-- Note: An extraneous <published/> element causes the report-unexpected-child-elements
+                template, not the template being called in this scenario, to output an error PI. -->
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for name=report-unexpected-child-elements template">
+        <x:scenario label="Unexpected elements among expected and opr:* child elements">
+            <x:context>
+                <parent>
+                    <param id="param-A.a">
+                        <label>A.a parameter</label>
+                        <value>A.a value</value>
+                    </param>
+                    <published/>
+                    <prop name="label" value="1st"/>
+                    <title>OSCAL Title</title>
+                    <opr:title>Non-OSCAL Title</opr:title>
+                    <unknown-element>Text</unknown-element>
+                </parent>
+            </x:context>
+            <x:call template="report-unexpected-child-elements">
+                <x:param name="expected-child-element-names"
+                    select="('title','param','prop')"/>
+            </x:call>
+            <x:expect label="Processing instructions about 'published' and 'unknown-element' elements"
+                test="/processing-instruction('message-handler')">
+                <?message-handler Error: Element of type <published> is not valid inside <parent> and will not be present in result.?>
+                <?message-handler Error: Element of type <unknown-element> is not valid inside <parent> and will not be present in result.?>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="No unexpected child elements">
+            <x:context>
+                <parent>
+                    <param id="param-A.a">
+                        <label>A.a parameter</label>
+                        <value>A.a value</value>
+                    </param>
+                    <prop name="label" value="1st"/>
+                    <title>OSCAL Title</title>
+                    <opr:title>Non-OSCAL Title</opr:title>
+                </parent>
+            </x:context>
+            <x:call template="report-unexpected-child-elements">
+                <x:param name="expected-child-element-names"
+                    select="('title','param','prop')"/>
+            </x:call>
+            <x:expect label="Nothing" select="()"/>
+        </x:scenario>
+        <x:scenario label="No child elements">
+            <x:context>
+                <parent>
+                    <!-- no child elements -->
+                </parent>
+            </x:context>
+            <x:call template="report-unexpected-child-elements">
+                <x:param name="expected-child-element-names"
+                    select="('title','param','prop')"/>
+            </x:call>
+            <x:expect label="Nothing" select="()"/>
+        </x:scenario>
+    </x:scenario>
+
     <x:scenario label="Tests for match=catalog template">
         <x:scenario label="Base">
             <x:context>


### PR DESCRIPTION
# Committer Notes

This PR implements support in the XSLT profile resolver for an XML profile importing an XML profile. This is a feature that the spec describes and that was partially implemented by @wendellpiez earlier.

This PR builds on top of #1549, so it might be simpler to merge that PR first. Let me know if I should create this PR in a different way when it depends on unmerged code. What's new in this PR are commits ccef4cfa7d3e05451c53d8d5ead5cc2d760479c0 and 883e1f32a33afc575eeb958081e53dfda4e2db37, containing the following pieces.

XSLT changes:
* Pass $trace global param from top level to selection phase
  so it can be passed back to top level in recursion
* When calling pipeline steps, output a trace message before
  and after, to make recursive operation clearer
* Handle terminating errors during recursion, including
  circular references among profiles

XSpec changes:
* Update tests for match='profile' mode='o:select' template
* Update tests for o:resolve-profile function

Sample profile documents with their expected output:
* import-profile_profile.xsl
* import-profile2_profile.xsl, which is imported by the above
  profile and in turn imports another profile

### Sample trace messages showing recursion
When I enabled tracing and ran the resolver on `import-profile1_profile.xml` which imports `import-profile2_profile.xml` which in turn imports `base-test_profile.xml`, the messages about steps in the pipeline were in the following sequence:
```
Start of step 1: XSLT oscal-profile-resolve-select.xsl, document import-profile1_profile.xml ... 
Start of step 1: XSLT oscal-profile-resolve-select.xsl, document import-profile2_profile.xml ... 
Start of step 1: XSLT oscal-profile-resolve-select.xsl, document base-test_profile.xml ... 
End of step 1: XSLT oscal-profile-resolve-select.xsl, document base-test_profile.xml ... 
Start of step 2: XSLT oscal-profile-resolve-metadata.xsl, document base-test_profile.xml ... 
End of step 2: XSLT oscal-profile-resolve-metadata.xsl, document base-test_profile.xml ... 
Start of step 3: XSLT oscal-profile-resolve-merge.xsl, document base-test_profile.xml ... 
End of step 3: XSLT oscal-profile-resolve-merge.xsl, document base-test_profile.xml ... 
Start of step 4: XSLT oscal-profile-resolve-modify.xsl, document base-test_profile.xml ... 
End of step 4: XSLT oscal-profile-resolve-modify.xsl, document base-test_profile.xml ... 
Start of step 5: XSLT oscal-profile-resolve-finish.xsl, document base-test_profile.xml ... 
End of step 5: XSLT oscal-profile-resolve-finish.xsl, document base-test_profile.xml ... 
Applying step 6: checking for severe errors ... 
Applying step 7: finalize ... 
End of step 1: XSLT oscal-profile-resolve-select.xsl, document import-profile2_profile.xml ... 
Start of step 2: XSLT oscal-profile-resolve-metadata.xsl, document import-profile2_profile.xml ... 
End of step 2: XSLT oscal-profile-resolve-metadata.xsl, document import-profile2_profile.xml ... 
Start of step 3: XSLT oscal-profile-resolve-merge.xsl, document import-profile2_profile.xml ... 
End of step 3: XSLT oscal-profile-resolve-merge.xsl, document import-profile2_profile.xml ... 
Start of step 4: XSLT oscal-profile-resolve-modify.xsl, document import-profile2_profile.xml ... 
End of step 4: XSLT oscal-profile-resolve-modify.xsl, document import-profile2_profile.xml ... 
Start of step 5: XSLT oscal-profile-resolve-finish.xsl, document import-profile2_profile.xml ... 
End of step 5: XSLT oscal-profile-resolve-finish.xsl, document import-profile2_profile.xml ... 
Applying step 6: checking for severe errors ... 
Applying step 7: finalize ... 
End of step 1: XSLT oscal-profile-resolve-select.xsl, document import-profile1_profile.xml ... 
Start of step 2: XSLT oscal-profile-resolve-metadata.xsl, document import-profile1_profile.xml ... 
End of step 2: XSLT oscal-profile-resolve-metadata.xsl, document import-profile1_profile.xml ... 
Start of step 3: XSLT oscal-profile-resolve-merge.xsl, document import-profile1_profile.xml ... 
End of step 3: XSLT oscal-profile-resolve-merge.xsl, document import-profile1_profile.xml ... 
Start of step 4: XSLT oscal-profile-resolve-modify.xsl, document import-profile1_profile.xml ... 
End of step 4: XSLT oscal-profile-resolve-modify.xsl, document import-profile1_profile.xml ... 
Start of step 5: XSLT oscal-profile-resolve-finish.xsl, document import-profile1_profile.xml ... 
End of step 5: XSLT oscal-profile-resolve-finish.xsl, document import-profile1_profile.xml ... 
Applying step 6: checking for severe errors ... 
Applying step 7: finalize ... 
```

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
