### PR TITLE
Profile resolver compatibility with Saxon 11 (on top of other unmerged PRs)

### DIFF
--- a/src/specifications/profile-resolution/profile-resolution-examples/import-profile2_profile.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/import-profile2_profile.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../example-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- Modified by conversion XSLT 2021-04-05T11:22:09.051-04:00 - RC2 OSCAL becomes RC3 OSCAL -->
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="d36cab7c-4973-465a-b79f-6d26420fcf11">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2020-05-30T14:39:42.758-04:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0</oscal-version>
+   </metadata>
+   <import href="base-test_profile.xml">
+      <include-controls>
+         <with-id>a1</with-id>
+         <with-id>b1</with-id>
+         <with-id>c1</with-id>
+      </include-controls>
+   </import>
+   <modify>
+      <alter control-id="a1">
+         <add position="starting">
+            <prop name="target_child" ns="https://fedramp.gov/ns/oscal" value="starting"/>
+         </add>
+      </alter>
+   </modify>
+</profile>

--- a/src/specifications/profile-resolution/profile-resolution-examples/import-profile_profile.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/import-profile_profile.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../example-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- Modified by conversion XSLT 2021-04-05T11:22:09.051-04:00 - RC2 OSCAL becomes RC3 OSCAL -->
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="d36cab7c-4973-465a-b79f-6d26420fcf11">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2020-05-30T14:39:42.758-04:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0</oscal-version>
+   </metadata>
+   <import href="import-profile2_profile.xml">
+      <include-controls>
+         <with-id>a1</with-id>
+         <with-id>c1</with-id>
+      </include-controls>
+   </import>
+   <modify>
+      <alter control-id="a1">
+         <add position="starting">
+            <prop name="another_target_child" ns="https://fedramp.gov/ns/oscal" value="starting"/>
+         </add>
+      </alter>
+   </modify>
+</profile>

--- a/src/specifications/profile-resolution/profile-resolution-examples/nonfatal-error-warning_profile.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/nonfatal-error-warning_profile.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../example-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="036213db-02d3-4234-8963-b83f79634e36">
+   <metadata>
+      <title>Example</title>
+      <last-modified>2020-05-30T14:39:50.536-04:00</last-modified>
+      <version>1.2</version>
+      <oscal-version>1.0.0</oscal-version>
+   </metadata>
+   <import href="#4d263315-ebac-45cc-801e-f5a986cd59a9">
+      <include-controls with-child-controls="yes">
+         <with-id>a1</with-id>
+         <with-id>a3</with-id>
+      </include-controls>
+   </import>
+   <modify>
+      <set-parameter param-id="a1_prm1-nonexistent"><!-- Warning -->
+         <constraint>
+            <description>
+               <p>at least every 3 years</p>
+            </description>
+         </constraint>
+      </set-parameter>
+      <set-parameter param-id="a3_prm1">
+         <constraint>
+            <description>
+               <p>at least annually</p>
+            </description>
+         </constraint>
+      </set-parameter>
+      <alter control-id="a1">
+         <add position="starting" by-id="a1">
+            <title>New Title of Control</title><!-- Warning -->
+            <title>Another New Title of Control</title><!-- Counted in same warning as the preceding sibling title -->
+            <back-matter/><!-- Error -->
+         </add>
+      </alter>
+   </modify>
+   <back-matter>
+      <resource uuid="4d263315-ebac-45cc-801e-f5a986cd59a9">
+         <rlink href="catalogs/abc-simple_catalog.xml"/>
+      </resource>
+   </back-matter>
+</profile>

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/import-profile2_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/import-profile2_profile_RESOLVED.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="00000000-0000-4000-B000-000000000000">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2022-12-03T20:30:33.7568343-05:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0</oscal-version>
+      <prop name="resolution-tool" value="some value"/>
+      <link rel="source-profile" href="../import-profile2_profile.xml"/>
+   </metadata>
+   <control id="a1">
+      <title>Control A1</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
+      <prop name="target_child"
+            ns="https://fedramp.gov/ns/oscal"
+            value="starting"/>
+      <prop name="label" value="first"/>
+      <part name="statement" id="a1-stmt">
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
+      </part>
+   </control>
+   <control id="b1">
+      <title>Control B1</title>
+      <prop name="label" value="fourth"/>
+      <part name="statement" id="b1-stmt">
+         <p>B1 bbbb bbbbbbb.</p>
+      </part>
+   </control>
+   <control id="c1">
+      <title>Control C1</title>
+      <prop name="label" value="seventh"/>
+      <part name="statement" id="c1-stmt">
+         <p>C1 ccccc ccc ccccccccccccccccc.</p>
+      </part>
+   </control>
+</catalog>

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/import-profile_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/import-profile_profile_RESOLVED.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="00000000-0000-4000-B000-000000000000">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2022-12-03T20:30:29.3084831-05:00</last-modified>
+      <version>1.0</version>
+      <oscal-version>1.0.0</oscal-version>
+      <prop name="resolution-tool" value="some value"/>
+      <link rel="source-profile" href="../import-profile_profile.xml"/>
+   </metadata>
+   <control id="a1">
+      <title>Control A1</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
+      <prop name="another_target_child"
+            ns="https://fedramp.gov/ns/oscal"
+            value="starting"/>
+      <prop name="target_child"
+            ns="https://fedramp.gov/ns/oscal"
+            value="starting"/>
+      <prop name="label" value="first"/>
+      <part name="statement" id="a1-stmt">
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
+      </part>
+   </control>
+   <control id="c1">
+      <title>Control C1</title>
+      <prop name="label" value="seventh"/>
+      <part name="statement" id="c1-stmt">
+         <p>C1 ccccc ccc ccccccccccccccccc.</p>
+      </part>
+   </control>
+</catalog>

--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/nonfatal-error-warning_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/nonfatal-error-warning_profile_RESOLVED.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="00000000-0000-4000-B000-000000000000">
+   <metadata>
+      <title>Example</title>
+      <last-modified>2022-11-13T16:20:39.9627184-05:00</last-modified>
+      <version>1.2</version>
+      <oscal-version>1.0.0</oscal-version>
+      <prop name="resolution-tool" value="some value"/>
+      <link rel="source-profile"href="../nonfatal-error-warning_profile.xml"/>
+   </metadata>
+   <control id="a1">
+      <title>Another New Title of Control</title>
+      <param id="a1_prm1">
+         <label>A1 Parameter 1</label>
+      </param>
+      <prop name="label" value="first"/>
+      <part name="statement" id="a1-stmt">
+         <p>A1 aaaaa <insert type="param" id-ref="a1_prm1"/> aaaaaaaaaa</p>
+      </part>
+   </control>
+   <control id="a3">
+      <title>Control A3</title>
+      <param id="a3_prm1">
+         <label>A3 Parameter 1</label>
+         <constraint>
+            <description>
+               <p>at least annually</p>
+            </description>
+         </constraint>
+      </param>
+      <prop name="label" value="third"/>
+      <part name="statement" id="a3-stmt">
+         <p>A3 aaaaa <insert type="param" id-ref="a3_prm1"/> aaaaaaaaaa</p>
+      </part>
+   </control>
+</catalog>

--- a/src/utils/util/resolver-pipeline/message-handler.xsl
+++ b/src/utils/util/resolver-pipeline/message-handler.xsl
@@ -5,15 +5,21 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     exclude-result-prefixes="#all"
     version="3.0">
-    
-    <xsl:template name="mh:message-handler">
+
+    <xsl:template name="mh:message-handler" as="processing-instruction()">
         <xsl:param name="text" as="xs:string"/>
         <xsl:param name="message-type" as="xs:string?"/><!-- e.g., 'Error', 'Warning' -->
         <xsl:param name="error-code" as="xs:string?"/>
         <xsl:param name="terminate" as="xs:boolean" select="false()"/>
-        <xsl:message expand-text="yes" terminate="{$terminate}">{
-            string-join(($message-type, $error-code, $text),': ')
-            }</xsl:message>
+        <xsl:variable name="joined-string" as="xs:string"
+            select="string-join(($message-type, $error-code, $text),': ')"/>
+        <xsl:processing-instruction name="message-handler" expand-text="yes">{
+            if ($terminate) then 'Terminating ' else ''
+            }{
+            $joined-string
+            }</xsl:processing-instruction>
+        <!-- Above, line break inside the text value template instead of outside it
+             prevents the output PI from including the line break. -->
     </xsl:template>
 
 </xsl:stylesheet>

--- a/src/utils/util/resolver-pipeline/oscal-profile-RESOLVE.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-RESOLVE.xsl
@@ -75,7 +75,7 @@
              Each represents a stage in processing.
              The result of each processing step is passed to the next step as its input, until no steps are left. -->
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="yes">RESOLVING PROFILE { document-uri($source) } </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="yes">RESOLVING PROFILE { base-uri($source) } </xsl:with-param>
         </xsl:call-template>
         <xsl:iterate select="$transformation-sequence/*">
             <xsl:param name="doc" select="$source" as="document-node()"/>
@@ -119,9 +119,9 @@
         </xsl:call-template>
         <xsl:variable name="runtime-params" as="map(xs:QName,item()*)">
             <xsl:map>
-                <xsl:map-entry key="QName('','profile-origin-uri')" select="document-uri($home)"/>
+                <xsl:map-entry key="QName('','profile-origin-uri')" select="base-uri($home)"/>
                 <xsl:map-entry key="QName('','path-to-source')"     select="$path-to-source"/>
-                <xsl:map-entry key="QName('','uri-stack-in')"       select="($uri-stack, document-uri($home))"/>
+                <xsl:map-entry key="QName('','uri-stack-in')"       select="($uri-stack, base-uri($home))"/>
                 <xsl:apply-templates select="." mode="opr:provide-parameters"/>
             </xsl:map>
         </xsl:variable>

--- a/src/utils/util/resolver-pipeline/oscal-profile-RESOLVE.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-RESOLVE.xsl
@@ -49,6 +49,7 @@
     <xsl:variable name="louder" select="$trace = 'on'"/>
 
     <xsl:variable name="home" select="/"/>
+    <xsl:variable name="home-filename" select="$home/base-uri() => replace('.*/','')"/>
 
     <!-- If true, do not record profile URI in output catalog's source-profile
         metadata, due to privacy or security concerns. -->
@@ -74,7 +75,7 @@
              Each represents a stage in processing.
              The result of each processing step is passed to the next step as its input, until no steps are left. -->
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="yes"> RESOLVING PROFILE { document-uri($source) } </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="yes">RESOLVING PROFILE { document-uri($source) } </xsl:with-param>
         </xsl:call-template>
         <xsl:iterate select="$transformation-sequence/*">
             <xsl:param name="doc" select="$source" as="document-node()"/>
@@ -114,7 +115,7 @@
         <xsl:param name="sourcedoc" as="document-node()"/>
         <xsl:variable name="xslt-spec" select="."/>
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true">Start of step { count(.|preceding-sibling::*) }: XSLT { $xslt-spec }, document {$home/base-uri() => replace('.*/','')} ... </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="true">Step { count(.|preceding-sibling::*) } start : document { $home-filename }, XSLT { $xslt-spec }</xsl:with-param>
         </xsl:call-template>
         <xsl:variable name="runtime-params" as="map(xs:QName,item()*)">
             <xsl:map>
@@ -144,7 +145,7 @@
              https://www.w3.org/TR/xpath-functions-31/#func-transform -->
         <xsl:sequence select="transform($runtime)?output"/>
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true">End of step { count(.|preceding-sibling::*) }: XSLT { $xslt-spec }, document {$home/base-uri() => replace('.*/','')} ... </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="true">Step { count(.|preceding-sibling::*) } end   : document { $home-filename }, XSLT { $xslt-spec }</xsl:with-param>
         </xsl:call-template>
     </xsl:template>
 
@@ -153,7 +154,7 @@
     <xsl:template mode="opr:execute" match="opr:terminate-if-severe-errors">
         <xsl:param name="sourcedoc" as="document-node()"/>
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true">Applying step { count(.|preceding-sibling::*) }: checking for severe errors ... </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="true">Step { count(.|preceding-sibling::*) }       : document { $home-filename }, check for severe errors</xsl:with-param>
         </xsl:call-template>
         <xsl:for-each select="$sourcedoc/descendant::processing-instruction('message-handler')[starts-with(.,$terminating-message)]">
             <xsl:message terminate="yes" expand-text="yes">{.}</xsl:message>
@@ -166,8 +167,7 @@
     <xsl:template mode="opr:execute" match="opr:finalize">
         <xsl:param name="sourcedoc" as="document-node()"/>
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true">Applying step {
-                count(.|preceding-sibling::*) }: finalize ... </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="true">Step { count(.|preceding-sibling::*) }       : document { $home-filename }, finalize</xsl:with-param>
         </xsl:call-template>
         <xsl:apply-templates select="$sourcedoc" mode="opr:finalize"/>
     </xsl:template>
@@ -176,7 +176,7 @@
     <xsl:template mode="opr:execute" match="*">
         <xsl:param name="sourcedoc" as="document-node()"/>
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="true"> ... applying step { count(.|preceding-sibling::*) }: { name() } ...</xsl:with-param>
+            <xsl:with-param name="msg" expand-text="true">Step { count(.|preceding-sibling::*) } : { name() }</xsl:with-param>
         </xsl:call-template>
         <xsl:sequence select="$sourcedoc"/>
     </xsl:template>

--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-finish.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-finish.xsl
@@ -1,15 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
     xmlns="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:mh="http://csrc.nist.gov/ns/message"
     xmlns:opr="http://csrc.nist.gov/ns/oscal/profile-resolution"
     exclude-result-prefixes="#all"
     xpath-default-namespace="http://csrc.nist.gov/ns/oscal/1.0" >
 
-    <xsl:template match="* | @*" mode="#all">
+    <xsl:import href="message-handler.xsl"/>
+
+    <xsl:variable name="oscal-ns" select="'http://csrc.nist.gov/ns/oscal/1.0'" as="xs:string"/>
+    <xsl:variable name="at-most-one" as="xs:string+"
+        select="(
+        'metadata',
+        'back-matter',
+        'title',
+        'published',
+        'last-modified',
+        'version',
+        'oscal-version',
+        'revisions',
+        'document-id',
+        'remarks'
+        )"/>
+
+    <xsl:template match="* | @* | processing-instruction('message-handler')" mode="#default">
         <xsl:copy copy-namespaces="no">
             <xsl:apply-templates mode="#current" select="node() | @*"/>
         </xsl:copy>
@@ -23,13 +40,13 @@
            - Use [last()] instead of [1] to accommodate the case of
              replacing a title during modify phase. The modify phase
              adds the title following the original one.
-           - Some "[last()]" expressions are expected to have no effect
-             if input documents are schema-valid but are included to
-             avoid producing schema-invalid output.
+           - Some uses of mode="all-or-last-only" are expected to behave
+             just like mode="#current" if input documents are schema-valid
+             but are included to avoid producing schema-invalid output.
          - Removing unclaimed inventory, defined as any 'resource'
            in back matter without something somewhere linking to it
 
-         What we are not doing:
+    What we are not doing:
          - Removing broken links
          - Remove opr and xsi namespaces (that happens in the shell)
     -->
@@ -43,64 +60,130 @@
     or aliasing via use-name.
     -->
 
+    <xsl:template match="*" mode="all-or-last-only">
+        <xsl:variable name="this" select="." as="element()"/>
+        <xsl:variable name="following-siblings-of-same-element-type" as="xs:integer"
+            select="count(following-sibling::*[local-name(.) = local-name($this)][namespace-uri(.) = namespace-uri($this)])"/>
+        <xsl:choose>
+            <xsl:when test="namespace-uri($this) = $oscal-ns and not(local-name($this) = $at-most-one)">
+                <!-- OSCAL element that is not limited to at most one instance in its parent -->
+                <xsl:apply-templates select="." mode="#default"/>
+            </xsl:when>
+            <xsl:when test="namespace-uri($this) != $oscal-ns">
+                <!-- Non-OSCAL element -->
+                <xsl:apply-templates select="." mode="#default"/>
+            </xsl:when>
+            <xsl:when test="$following-siblings-of-same-element-type gt 1">
+                <!-- Element type is limited to at most one instance in its parent, and
+                    there will be at least one following sibling to produce a warning
+                    another following sibling to copy to result. This case is a no-op. -->
+            </xsl:when>
+            <xsl:when test="$following-siblings-of-same-element-type = 1">
+                <!-- Element type is limited to at most one instance in its parent, and this is the next to last one -->
+                <xsl:variable name="instances-of-same-element-type" as="xs:integer"
+                    select="count(parent::*/*[local-name(.) = local-name($this)][namespace-uri(.) = namespace-uri($this)])"/>
+                <xsl:call-template name="mh:message-handler">
+                    <xsl:with-param name="text" expand-text="yes">Found {$instances-of-same-element-type
+                        } elements of type &lt;{local-name($this)}>. Only the last will be present in result.</xsl:with-param>
+                    <xsl:with-param name="message-type">Warning</xsl:with-param>
+                    <xsl:with-param name="terminate" select="false()"/>
+                </xsl:call-template>        
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- Element type is limited to at most one instance in its parent, and this is the last one -->
+                <xsl:apply-templates select="." mode="#default"/>
+            </xsl:otherwise>
+        </xsl:choose>        
+    </xsl:template>
+
+    <xsl:template name="process-expected-child-elements">
+        <xsl:param name="expected-child-element-names" as="xs:string+" required="yes"/>
+        <xsl:variable name="context" as="element()" select="."/>
+        <xsl:for-each select="$expected-child-element-names">
+            <xsl:variable name="this-child-name" as="xs:string" select="."/>
+            <xsl:apply-templates mode="all-or-last-only"
+                select="$context/*[namespace-uri(.) = $oscal-ns][local-name(.) = $this-child-name]"/>
+        </xsl:for-each>
+        <!-- Pass through messages for handling in oscal-profile-RESOLVE.xsl -->
+        <xsl:apply-templates select="$context/processing-instruction('message-handler')"/>
+    </xsl:template>
+    
+    <xsl:template name="report-unexpected-child-elements">
+        <xsl:param name="expected-child-element-names" as="xs:string+" required="yes"/>
+        <xsl:variable name="context" as="element()" select="."/>
+        <xsl:for-each select="*[not(self::opr:*)][not(
+            local-name(.)=$expected-child-element-names
+            and namespace-uri(.)=$oscal-ns
+            )]">
+            <xsl:call-template name="mh:message-handler">
+                <xsl:with-param name="text" expand-text="yes">Element of type &lt;{local-name(.)}> is not valid inside &lt;{
+                    local-name($context)}> and will not be present in result.</xsl:with-param>
+                <xsl:with-param name="message-type">Error</xsl:with-param>
+                <xsl:with-param name="terminate" select="false()"/>
+            </xsl:call-template>
+        </xsl:for-each>        
+    </xsl:template>
+
     <xsl:template match="catalog">
+        <xsl:variable name="context" select="." as="element(catalog)"/>
+        <xsl:variable name="expected-oscal-children" as="xs:string+"
+            select="('metadata','param','control','group','back-matter')"/>
+        <!-- Construct portion of result. -->
         <xsl:copy copy-namespaces="no">
             <xsl:apply-templates mode="#current" select="@*"/>
-            <xsl:apply-templates mode="#current" select="metadata[last()]"/>
-            <xsl:apply-templates mode="#current" select="opr:*"/>
-            <xsl:apply-templates mode="#current" select="param"/>
-            <xsl:apply-templates mode="#current" select="control"/>
-            <xsl:apply-templates mode="#current" select="group"/>
-            <xsl:apply-templates mode="#current" select="back-matter[last()]"/>
-        </xsl:copy>
+            <!-- opr:* elements can occur in catalog. Put them at the top, for convenience. -->
+            <xsl:apply-templates mode="all-or-last-only" select="opr:*"/>
+            <xsl:call-template name="process-expected-child-elements">
+                <xsl:with-param name="expected-child-element-names" select="$expected-oscal-children"/>
+            </xsl:call-template>
+        </xsl:copy>        
+        <!-- Report unexpected element types. -->
+        <xsl:call-template name="report-unexpected-child-elements">
+            <xsl:with-param name="expected-child-element-names" select="$expected-oscal-children"/>
+        </xsl:call-template>
     </xsl:template>
 
     <xsl:template match="metadata">
+        <xsl:variable name="expected-oscal-children" as="xs:string+"
+            select="('title','published','last-modified','version','oscal-version',
+            'revisions','document-id','prop','link','role','location','party','responsible-party','remarks')"/>
         <xsl:copy copy-namespaces="no">
             <xsl:apply-templates mode="#current" select="@*"/>
-            <xsl:apply-templates mode="#current" select="title[last()]"/>
-            <xsl:apply-templates mode="#current" select="published[last()]"/>
-            <xsl:apply-templates mode="#current" select="last-modified[last()]"/>
-            <xsl:apply-templates mode="#current" select="version[last()]"/>
-            <xsl:apply-templates mode="#current" select="oscal-version[last()]"/>
-            <xsl:apply-templates mode="#current" select="revisions[last()]"/>
-            <xsl:apply-templates mode="#current" select="document-id"/>
-            <xsl:apply-templates mode="#current" select="prop"/>
-            <xsl:apply-templates mode="#current" select="link"/>
-            <xsl:apply-templates mode="#current" select="role"/>
-            <xsl:apply-templates mode="#current" select="location"/>
-            <xsl:apply-templates mode="#current" select="party"/>
-            <xsl:apply-templates mode="#current" select="responsible-party"/>
-            <xsl:apply-templates mode="#current" select="remarks[last()]"/>
+            <xsl:call-template name="process-expected-child-elements">
+                <xsl:with-param name="expected-child-element-names" select="$expected-oscal-children"/>
+            </xsl:call-template>
         </xsl:copy>
+        <xsl:call-template name="report-unexpected-child-elements">
+            <xsl:with-param name="expected-child-element-names" select="$expected-oscal-children"/>
+        </xsl:call-template>
     </xsl:template>
 
     <xsl:template match="group">
+        <xsl:variable name="expected-oscal-children" as="xs:string+"
+            select="('title','param','prop','link','part','control','group')"/>
         <xsl:copy copy-namespaces="no">
             <xsl:apply-templates mode="#current" select="@*"/>
-            <xsl:apply-templates mode="#current" select="title[last()]"/>
-            <xsl:apply-templates mode="#current" select="param"/>
-            <xsl:apply-templates mode="#current" select="prop"/>
-            <xsl:apply-templates mode="#current" select="link"/>
-
-            <xsl:apply-templates mode="#current" select="part"/>
-            <xsl:apply-templates mode="#current" select="control"/>
-            <xsl:apply-templates mode="#current" select="group"/>
+            <xsl:call-template name="process-expected-child-elements">
+                <xsl:with-param name="expected-child-element-names" select="$expected-oscal-children"/>
+            </xsl:call-template>
         </xsl:copy>
+        <xsl:call-template name="report-unexpected-child-elements">
+            <xsl:with-param name="expected-child-element-names" select="$expected-oscal-children"/>
+        </xsl:call-template>
     </xsl:template>
 
     <xsl:template match="control">
+        <xsl:variable name="expected-oscal-children" as="xs:string+"
+            select="('title','param','prop','link','part','control')"/>
         <xsl:copy copy-namespaces="no">
             <xsl:apply-templates mode="#current" select="@*"/>
-            <!-- Keep only the last title. There could be multiple titles if
-                modify phase processed alter/add/title. -->
-            <xsl:apply-templates mode="#current" select="title[last()]"/>
-            <xsl:apply-templates mode="#current" select="param"/>
-            <xsl:apply-templates mode="#current" select="prop"/>
-            <xsl:apply-templates mode="#current" select="link"/>
-            <xsl:apply-templates mode="#current" select="part"/>
-            <xsl:apply-templates mode="#current" select="control"/>
+            <xsl:call-template name="process-expected-child-elements">
+                <xsl:with-param name="expected-child-element-names" select="$expected-oscal-children"/>
+            </xsl:call-template>
         </xsl:copy>
+        <xsl:call-template name="report-unexpected-child-elements">
+            <xsl:with-param name="expected-child-element-names" select="$expected-oscal-children"/>
+        </xsl:call-template>
     </xsl:template>
 
     <xsl:key name="param-insertions" match="insert[@type='param']" use="@id-ref"/>
@@ -110,7 +193,7 @@
     <xsl:template match="catalog/param[empty(key('param-insertions',@id))][not(prop[@name='keep'][@value='always'])]
         | group/param[empty(key('param-insertions',@id))][not(prop[@name='keep'][@value='always'])]"/>
 
-    <!-- Don't copy back-matter wrapper if it has no contents in result -->
+    <!-- Process back-matter, but if it has no contents in result then suppress wrapper. -->
     <xsl:template match="back-matter">
         <xsl:where-populated>
             <xsl:next-match/>

--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-merge.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-merge.xsl
@@ -12,10 +12,9 @@
 
     <xsl:import href="message-handler.xsl"/>
 
-    <xsl:variable name="in_xspec" as="xs:boolean" select="false()"/>
     <xsl:variable name="true-content" as="xs:string+" select="('true','1')"/>
 
-    <xsl:template match="* | @*" mode="#all">
+    <xsl:template match="* | @* | processing-instruction('message-handler')" mode="#all">
         <xsl:copy copy-namespaces="no">
             <xsl:apply-templates mode="#current" select="node() | @*"/>
         </xsl:copy>
@@ -26,6 +25,7 @@
     <xsl:template match="/*" priority="1">
         <!-- emitting nothing as this is input is erroneous; a catalog will match one of the following
             templates not this one. -->
+        
     </xsl:template>
 
     <!-- If there is no selection and no merge (i.e., we don't reach one of
@@ -36,12 +36,20 @@
     </xsl:template>
 
     <!-- If there is a selection but neither merge/as-is nor merge/custom,
-        use flat structuring. -->
+        use flat structuring without grouping or hierarchy of controls. -->
     <xsl:template match="catalog[exists(selection)]" priority="10" as="element(catalog)">
         <catalog>
             <xsl:apply-templates select="@*"/>
             <xsl:apply-templates select="metadata"/>
-            <xsl:apply-templates select="selection"/>
+
+            <!-- For controls, first undo grouping and then undo nesting. -->
+            <xsl:variable name="controls-ungrouped-but-nested">
+                <xsl:apply-templates select="selection"/>
+            </xsl:variable>
+            <xsl:apply-templates select="$controls-ungrouped-but-nested/* | $controls-ungrouped-but-nested/*/descendant::control"
+                mode="remove-nested-controls"/>
+
+            <xsl:apply-templates select="processing-instruction('message-handler')"/>
             <xsl:apply-templates select="modify"/>
             <xsl:where-populated>
                 <back-matter>
@@ -50,11 +58,25 @@
             </xsl:where-populated>
         </catalog>
     </xsl:template>
+    
+    <!-- Skip descendant controls as part of flat structuring. The template that
+        initiates this mode outputs the descendants as siblings instead, so this
+        skipping operation avoids redundancy.
+        
+        For other contexts, the 'remove-nested-controls' operation falls back
+        to the generic template rule having mode="#all". -->
+    <xsl:template match="control[control]" mode="remove-nested-controls">
+        <xsl:copy copy-namespaces="no">
+            <xsl:apply-templates mode="#current" select="(* | @*) except control"/>
+        </xsl:copy>
+    </xsl:template>
 
     <!-- If there is a merge/as-is directive, we go down that branch.
         If there is also a merge/custom directive, we apply the
         higher-priority template instead of this one. -->
-    <xsl:template match="catalog[merge/as-is=$true-content]" priority="12" as="element(catalog)">
+    <!-- Template return value is element(catalog) possibly preceded by a
+        processing instruction from detect-multiple-structuring-directives. -->
+    <xsl:template match="catalog[merge/as-is=$true-content]" priority="12" as="item()+">
         <xsl:call-template name="detect-multiple-structuring-directives"/>
         <catalog>
             <xsl:apply-templates select="@*"/>
@@ -68,6 +90,7 @@
             <xsl:for-each select="$merged-selections/selection">
                 <xsl:sequence select="* except back-matter"/>
             </xsl:for-each>
+            <xsl:apply-templates select="processing-instruction('message-handler')"/>
             <!-- copying 'modify' unchanged through this transformation -->
             <xsl:apply-templates select="modify"/>
             <xsl:call-template name="combine-back-matter"/>
@@ -76,7 +99,9 @@
 
 
     <!-- If there is a merge/custom directive, we go down that branch. -->
-    <xsl:template match="catalog[exists(merge/custom)]" priority="13" as="element(catalog)">
+    <!-- Template return value is element(catalog) possibly preceded by a
+        processing instruction from detect-multiple-structuring-directives. -->
+    <xsl:template match="catalog[exists(merge/custom)]" priority="13" as="item()+">
         <xsl:call-template name="detect-multiple-structuring-directives"/>
         <catalog>
             <xsl:apply-templates select="@*"/>
@@ -84,13 +109,15 @@
 
             <xsl:apply-templates select="merge/custom" mode="o:custom-merge"/>
 
+            <xsl:apply-templates select="processing-instruction('message-handler')"/>
+
             <!-- copying 'modify' unchanged through this transformation -->
             <xsl:apply-templates select="modify"/>
             <xsl:call-template name="combine-back-matter"/>
         </catalog>
     </xsl:template>
 
-    <xsl:template name="detect-multiple-structuring-directives" as="empty-sequence()">
+    <xsl:template name="detect-multiple-structuring-directives" as="processing-instruction()?">
         <xsl:context-item as="element(catalog)" use="required"/>
         <xsl:variable name="flat" as="element(flat)*" select="merge/flat[.=$true-content]"/>
         <xsl:variable name="as-is" as="element(as-is)*" select="merge/as-is[.=$true-content]"/>
@@ -237,7 +264,7 @@
             <xsl:call-template name="mh:message-handler">
                 <xsl:with-param name="text">Combining elements of different types is not supported.</xsl:with-param>
                 <xsl:with-param name="message-type">Error</xsl:with-param>
-                <xsl:with-param name="terminate" select="$in_xspec"/>
+                <xsl:with-param name="terminate" select="false()"/>
             </xsl:call-template>
         </xsl:if>
         <xsl:for-each-group select="$elements" group-by="(@opr:id,@id,generate-id())[1]">

--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-metadata.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-metadata.xsl
@@ -125,7 +125,7 @@
             </xsl:if>
         </xsl:for-each>
         <!-- Return the version from the source parameter. -->
-        <xsl:value-of select="$source"/>
+        <xsl:sequence select="$source"/>
     </xsl:function>
 
     <!--<xsl:template match="selection" mode="imported-metadata">

--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-modify.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-modify.xsl
@@ -16,7 +16,7 @@
 
     <xsl:variable name="oscal-versionless-ns" select="'http://csrc.nist.gov/ns/oscal'"/>
 
-    <xsl:template match="node() | @*">
+    <xsl:template match="node() | @* | processing-instruction('message-handler')">
         <xsl:copy>
             <xsl:apply-templates select="node() | @*"/>
         </xsl:copy>
@@ -33,13 +33,13 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="modify" as="empty-sequence()">
+    <xsl:template match="modify" as="processing-instruction()*">
         <!-- No output is required, but invoke template to warn if set-parameter
             does not match anything. -->
         <xsl:apply-templates select="set-parameter"/>
     </xsl:template>
 
-    <xsl:template match="set-parameter" as="empty-sequence()">
+    <xsl:template match="set-parameter" as="processing-instruction()?">
         <xsl:if test="not(@param-id = ancestor::catalog/descendant::param/@id)">
             <xsl:call-template name="mh:message-handler">
                 <xsl:with-param name="text" expand-text="yes">set-parameter with param-id=&quot;{@param-id}&quot; does not match any param id.</xsl:with-param>
@@ -48,8 +48,11 @@
         </xsl:if>
     </xsl:template>
 
-    <!-- priority to override template match="control//*" -->
-    <xsl:template match="param" priority="2">
+    <!-- The match="control//*" template is responsible for inserting other
+        param elements before or after a param context node, while this template
+        is responsible for processing this param element. -->
+    <xsl:template name="process-param">
+        <xsl:context-item as="element(param)" use="required"/>
         <xsl:param name="modifications" tunnel="yes" as="element(modify)?" required="yes"/>
         <xsl:variable name="id" select="@id"/>
 <!-- depending on 'merge' behavior there could be multiple settings. combine/use-first should keep only the first setting in the first profile with such a setting. combine/merge should remove all duplicates by value. combine/keep should keep all parameter settings contents even when results are invalid. These operations are assumed to be performed in the merge phase. -->
@@ -79,78 +82,197 @@
         </xsl:copy>
     </xsl:template>
 
-    <!-- When matching a control, insert content as indicated by <add> and copy everything else. -->
-
+    <!-- This template implements these cases:
+        a) Implicit binding to a control as a whole.
+        b) The special case in explicit binding where <add> targets the same
+           control that <alter> targets. Handling is as in (a), per #1311.
+        c) The special case in explicit binding where <add> targets a control that is
+           a descendant of the control that <alter> targets.
+        
+        Compare with the match="control//*" template, which implements explicit binding
+        to a control descendant that is not itself a control. -->
     <xsl:template match="control" priority="2">
         <xsl:param name="modifications" tunnel="yes" as="element(modify)?" required="yes"/>
         <!--<xsl:variable name="modifications" select="/*/modify"/>-->
         <xsl:variable name="id" select="@id"/>
-        <xsl:variable name="patches-to-id-targeting-ancestor" select="oscal:patches-to-id-targeting-ancestor(., $modifications)" as="element(add)*"/>
-        <!-- condition not(@by-id != $id) includes any addition without an @by-id, or whose @by-id is the control id -->
-        <xsl:variable name="implicit-patches-to-id" select="$modifications/key('alteration-for-control-id',$id,.)/add[not(@by-id != $id)]" as="element(add)*"/>
+        <xsl:variable name="descendant-or-self-ids" select="descendant-or-self::*/@id"/>
 
-        <xsl:copy-of select="$patches-to-id-targeting-ancestor[@position = 'before']/*"/><xsl:message>got here! removable is <xsl:sequence select="oscal:removable(./*[1],$modifications)"/></xsl:message>
-        <xsl:if test="not(ancestor::control and oscal:removable(.,$modifications))">
-            <xsl:copy>
-                <xsl:copy-of select="@*"/>
-                <xsl:apply-templates select="title" mode="#current"/>
-                <xsl:copy-of select="(
-                    $implicit-patches-to-id[@position=('before','starting')] | 
-                    $patches-to-id-targeting-ancestor[@position='starting']
-                    )/*"/>
-    
-                <xsl:apply-templates select="* except title" mode="#current"/>
-                <!--<xsl:message expand-text="true">{ string-join((* except title)/(name() || '#' || @id), ', ') }</xsl:message>-->
-    
-                <xsl:copy-of select="(
-                    $implicit-patches-to-id[not(@position = ('before','starting'))] | 
-                    $patches-to-id-targeting-ancestor[empty(@position) or @position='ending' or not(@position=('before','after','starting','ending'))]
-                    )/*"/><!-- TODO: Revisit after approach to #1311 is clarified -->
-    
-            </xsl:copy>
-        </xsl:if>
-        <xsl:copy-of select="$patches-to-id-targeting-ancestor[@position = 'after']/*"/>
+        <!-- $implicit-patches-to-id represents both the implicit <add> and explicit <add by-id="id_from_alter">. -->
+        <!-- condition not(@by-id != $id) includes any addition without an @by-id, or whose @by-id is the control id -->
+        <xsl:variable name="implicit-patches-to-id" as="element(add)*"
+            select="$modifications/key('alteration-for-control-id',$id,.)/add[not(@by-id != $id)]"/>
+
+        <xsl:variable name="explicit-patches-to-id-targeting-non-match" as="element(add)*"
+            select="$modifications/key('alteration-for-control-id',$id,.)/add[@by-id and not(@by-id=$descendant-or-self-ids)]"/>
+        <xsl:for-each select="$explicit-patches-to-id-targeting-non-match">
+            <!-- Error case: An alter element targets this control, but the add element does not match anything in this control. -->
+            <xsl:call-template name="mh:message-handler">
+                <xsl:with-param name="text" expand-text="yes">The by-id value does not match anything. Error in element {serialize(.)}.</xsl:with-param>
+                <xsl:with-param name="message-type">Error</xsl:with-param>
+                <xsl:with-param name="terminate" select="true()"/>
+            </xsl:call-template>
+        </xsl:for-each>
+
+        <!-- Data type of the next variable is element(add)*, or a PI in the error case. -->
+        <xsl:variable name="explicit-patches-to-id-targeting-ancestor" as="item()*"
+            select="oscal:patches-to-id-targeting-ancestor(., $modifications) except $implicit-patches-to-id"/>
+        <xsl:for-each select="$explicit-patches-to-id-targeting-ancestor[self::add and not(@position = ('before','after'))]">
+            <!-- Error case: An alter element targets an ancestor of this control, and the add element tries to add a control inside this control. -->
+            <xsl:call-template name="mh:message-handler">
+                <xsl:with-param name="text" expand-text="yes">When &lt;add> targets a child control, supported positions are 'before' and 'after', which add a sibling control. Error in element {serialize(.)}.</xsl:with-param>
+                <xsl:with-param name="message-type">Error</xsl:with-param>
+                <xsl:with-param name="terminate" select="true()"/>
+            </xsl:call-template>
+        </xsl:for-each>
+        <!-- If an upstream computation found an error or warning, pass it along. -->
+        <xsl:sequence select="$explicit-patches-to-id-targeting-ancestor[self::processing-instruction('message-handler')]"/>
+
+        <xsl:for-each select="$implicit-patches-to-id[@position = ('before','after')]">
+            <!-- Error case: Implicit binding with 'before' or 'after'. -->
+            <xsl:call-template name="mh:message-handler">
+                <xsl:with-param name="text" expand-text="yes">When &lt;add> targets the same control targeted by &lt;alter&gt;, supported positions are 'starting' and 'ending', which add content strictly within the targeted control. Error in element {serialize(.)}.</xsl:with-param>
+                <xsl:with-param name="message-type">Error</xsl:with-param>
+                <xsl:with-param name="terminate" select="true()"/>
+            </xsl:call-template>            
+        </xsl:for-each>
+        <xsl:choose>
+            <xsl:when test="ancestor::control and oscal:removable(.,$modifications) and
+                (exists($explicit-patches-to-id-targeting-ancestor) or exists($implicit-patches-to-id))">
+                <xsl:call-template name="mh:message-handler">
+                    <xsl:with-param name="text" expand-text="yes">Cannot insert content in control with id=&quot;{$id}&quot; because it is being removed.</xsl:with-param>
+                    <xsl:with-param name="message-type">Error</xsl:with-param>
+                    <xsl:with-param name="terminate" select="true()"/>
+                </xsl:call-template>            
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- Special case of explicit binding: Insert control(s) before this one. -->
+                <xsl:copy-of select="($explicit-patches-to-id-targeting-ancestor[@position='before'])/*[self::control]"/>
+
+                <!-- In this control, insert content as indicated by <add> and copy everything else. -->
+                <!-- The result might have elements in an invalid sequence, but the final phase adjusts that. -->                
+                <xsl:copy>
+                    <xsl:copy-of select="@*"/>
+                    <xsl:apply-templates select="title" mode="#current"/>
+                    <xsl:copy-of select="($implicit-patches-to-id[@position='starting'])/*"/>
+
+                    <xsl:apply-templates select="* except title" mode="#current"/>
+                    <!--<xsl:message expand-text="true">{ string-join((* except title)/(name() || '#' || @id), ', ') }</xsl:message>-->
+
+                    <!-- Insert content at end of this control, if position is 'ending' or if no valid position is given. -->
+                    <xsl:copy-of select="($implicit-patches-to-id[
+                        @position = 'ending' or oscal:no-valid-position-given(@position)
+                        ])/*"/>
+        
+                </xsl:copy>
+                
+                <!-- Special case of explicit binding: Insert control(s) after this one. -->
+                <xsl:copy-of select="($explicit-patches-to-id-targeting-ancestor[@position='after'])/*[self::control]"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
+
+    <!-- Return true if and only if the input is not an attribute with a valid position value. -->
+    <xsl:function name="oscal:no-valid-position-given" as="xs:boolean">
+        <xsl:param name="position" as="attribute(position)?"/>
+        <xsl:sequence select="boolean(
+            not($position = ('before','after','starting','ending'))
+            )"/>
+    </xsl:function>
 
     <!-- Find <add> elements that reference the $here element by ID,
         from the given <modify> element. -->
-    <xsl:function name="oscal:patches-to-id-targeting-ancestor" as="element(add)*">
+    <!-- Return value is element(add)*, or a PI in the error case. -->
+    <xsl:function name="oscal:patches-to-id-targeting-ancestor" as="item()*">
         <xsl:param name="here" as="element()"/>
         <xsl:param name="modifications" as="element(modify)?"/>
-        <xsl:variable name="controls" select="$here/ancestor-or-self::control" as="element(control)*"/>
+        <xsl:variable name="first-ancestor-control" select="$here/ancestor::control[1]" as="element(control)?"/>
         <xsl:variable name="alterations" as="element(alter)*"
-            select="for $control in $controls return $modifications/key('alteration-for-control-id',$control/@id,.)"/>
-        <!-- Key retrievals scoped to alterations...   -->
-        <xsl:sequence select="$alterations/key('addition-by-id-ref',$here/@id,.)"/>
+            select="$modifications/key('alteration-for-control-id',$first-ancestor-control/@id,.)"/>
+        <xsl:variable name="same-element-type" as="function(*)"
+            select="function($elem1, $elem2) as xs:boolean {
+            local-name($elem1)=local-name($elem2) and namespace-uri($elem1)=namespace-uri($elem2)
+            }"/>
+        <!-- Key retrievals scoped to alterations -->
+        <xsl:variable name="all-patches-meeting-id-criteria" as="element(add)*"
+            select="$alterations/key('addition-by-id-ref',$here/@id,.)"/>
+        <!-- Do error handling and compute output sequence -->
+        <xsl:for-each select="$all-patches-meeting-id-criteria">
+            <xsl:choose>
+                <xsl:when test="parent::alter/@control-id = $here/@id">
+                    <!-- alter and add target the same ID. Formally, this is explicit binding
+                        but treat as implicit binding. -->
+                    <xsl:sequence select="."/>
+                </xsl:when>
+                <xsl:when test="not(@position = ('before','after')) or
+                    (every $element-to-add in child::* satisfies $same-element-type($element-to-add, $here))">
+                    <!-- Typical explicit binding case, and selection type and insertion type match. --> 
+                    <xsl:sequence select="."/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:call-template name="mh:message-handler">
+                        <xsl:with-param name="text" expand-text="yes">When position="{./@position}", the target element and the elements to add must have the same element type. This element is {$here/name()} and element to add is {*[1]/name()}. Error in element {serialize(.)}.</xsl:with-param>
+                        <xsl:with-param name="message-type">Error</xsl:with-param>
+                        <xsl:with-param name="terminate" select="true()"/>
+                    </xsl:call-template>                    
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
     </xsl:function>
 
+    <!-- This template is for explicit binding to a descendant of a control. -->
     <xsl:template match="control//*">
         <xsl:param name="modifications" tunnel="yes" as="element(modify)?" required="yes"/>
+        <xsl:variable name="this" as="element()" select="."/>
         <!--<xsl:variable name="modifications" select="/*/modify"/>-->
-        <xsl:variable name="patches-to-id" select="oscal:patches-to-id-targeting-ancestor(., $modifications)" as="element(add)*"/>
 
-        <!-- $patches-before contains 'add' elements marked as patching before this element, by its @id -->
-        <xsl:variable name="patches-before" select="$patches-to-id[@position='before']"/>
+        <xsl:variable name="same-element-type" as="function(*)"
+            select="function($elem1, $elem2) as xs:boolean {
+                local-name($elem1)=local-name($elem2) and namespace-uri($elem1)=namespace-uri($elem2)
+            }"/>
+        <!-- Data type of the next variable is element(add)*, or a PI in the error case. -->
+        <xsl:variable name="patches-to-id" select="oscal:patches-to-id-targeting-ancestor($this, $modifications)" as="item()*"/>
+        <!-- If an upstream computation found an error or warning, pass it along. -->
+        <xsl:sequence select="$patches-to-id[self::processing-instruction('message-handler')]"/>
 
-        <xsl:copy-of select="$patches-before/*"/>
-        <xsl:if test="not(oscal:removable(.,$modifications))">
+        <!-- $patches-before contains 'add' elements marked as patching before this element, by this element's @id -->
+        <xsl:variable name="patches-before" select="$patches-to-id[@position='before']" as="element(add)*"/>
+        <xsl:variable name="patches-before-same-element-type" as="element(add)*"
+            select="$patches-before[$same-element-type(./*[1],$this)]"/>
+        <xsl:copy-of select="$patches-before-same-element-type/*"/>
+        <!-- When position="before|after", selection type must equal insertion type. -->
+
+        <xsl:variable name="removable" as="xs:boolean"
+            select="oscal:removable(.,$modifications)"/>
+        <xsl:if test="not($removable)">
             <xsl:copy>
                 <xsl:apply-templates select="@*" mode="#current"/>
                 <xsl:apply-templates select="title" mode="#current"/>
-
+                
                 <xsl:variable name="patches-starting" select="$patches-to-id[@position='starting']"/>
                 <xsl:copy-of select="$patches-starting/*"/>
-
-                <xsl:apply-templates select="node() except title" mode="#current"/>
-
-                <xsl:variable name="patches-ending" select="$patches-to-id[empty(@position) or @position='ending' or not(@position=('before','after','starting','ending'))]"/>
+                
+                <xsl:choose>
+                    <xsl:when test="self::param"> 
+                        <xsl:variable name="processed-param">
+                            <xsl:call-template name="process-param"/>
+                        </xsl:variable>
+                        <xsl:sequence select="$processed-param/param/node()"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:apply-templates select="node() except title" mode="#current"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+                
+                <xsl:variable name="patches-ending" select="$patches-to-id[@position='ending' or oscal:no-valid-position-given(@position)]"/>
                 <xsl:copy-of select="$patches-ending/*"/>
             </xsl:copy>
         </xsl:if>
 
-        <!-- Reverse logic for 'after' patches. -->
+        <!-- $patches-after contains 'add' elements marked as patching after this element, by this element's @id -->
         <xsl:variable name="patches-after" select="$patches-to-id[@position='after']"/>
-        <xsl:copy-of select="$patches-after/*"/>
+        <xsl:variable name="patches-after-same-element-type" as="element(add)*"
+            select="$patches-after[$same-element-type(./*[1],$this)]"/>
+        <xsl:copy-of select="$patches-after-same-element-type/*"/>
 
     </xsl:template>
 

--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-select.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-select.xsl
@@ -101,9 +101,8 @@
 
     <xsl:template match="catalog" mode="o:select">
         <xsl:param name="uri-stack" tunnel="yes" as="xs:anyURI*" select="()"/>
-        <selection opr:src="{if (exists($uri-stack)) then $uri-stack[last()] else document-uri(root())}">
+        <selection opr:src="{if (exists($uri-stack)) then $uri-stack[last()] else base-uri(root())}">
             <xsl:copy-of select="@* except @xsi:*" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
-            <!--<xsl:attribute name="opr:base" select="document-uri(root())"/>-->
             <xsl:apply-templates mode="#current"/>
         </selection>
     </xsl:template>

--- a/src/utils/util/resolver-pipeline/random-util.xsl
+++ b/src/utils/util/resolver-pipeline/random-util.xsl
@@ -30,7 +30,7 @@ v4 UUID
     <!-- Set $germ to a string for reproducible outputs of r:make-uuid.
          Pass in a blind value - and don't save it - for irreproducible outputs. -->
 
-    <xsl:param name="germ" select="current-dateTime() || document-uri(/)"/>
+    <xsl:param name="germ" select="current-dateTime() || base-uri(/)"/>
 
     <!-- for testing random number features   -->
     <xsl:template match="/" name="xsl:initial-template" expand-text="true">

--- a/src/utils/util/resolver-pipeline/select-or-custom-merge.xsl
+++ b/src/utils/util/resolver-pipeline/select-or-custom-merge.xsl
@@ -91,7 +91,7 @@
 
     <xsl:function name="opr:catalog-identifier" as="xs:string">
         <xsl:param name="catalog-or-profile" as="element()"/>
-        <xsl:sequence select="$catalog-or-profile/(@uuid,document-uri(root(.)))[1]"/>
+        <xsl:sequence select="$catalog-or-profile/(@uuid,base-uri(root(.)))[1]"/>
     </xsl:function>
 
 </xsl:stylesheet>

--- a/src/utils/util/resolver-pipeline/select-or-custom-merge.xsl
+++ b/src/utils/util/resolver-pipeline/select-or-custom-merge.xsl
@@ -33,7 +33,7 @@
         <xsl:param name="context" select="." as="element()"/>
         <xsl:attribute name="opr:id" namespace="http://csrc.nist.gov/ns/oscal/profile-resolution">
             <xsl:value-of
-                select="concat(opr:catalog-identifier($context/root()/o:catalog), '#', $context/(@id, generate-id())[1])"/>
+                select="concat(opr:catalog-identifier($context/root()/(o:catalog|o:profile)), '#', $context/(@id, generate-id())[1])"/>
         </xsl:attribute>
     </xsl:template>
 
@@ -90,8 +90,8 @@
     </xsl:function>
 
     <xsl:function name="opr:catalog-identifier" as="xs:string">
-        <xsl:param name="catalog" as="element(o:catalog)"/>
-        <xsl:sequence select="$catalog/(@uuid,document-uri(root(.)))[1]"/>
+        <xsl:param name="catalog-or-profile" as="element()"/>
+        <xsl:sequence select="$catalog-or-profile/(@uuid,document-uri(root(.)))[1]"/>
     </xsl:function>
 
 </xsl:stylesheet>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/message-handler.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/message-handler.xspec
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:mh="http://csrc.nist.gov/ns/message"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    stylesheet="../../message-handler.xsl"
+    xslt-version="3.0">
+
+    <x:scenario label="Tests for mh:message-handler template">
+        <x:scenario label="Call with text, type, and code">
+            <x:call template="mh:message-handler">
+                <x:param name="text" select="'message text'"/>
+                <x:param name="message-type" select="'Warning'"/>
+                <x:param name="error-code" select="'ERR1'"/>
+            </x:call>
+            <x:expect label="PI indicating type, code, and text">
+                <?message-handler Warning: ERR1: message text?>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Call with text and type only">
+            <x:call template="mh:message-handler">
+                <x:param name="text" select="'message text'"/>
+                <x:param name="message-type" select="'Warning'"/>
+            </x:call>
+            <x:expect label="PI indicating type and text">
+                <?message-handler Warning: message text?>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Call with text and code only">
+            <x:call template="mh:message-handler">
+                <x:param name="text" select="'message text'"/>
+                <x:param name="error-code" select="'ERR1'"/>
+            </x:call>
+            <x:expect label="PI indicating code and text">
+                <?message-handler ERR1: message text?>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Call with text only">
+            <x:call template="mh:message-handler">
+                <x:param name="text" select="'message text'"/>
+            </x:call>
+            <x:expect label="PI indicating text">
+                <?message-handler message text?>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Call with text and type only, with terminate=true">
+            <x:call template="mh:message-handler">
+                <x:param name="text" select="'message text'"/>
+                <x:param name="message-type" select="'Error'"/>
+                <x:param name="terminate" select="true()"/>
+            </x:call>
+            <x:expect label="PI indicating type and text, where type is 'Terminating Error'">
+                <?message-handler Terminating Error: message text?>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+</x:description>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/select.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/select.xspec
@@ -486,25 +486,88 @@
     </x:scenario>
 
     <x:scenario label="Tests for match='profile' mode='o:select' template">
-        <!-- Tests for this template are incomplete. When it is decided whether to keep this
-            approach, we can add more test scenarios.-->
-        <x:scenario label="Profile that calls itself" catch="yes" pending="Returns nothing now">
-            <x:context mode="o:select" select="doc($ov:filedir || '/base-test_profile.xml')/o:profile">
-                <x:param name="uri-stack" tunnel="yes"
-                    select="xs:anyURI($ov:filedir || '/base-test_profile.xml')"/>
-            </x:context>
-            <x:expect label="Fatal XSLT error due to circular reference"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+        <x:scenario label="Tests for circularity error checking: circular_profile.xml > home_profile.xml > circular_profile.xml; ">
+            <x:scenario label="Template context is home_profile.xml, coming from circular_profile.xml" catch="yes">
+                <x:context mode="o:select" select="doc($ov:filedir || '/home_profile.xml')/o:profile">
+                    <x:param name="uri-stack" tunnel="yes"
+                        select="xs:anyURI($ov:filedir || '/circular_profile.xml')"/>
+                </x:context>
+                <!-- Calling oscal-profile-RESOLVE.xsl causes a terminating error, not only a PI representing a terminating error. -->
+                <x:expect label="Fatal XSLT error due to circular reference"
+                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:variable name="error-message" select="$x:result('err')('value')/string()" as="xs:string?"/>
+                <x:expect label="Error message mentions circularity"
+                    test="contains($error-message, 'Terminating Error: Circular reference to profile ')"/>
+                <x:expect label="Problematic import is circular_profile.xml"
+                    test="matches($error-message, 'reference to profile .*/circular_profile\.xml.+Stack:')"/>
+                <x:expect label="Stack of profiles is circular_profile.xml followed by home_profile.xml"
+                    test="matches($error-message, 'Stack: .*/circular_profile\.xml.+/home_profile\.xml')"/>
+            </x:scenario>
+            <x:scenario label="Template context is circular_profile.xml, coming from home_profile.xml" catch="yes">
+                <x:context mode="o:select" select="doc($ov:filedir || '/circular_profile.xml')/o:profile">
+                    <x:param name="uri-stack" tunnel="yes"
+                        select="xs:anyURI($ov:filedir || '/home_profile.xml')"/>
+                </x:context>
+                <x:expect label="Fatal XSLT error due to circular reference"
+                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:variable name="error-message" select="$x:result('err')('value')/string()" as="xs:string?"/>
+                <x:expect label="Error message mentions circularity"
+                    test="contains($error-message, 'Terminating Error: Circular reference to profile ')"/>
+                <x:expect label="Problematic import is home_profile.xml"
+                    test="matches($error-message, 'reference to profile .*/home_profile\.xml.+Stack:')"/>
+                <x:expect label="Stack of profiles is home_profile.xml followed by circular_profile.xml"
+                    test="matches($error-message, 'Stack: .*/home_profile\.xml.+/circular_profile\.xml')"/>
+            </x:scenario>
         </x:scenario>
-        <x:scenario label="Profile that calls a distinct profile"
-            pending="Not implemented yet; revisit later">
-            <x:context mode="o:select" select="doc($ov:filedir || '/base2-test_profile.xml')/o:profile">
-                <x:param name="uri-stack" tunnel="yes"
-                    select="xs:anyURI($ov:filedir || '/base-test_profile.xml')"/>
-            </x:context>
-            <x:expect label="Catalog">
-                <catalog uuid="...">...</catalog>
-            </x:expect>
+        <x:scenario label="Tests for profiles that import distinct profiles: import-profile_profile.xml > import-profile2_profile.xml > base-test_profile.xml; ">
+            <x:scenario label="Template context is import-profile2_profile.xml, coming from import-profile_profile.xml">
+                <!-- import-profile2_profile.xml is the profile we're trying to import, from import-profile_profile.xml. -->
+                <x:context mode="o:select" select="doc($ov:filedir || '/import-profile2_profile.xml')/o:profile">
+                    <x:param name="uri-stack" tunnel="yes"
+                        select="xs:anyURI($ov:filedir || '/import-profile_profile.xml')"/>
+                    <!-- The import instruction tunnel parameter is from the profile
+                        we're coming from, not the profile we're about to import. -->
+                    <x:param name="import-instruction" tunnel="yes"
+                        select="doc($ov:filedir || '/import-profile_profile.xml')/o:profile/o:import"/>
+                </x:context>
+                <x:expect label="selection element, as when importing the catalog that results from resolving import-profile2_profile.xml"
+                    test="*">
+                    <selection opr:src="..." uuid="...">...</selection>
+                </x:expect>
+                <x:expect label="PI indicating recursion"
+                    test="exists(processing-instruction('message-handler')[starts-with(.,'Info: Resolving imported profile')])"/>
+                <x:expect label="The controls included in import-profile2_profile.xml that are also included by import-profile1_profile.xml: a1 and c1"
+                    test="$x:result/descendant::o:control/@id/string()"
+                    select="('a1','c1')"/>
+                <x:expect label="Control a1 has props from import-profile2_profile.xml and the catalog"
+                    test="$x:result/descendant::o:control[@id='a1']/o:prop/@name/string()"
+                    select="('target_child','label')"/>
+            </x:scenario>
+            <x:scenario label="Template context is base-test_profile.xml, coming from import-profile2_profile.xml">
+                <x:context mode="o:select" select="doc($ov:filedir || '/base-test_profile.xml')/o:profile">
+                    <x:param name="uri-stack" tunnel="yes"
+                        select="(
+                        )"/>
+                    <!-- The import instruction tunnel parameter is from the profile
+                        we're coming from, not the profile we're about to import. -->
+                    <x:param name="import-instruction" tunnel="yes"
+                        select="doc($ov:filedir || '/import-profile2_profile.xml')/o:profile/o:import"/>
+                </x:context>
+                <x:expect label="selection element, as when importing the catalog that results from resolving base-test_profile.xml"
+                    test="*">
+                    <selection opr:src="..." uuid="...">...</selection>
+                </x:expect>
+                <x:expect label="PI indicating recursion"
+                    test="exists(processing-instruction('message-handler')[starts-with(.,'Info: Resolving imported profile')])"/>
+                <x:expect label="The controls included in base-test_profile.xml that are also included by import-profile2_profile.xml: a1, b1, and c1"
+                    test="$x:result/descendant::o:control/@id/string()"
+                    select="('a1','b1','c1')"/>
+                <!-- Note about the next x:expect element: A top-level test would see the prop that import-profile2_profile.xml
+                    adds (target_child). However, it is not in the output of this template call, so this scenario does not see it. -->
+                <x:expect label="Control a1 has the prop from the catalog (base-test_profile.xml didn't add any)"
+                    test="$x:result/descendant::o:control[@id='a1']/o:prop/@name/string()"
+                    select="('label')"/>
+            </x:scenario>
         </x:scenario>
     </x:scenario>
 
@@ -603,16 +666,21 @@
             <x:expect label="PI indicating a terminating error"
                 test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
         </x:scenario>
-        <x:scenario label="Error case: Resource reference is circular" catch="yes" pending="XSLT needs to catch up to spec">
-            <x:context mode="o:select"
-                select="(doc($ov:filedir || '/circular_profile.xml')//o:import)[1]"/>
-            <x:expect label="PI indicating a terminating error"
-                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
-        </x:scenario>
         <x:scenario label="Error case: href is not castable as xs:anyURI">
             <x:context mode="o:select"><import/></x:context>
             <x:expect label="PI indicating a terminating error"
                 test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+        </x:scenario>
+        <x:scenario label="Error case: Resource reference is circular" catch="yes">
+            <x:context mode="o:select"
+                select="(doc($ov:filedir || '/circular_profile.xml')//o:import)[1]"/>
+            <!-- Calling oscal-profile-RESOLVE.xsl downstream from this template causes a
+                terminating error, not only a PI representing a terminating error. -->
+            <x:expect label="Fatal XSLT error due to circular reference"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+            <x:variable name="error-message" select="$x:result('err')('value')/string()" as="xs:string?"/>
+            <x:expect label="Error message mentions circularity"
+                test="contains($error-message, 'Terminating Error: Circular reference to profile ')"/>
         </x:scenario>
     </x:scenario>
 
@@ -1495,21 +1563,46 @@
         </x:scenario>
     </x:scenario>
     
-    <x:scenario label="Tests for o:resolve-profile function" pending="incomplete">
-        <!-- Intended for the case where an profile imports another profile,
-            this function is not in use yet. For now, just test that the
-            function can run. When it is decided whether to keep this
-            approach, we can add more test scenarios. -->
-        <x:scenario label="Sanity check">
+    <x:scenario label="Tests for o:resolve-profile function">
+        <x:scenario label="Sanity check: Resolve base-test_profile.xml as if importing from import-profile2_profile.xml">
             <x:call function="o:resolve-profile">
-                <x:param name="profile">
-                    <o:profile href="{$ov:filedir}/base-test_profile.xml"/>
-                </x:param>
-                <x:param name="uri-stack" select="xs:anyURI($ov:filedir || '/base-test_profile.xml')"/>
+                <x:param name="profile" select="doc($ov:filedir || '/base-test_profile.xml')/o:profile"/>
+                <x:param name="uri-stack" select="xs:anyURI($ov:filedir || '/import-profile2_profile.xml')"/>
             </x:call>
-            <x:expect label="Catalog">
+            <x:expect label="Catalog" test="/o:catalog">
                 <catalog uuid="...">...</catalog>
             </x:expect>
+            <x:expect label="Catalog contains the controls included in base-test_profile.xml, including child controls"
+                test="$x:result/descendant::o:control/@id/string()"
+                select="('a1','b1','c1','c3','c3.a','c3.a-1')"/>
+        </x:scenario>
+        <x:scenario label="Resolve base-test_profile.xml as if importing from import-profile1_profile.xml">
+            <x:call function="o:resolve-profile">
+                <x:param name="profile" select="doc($ov:filedir || '/base-test_profile.xml')/o:profile"/>
+                <x:param name="uri-stack" select="(
+                    xs:anyURI($ov:filedir || '/import-profile1_profile.xml'),
+                    xs:anyURI($ov:filedir || '/import-profile2_profile.xml')
+                    )"/>
+            </x:call>
+            <x:expect label="Catalog" test="/o:catalog">
+                <catalog uuid="...">...</catalog>
+            </x:expect>
+            <x:expect label="Catalog contains the controls included in base-test_profile.xml, including child controls"
+                test="$x:result/descendant::o:control/@id/string()"
+                select="('a1','b1','c1','c3','c3.a','c3.a-1')"/>
+        </x:scenario>
+        <x:scenario label="Resolve circular_profile.xml as if importing from home_profile.xml" catch="yes">
+            <x:call function="o:resolve-profile">
+                <x:param name="profile" select="doc($ov:filedir || '/circular_profile.xml')/o:profile"/>
+                <x:param name="uri-stack" select="xs:anyURI($ov:filedir || '/home_profile.xml')"/>
+            </x:call>
+            <x:expect label="Fatal XSLT error due to circular reference"
+                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+            <x:variable name="error-message" select="$x:result('err')('value')/string()" as="xs:string?"/>
+            <x:expect label="Error message mentions circularity"
+                test="contains($error-message, 'Terminating Error: Circular reference to profile ')"/>
+            <x:expect label="Problematic import is home_profile.xml"
+                test="matches($error-message, 'reference to profile .*/home_profile\.xml.+Stack:')"/>
         </x:scenario>
     </x:scenario>
 </x:description>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/select.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/select.xspec
@@ -100,14 +100,14 @@
             <x:expect label="which matches the original catalog's top-level uuid."
                 test="$x:result/o:selection/@uuid = $ov:catalog_uuid"/>
         </x:scenario>
-        <x:scenario label="Error case: Profile cannot find catalog" catch="yes">
+        <x:scenario label="Error case: Profile cannot find catalog">
             <x:context>
                 <profile>
                     <import href="nonexistent_catalog.xml"/>
                 </profile>
             </x:context>
-            <x:expect label="Fatal XSLT error"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+            <x:expect label="PI indicating a terminating error"
+                test="exists($x:result/processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
         </x:scenario>
         <x:scenario label="Profile select include all">
             <x:context>
@@ -576,19 +576,17 @@
                 <selection opr:src="..." uuid="xmlcat">...</selection>
             </x:expect>
         </x:scenario>
-        <x:scenario label="Error case: No rlink child with suitable href or media-type" catch="yes">
+        <x:scenario label="Error case: No rlink child with suitable href or media-type">
             <x:context mode="o:import">
                 <resource uuid="foo">
                     <rlink href="foo.json"/>
                 </resource>
             </x:context>
             <x:variable name="ov:expected_error" as="xs:string">Document not acquired for resource with uuid foo: No rlink with media-type='xml' or href ending with '.xml'</x:variable>
-            <x:expect label="Fatal XSLT error"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
-            <!-- The next assertion requires a newer XSpec version; passes in Oxygen v24, fails in Oxygen v22.1 -->
+            <x:expect label="PI indicating a terminating error"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             <x:expect label="with message specific to situation"
-                test="$x:result('err')('value')/string()"
-                select="$ov:expected_error"/>
+                test="exists($x:result/self::processing-instruction('message-handler')[contains(.,$ov:expected_error)])"/>
         </x:scenario>
     </x:scenario>
 
@@ -599,22 +597,22 @@
             <x:expect label="Selection from imported catalog"
                 select="$ov:catalog-selection-structure"/>
         </x:scenario>
-        <x:scenario label="Error case: Resource is not available" catch="yes">
+        <x:scenario label="Error case: Resource is not available">
             <x:context mode="o:select"
                 select="(doc($ov:filedir || '/broken_profile.xml')//o:import)[1]"/>
-            <x:expect label="Fatal XSLT error"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+            <x:expect label="PI indicating a terminating error"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
         </x:scenario>
         <x:scenario label="Error case: Resource reference is circular" catch="yes" pending="XSLT needs to catch up to spec">
             <x:context mode="o:select"
                 select="(doc($ov:filedir || '/circular_profile.xml')//o:import)[1]"/>
-            <x:expect label="Fatal XSLT error"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+            <x:expect label="PI indicating a terminating error"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
         </x:scenario>
-        <x:scenario label="Error case: href is not castable as xs:anyURI" catch="yes">
+        <x:scenario label="Error case: href is not castable as xs:anyURI">
             <x:context mode="o:select"><import/></x:context>
-            <x:expect label="Fatal XSLT error"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+            <x:expect label="PI indicating a terminating error"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
         </x:scenario>
     </x:scenario>
 
@@ -1488,12 +1486,12 @@
             </x:call>
             <x:expect label="Resolved document" test="exists($x:result/self::document-node()/o:catalog)"/>
         </x:scenario>
-        <x:scenario label="Error case: Document is not available" catch="yes">
+        <x:scenario label="Error case: Document is not available">
             <x:call function="o:resource-or-error">
                 <x:param select="(doc($ov:filedir || '/broken_profile.xml')//o:import)[1]/@href"/>
             </x:call>
-            <x:expect label="Fatal XSLT error"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+            <x:expect label="PI indicating a terminating error"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
         </x:scenario>
     </x:scenario>
     

--- a/src/utils/util/resolver-pipeline/testing/1_selected/select.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/select.xspec
@@ -739,7 +739,7 @@
             <x:call function="opr:catalog-identifier">
                 <x:param href="catalog-no-uuid.xml" select="/o:catalog"/>
             </x:call>
-            <x:expect label="Returns document URI of catalog" test="ends-with($x:result,'/catalog-no-uuid.xml')"/>
+            <x:expect label="Returns base URI of catalog" test="ends-with($x:result,'/catalog-no-uuid.xml')"/>
         </x:scenario>
     </x:scenario>
 

--- a/src/utils/util/resolver-pipeline/testing/2_metadata/metadata.xspec
+++ b/src/utils/util/resolver-pipeline/testing/2_metadata/metadata.xspec
@@ -252,8 +252,8 @@
                         </selection>
                     </profile>
                 </x:context>
-                <x:expect label="Error"
-                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:expect label="oscal-version containing PI indicating a terminating error"
+                    test="exists($x:result/self::o:oscal-version/processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
             <x:scenario label="Most recent version is in profile metadata">
                 <x:context select="/o:profile/o:metadata/o:oscal-version">
@@ -289,16 +289,16 @@
                     <x:param name="source" select="'1.0.0'"/>
                     <x:param name="imported" select="('1.0.0','1.0.1')"/>
                 </x:call>
-                <x:expect label="Error"
-                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:expect label="PI indicating a terminating error"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
             <x:scenario label="Imported document has a newer pre-release identifier" catch="yes">
                 <x:call function="opr:oscal-version">
                     <x:param name="source" select="'1.0.1-rc1'"/>
                     <x:param name="imported" select="('1.0.0','1.0.1-rc2')"/>
                 </x:call>
-                <x:expect label="Error"
-                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:expect label="PI indicating a terminating error"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
         </x:scenario>
         <x:scenario label="Different major version">
@@ -314,8 +314,8 @@
                     <x:param name="source" select="'1.37.40'"/>
                     <x:param name="imported" select="('2.0','1.0.1')"/>
                 </x:call>
-                <x:expect label="Error"
-                    test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
+                <x:expect label="PI indicating a terminating error"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
         </x:scenario>
     </x:scenario>

--- a/src/utils/util/resolver-pipeline/testing/2_metadata/random-util.xspec
+++ b/src/utils/util/resolver-pipeline/testing/2_metadata/random-util.xspec
@@ -8,7 +8,7 @@
     xslt-version="3.0">
 
     <!-- For repeatable testing, use a fixed germ. Also, XSpec
-        cannot evaluate document-uri(/) in the default parameter
+        cannot evaluate base-uri(/) in the default parameter
         value from the XSLT. -->
     <x:param name="germ">x</x:param>
 

--- a/src/utils/util/resolver-pipeline/testing/2_metadata/uuid-method-choice.xspec
+++ b/src/utils/util/resolver-pipeline/testing/2_metadata/uuid-method-choice.xspec
@@ -21,7 +21,11 @@
                 <x:param name="top-uuid" select="'123'"/>
                 <x:param name="uuid-method" select="'user-provided'"/>
             </x:call>
-            <x:expect label="Fixed UUID" select="$ov:fixed"/>
+            <x:expect label="Fixed UUID" test="$x:result[. instance of xs:string]" select="$ov:fixed"/>
+            <x:expect label="PI warning about invalid value"
+                test="$x:result[. instance of processing-instruction('message-handler')]">
+                <?message-handler Warning: top-uuid value, '123', does not meet UUID requirements. Using default UUID instead.?>
+            </x:expect>
         </x:scenario>
         <x:scenario label="Random UUID using XSLT">
             <!-- Random XSLT method requires a global context item.
@@ -42,10 +46,10 @@
                 <x:param name="top-uuid" select="$ov:specified"/>
                 <x:param name="uuid-method" select="'random-java'"/>
             </x:call>
-            <x:expect label="Nonempty string"
-                test="$x:result instance of xs:string and $x:result != ''"/>
+            <x:expect label="Nonempty"
+                test="string($x:result) != ''"/>
             <x:expect label="UUID is neither fixed one nor specified one"
-                test="$x:result ne $ov:specified and $x:result ne $ov:fixed"/>
+                test="string($x:result) ne $ov:specified and string($x:result) ne $ov:fixed"/>
         </x:scenario>
         <!-- FYI: Because the transform relies on use-when, which is evaluated at
             compile time, the same test invocation cannot check both
@@ -68,7 +72,11 @@
                 <x:param name="uuid-service" select="'nonexistent.txt'"/>
                 <x:param name="uuid-method" select="'web-service'"/>
             </x:call>
-            <x:expect label="Fixed UUID" select="$ov:fixed"/>
+            <x:expect label="Fixed UUID" test="$x:result[. instance of xs:string]" select="$ov:fixed"/>
+            <x:expect label="PI warning about unavailable service"
+                test="$x:result[. instance of processing-instruction('message-handler')]">
+                <?message-handler Warning: uuid-service, 'nonexistent.txt', is not available. Using default UUID instead.?>
+            </x:expect>
         </x:scenario>
         <x:scenario label="Fixed UUID">
             <x:call template="u:determine-uuid">
@@ -80,7 +88,11 @@
             <x:call template="u:determine-uuid">
                 <x:param name="uuid-method" select="'junk'"/>
             </x:call>
-            <x:expect label="Fixed UUID" select="$ov:fixed"/>
+            <x:expect label="Fixed UUID" test="$x:result[. instance of xs:string]" select="$ov:fixed"/>
+            <x:expect label="PI warning about unrecognized method"
+                test="$x:result[. instance of processing-instruction('message-handler')]">
+                <?message-handler Warning: uuid-method, 'junk', is not recognized. Using default UUID instead.?>
+            </x:expect>
         </x:scenario>
     </x:scenario>
 </x:description>

--- a/src/utils/util/resolver-pipeline/testing/3_merged/merge-combine.xspec
+++ b/src/utils/util/resolver-pipeline/testing/3_merged/merge-combine.xspec
@@ -6,11 +6,6 @@
     xmlns:x="http://www.jenitennison.com/xslt/xspec"
     stylesheet="../../oscal-profile-resolve-merge.xsl">
 
-    <!-- Override value of $in_xspec global XSLT variable so that error behavior
-        in "Error case: Elements of different kinds" scenario can differ for
-        testing vs. production usage. -->
-    <x:param name="in_xspec" select="true()"/>
-
     <!-- These variables provide contexts that indicate how to combine elements. -->
     <x:variable name="ov:combine-merge">
         <catalog>
@@ -144,7 +139,7 @@
                 </control>
             </x:expect>
         </x:scenario>
-        <x:scenario label="Error case: Elements of different kinds" catch="yes">
+        <x:scenario label="Error case: Elements of different kinds">
             <x:context mode="o:combine-elements" select="$ov:combine-merge">
                 <x:param name="elements" as="element()+" select="//*:control">
                     <selection>
@@ -153,8 +148,10 @@
                     </selection>
                 </x:param>
             </x:context>
-            <x:expect label="XSLT error, fatal when $in_xspec is true"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>            
+            <x:expect label="PI for error about lack of support"
+                test="$x:result/self::processing-instruction('message-handler')">
+                <?message-handler Error: Combining elements of different types is not supported.?>
+            </x:expect>
         </x:scenario>
         <x:scenario label="Empty sequence">
             <x:context mode="o:combine-elements" select="$ov:combine-merge">

--- a/src/utils/util/resolver-pipeline/testing/3_merged/merge.xspec
+++ b/src/utils/util/resolver-pipeline/testing/3_merged/merge.xspec
@@ -79,7 +79,7 @@
                     <!-- no merge -->
                 </catalog>
             </x:context>
-            <x:expect label="All XYZ controls, ungrouped">
+            <x:expect label="All XYZ controls, ungrouped and without nesting">
                 <catalog>
                     <control id="x1"><title>Control X1</title></control>
                     <control id="x2"><title>Control X2</title></control>
@@ -89,11 +89,9 @@
                     <control id="y3"><title>Control Y3</title></control>
                     <control id="z1"><title>Control Z1</title></control>
                     <control id="z2"><title>Control Z2</title></control>
-                    <control id="z3"><title>Control Z3</title>
-                        <control id="z3.a"><title>Control Z3-A</title>
-                            <control id="z3.a-1"><title>Control Z3-A-1</title></control>
-                        </control>
-                    </control>
+                    <control id="z3"><title>Control Z3</title></control>
+                    <control id="z3.a"><title>Control Z3-A</title></control>
+                    <control id="z3.a-1"><title>Control Z3-A-1</title></control>
                 </catalog>
             </x:expect>
         </x:scenario>
@@ -146,11 +144,9 @@
                 <catalog>
                     <control id="x1"><title>Control X1</title></control>
                     <control id="z1"><title>Control Z1</title></control>
-                    <control id="z3"><title>Control Z3</title>
-                        <control id="z3.a"><title>Control Z3-A</title>
-                            <control id="z3.a-1"><title>Control Z3-A-1</title></control>
-                        </control>
-                    </control>
+                    <control id="z3"><title>Control Z3</title></control>
+                    <control id="z3.a"><title>Control Z3-A</title></control>
+                    <control id="z3.a-1"><title>Control Z3-A-1</title></control>
                     <control id="x1">
                         <title>Control X1</title>
                         <prop value="modified property" name="mod"/>
@@ -159,11 +155,9 @@
                     <control id="y1"><title>Control Y1</title></control>
                     <control id="y2"><title>Control Y2</title></control>
                     <control id="y3"><title>Control Y3</title></control>
-                    <control id="z3"><title>Control Z3</title>
-                        <control id="z3.a"><title>Control Z3-A</title>
-                            <control id="z3.a-1"><title>Control Z3-A-1</title></control>
-                        </control>
-                    </control>
+                    <control id="z3"><title>Control Z3</title></control>
+                    <control id="z3.a"><title>Control Z3-A</title></control>
+                    <control id="z3.a-1"><title>Control Z3-A-1</title></control>
                 </catalog>
             </x:expect>
         </x:scenario>
@@ -305,7 +299,7 @@
     <!-- Tests for match=catalog[exists(merge/custom)] priority=13 template are in merge-custom.xspec -->
 
     <x:scenario label="Tests for detect-multiple-structuring-directives template">
-        <x:scenario label="Error case: custom appears and as-is is true" catch="yes">
+        <x:scenario label="Error case: custom appears and as-is is true">
             <x:context>
                 <catalog uuid="xyz-tiny_catalog">
                     <merge>
@@ -315,10 +309,10 @@
                 </catalog>
             </x:context>
             <x:call template="detect-multiple-structuring-directives"/>
-            <x:expect label="Fatal XSLT error"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>            
+            <x:expect label="PI indicating a terminating error"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>            
         </x:scenario>
-        <x:scenario label="Error case: custom appears and flat is true" catch="yes">
+        <x:scenario label="Error case: custom appears and flat is true">
             <x:context>
                 <catalog uuid="xyz-tiny_catalog">
                     <merge>
@@ -328,10 +322,10 @@
                 </catalog>
             </x:context>
             <x:call template="detect-multiple-structuring-directives"/>
-            <x:expect label="Fatal XSLT error"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>            
+            <x:expect label="PI indicating a terminating error"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>            
         </x:scenario>
-        <x:scenario label="Error case: as-is and flat are both true" catch="yes">  
+        <x:scenario label="Error case: as-is and flat are both true">  
             <x:context>
                 <catalog>
                     <merge>
@@ -341,10 +335,10 @@
                 </catalog>
             </x:context>
             <x:call template="detect-multiple-structuring-directives"/>
-            <x:expect label="Fatal XSLT error"
-                test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>            
+            <x:expect label="PI indicating a terminating error"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>            
         </x:scenario>
-        <x:scenario label="Non-error case: as-is and flat both appear but flat is not true" catch="no">  
+        <x:scenario label="Non-error case: as-is and flat both appear but flat is not true">  
             <x:context>
                 <catalog>
                     <merge>

--- a/src/utils/util/resolver-pipeline/testing/4_modified/modify.xspec
+++ b/src/utils/util/resolver-pipeline/testing/4_modified/modify.xspec
@@ -122,7 +122,7 @@
                 </catalog>
             </x:expect>
         </x:scenario>
-        
+
         <x:scenario label="Simple property addition to a control, solo">
             <x:context>
                 <catalog id="abc">
@@ -197,7 +197,7 @@
                 </catalog>
             </x:expect>
         </x:scenario>
-        
+
         <x:scenario label="Add a part and a prop, explicit ending position">
             <x:context>
                 <catalog id="abc">
@@ -297,10 +297,10 @@
         <x:context select="$ov:catalog1//o:modify"/>
         <x:expect label="Nothing" select="()"/>
     </x:scenario>
-        
+
     <x:scenario label="Tests for match=set-parameter template">
-        <x:scenario label="set-param child does not match anything">
-            <x:context select="//set-parameter">
+        <x:scenario label="set-parameter child does not match anything">
+            <x:context select="//o:set-parameter">
                 <catalog id="abc">
                     <param id="p1">
                         <label>Parameter #1</label>
@@ -312,12 +312,14 @@
                     </modify>
                 </catalog>
             </x:context>
-            <x:expect label="No result; there is a nonfatal warning message but we don't catch it"
-                select="()"/>
+            <x:expect label="No elements" test="$x:result/self::element()" select="()"/>
+            <x:expect label="PI for warning" test="$x:result/self::processing-instruction('message-handler')">
+                <?message-handler Warning: set-parameter with param-id="nonexistent" does not match any param id.?>
+            </x:expect>
         </x:scenario>
     </x:scenario>
 
-    <x:scenario label="Tests for match=param priority=2 template">
+    <x:scenario label="Tests for name=process-param template">
         <x:scenario label="Basic case: Add a constraint to a parameter that doesn't have one">
             <x:variable name="ov:context">
                 <catalog id="abc">
@@ -331,16 +333,17 @@
                     </modify>
                 </catalog>
             </x:variable>
-            <x:context select="$ov:context//o:param">
+            <x:context select="$ov:context//o:param"/>
+            <x:call template="process-param">
                 <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
-            </x:context>
+            </x:call>
             <x:expect label="Copy of parameter with constraint inserted">
                 <param id="p1">
                     <label>Parameter #1</label>
                     <constraint>at least every 3 years</constraint>
-                </param>                
+                </param>
             </x:expect>
-        </x:scenario>        
+        </x:scenario>
         <x:scenario label="Add constraint, guideline, and link to a parameter that has these items">
             <x:variable name="ov:context">
                 <catalog id="abc">
@@ -360,9 +363,10 @@
                     </modify>
                 </catalog>
             </x:variable>
-            <x:context select="$ov:context//o:param">
+            <x:context select="$ov:context//o:param"/>
+            <x:call template="process-param">
                 <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
-            </x:context>
+            </x:call>
             <x:expect label="Parameter with link, constraint, and guideline inserted after existing ones; remarks preserved">
                 <param id="p1">
                     <link href="ORIGINAL"/>
@@ -373,9 +377,9 @@
                     <guideline><p>ORIGINAL guideline</p></guideline>
                     <guideline><p>NEW guideline</p></guideline>
                     <remarks><p>ORIGINAL remarks</p></remarks>
-                </param>                
+                </param>
             </x:expect>
-        </x:scenario>        
+        </x:scenario>
         <x:scenario label="Override label, usage, and value, keeping the last one of each element">
             <x:variable name="ov:context">
                 <catalog id="abc">
@@ -402,9 +406,10 @@
                     </modify>
                 </catalog>
             </x:variable>
-            <x:context select="$ov:context//o:param">
+            <x:context select="$ov:context//o:param"/>
+            <x:call template="process-param">
                 <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
-            </x:context>
+            </x:call>
             <x:expect label="Newer label, usage, and value; original constraint plus new one">
                 <param id="p1">
                     <label>Further Modified Parameter #1</label>
@@ -412,7 +417,7 @@
                     <constraint>in the first quarter</constraint>
                     <constraint>at least every 3 years</constraint>
                     <value>NEWER</value>
-                </param>                
+                </param>
             </x:expect>
         </x:scenario>
         <x:scenario label="select and value are mutually exclusive; keep the last one in document order">
@@ -442,18 +447,19 @@
                     </modify>
                 </catalog>
             </x:variable>
-            <x:context select="$ov:context//o:param">
+            <x:context select="$ov:context//o:param"/>
+            <x:call template="process-param">
                 <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
-            </x:context>
+            </x:call>
             <x:expect label="p1 has select, while p2 has NEW value">
                 <param id="p1">
                     <label>Parameter #1</label>
                     <select><choice>1</choice></select>
-                </param>                
+                </param>
                 <param id="p2">
                     <label>Parameter #2</label>
                     <value>NEW</value>
-                </param>                
+                </param>
             </x:expect>
         </x:scenario>
         <x:scenario label="Override prop with same uuid, and insert prop with distinct uuid">
@@ -487,9 +493,10 @@
                     </modify>
                 </catalog>
             </x:variable>
-            <x:context select="$ov:context//o:param">
+            <x:context select="$ov:context//o:param"/>
+            <x:call template="process-param">
                 <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
-            </x:context>
+            </x:call>
             <x:expect label="All uuid-lacking props in order. Among uuid-bearing props, the survivors are original bbb, newer ccc, and newest aaa">
                 <param id="p1">
                     <prop value="1" name="pr1"/>
@@ -504,7 +511,7 @@
                     <prop value="NEWEST-A" name="aaa" uuid="309deb03-491b-4677-9148-bc1b79a21c9c"/>
                     <prop value="8" name="pr8"/>
                     <label>Parameter #1</label>
-                </param>                
+                </param>
             </x:expect>
         </x:scenario>
     </x:scenario>
@@ -522,7 +529,7 @@
                         <prop value="20" name="add2"/>
                         <prop value="1" name="source1"/>
                         <prop value="2" name="source2"/>
-                    </control>                    
+                    </control>
                 </x:expect>
             </x:scenario>
             <x:scenario label="with position=ending">
@@ -535,7 +542,7 @@
                         <prop value="2" name="source2"/>
                         <prop value="10" name="add1"/>
                         <prop value="20" name="add2"/>
-                    </control>                    
+                    </control>
                 </x:expect>
             </x:scenario>
             <x:scenario label="with no valid position">
@@ -548,34 +555,20 @@
                         <prop value="2" name="source2"/>
                         <prop value="10" name="add1"/>
                         <prop value="20" name="add2"/>
-                    </control>                    
+                    </control>
                 </x:expect>
             </x:scenario>
             <x:scenario label="with position=before">
                 <x:variable name="ov:add-position" select="'before'"/>
                 <x:like label="SHARED_add-parameterized-position"/>
-                <x:expect label="Props added inside control after title (same as position=starting)">
-                    <control id="a1">
-                        <title>Control A</title>
-                        <prop value="10" name="add1"/>
-                        <prop value="20" name="add2"/>
-                        <prop value="1" name="source1"/>
-                        <prop value="2" name="source2"/>
-                    </control>                    
-                </x:expect>
+                <x:expect label="Error (before is not the same as starting)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
             <x:scenario label="with position=after">
                 <x:variable name="ov:add-position" select="'after'"/>
                 <x:like label="SHARED_add-parameterized-position"/>
-                <x:expect label="Props added inside control after other content (same as position=ending)">
-                    <control id="a1">
-                        <title>Control A</title>
-                        <prop value="1" name="source1"/>
-                        <prop value="2" name="source2"/>
-                        <prop value="10" name="add1"/>
-                        <prop value="20" name="add2"/>
-                    </control>                    
-                </x:expect>
+                <x:expect label="Error (after is not the same as ending)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
             <x:scenario label="adding title to this control">
                 <x:variable name="ov:context">
@@ -601,10 +594,10 @@
                         <title>Control A</title>
                         <title>New Title</title>
                         <prop value="1" name="source1"/>
-                    </control>                    
+                    </control>
                 </x:expect>
             </x:scenario>
-            <x:scenario label="with a child control marked as removed">
+            <x:scenario label="where this control is a child control independently marked as removed">
                 <x:variable name="ov:context">
                     <catalog id="abc">
                         <control id="a1">
@@ -634,7 +627,8 @@
                 <x:context select="$ov:context//o:control[@id='a1.1']">
                     <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
                 </x:context>
-                <x:expect label="Nothing, because the control was removed" select="()"/>
+                <x:expect label="Error (cannot modify a removed control)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
             <x:scenario label="with multiple identically configured alter directives">
                 <x:variable name="ov:context">
@@ -672,7 +666,7 @@
                         <prop value="20" name="add2"/>
                         <prop value="30" name="add3"/>
                         <prop value="40" name="add4"/>
-                    </control>                    
+                    </control>
                 </x:expect>
             </x:scenario>
             <x:scenario label="with multiple alter directives and different positions">
@@ -711,7 +705,7 @@
                         <prop value="2" name="source2"/>
                         <prop value="10" name="add1"/>
                         <prop value="20" name="add2"/>
-                    </control>                    
+                    </control>
                 </x:expect>
             </x:scenario>
             <x:scenario label="with multiple identically configured add directives in one alter">
@@ -748,21 +742,23 @@
                         <prop value="20" name="add2"/>
                         <prop value="30" name="add3"/>
                         <prop value="40" name="add4"/>
-                    </control>                    
+                    </control>
                 </x:expect>
             </x:scenario>
         </x:scenario>
-        <x:scenario label="Explicit binding to this control as a descendant of another control, ">
-            <x:scenario label="with position=starting">
+        <x:scenario label="Explicit binding to this control as a child of another control, ">
+            <x:scenario label="with position=starting, trying to insert part">
                 <x:variable name="ov:add-position" select="'starting'"/>
                 <x:variable name="ov:by-id" select="'a1.1'"/>
-                <x:like label="SHARED_add-explicit-parameterized-position"/>
-                <x:expect label="Part added inside control A.1 before other content">
+                <x:like label="SHARED_add-explicit-part-parameterized-position"/>
+                <x:expect label="Error (selection type is control, while insertion type is part)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+<!--                <x:expect label="Part added inside control A.1 before other content">
                     <control id="a1.1">
                         <title>Control A.1</title>
                         <part name="statement" id="new-stmt">
                             <p>New text</p>
-                        </part>                            
+                        </part>
                         <prop value="3" name="source3"/>
                         <prop value="4" name="source4"/>
                         <part name="statement" id="a1.1-stmt">
@@ -770,12 +766,15 @@
                         </part>
                     </control>
                 </x:expect>
+-->
             </x:scenario>
-            <x:scenario label="with position=ending">
+            <x:scenario label="with position=ending, trying to insert part">
                 <x:variable name="ov:add-position" select="'ending'"/>
                 <x:variable name="ov:by-id" select="'a1.1'"/>
-                <x:like label="SHARED_add-explicit-parameterized-position"/>
-                <x:expect label="Part added inside control A.1 after other content">
+                <x:like label="SHARED_add-explicit-part-parameterized-position"/>
+                <x:expect label="Error (selection type is control, while insertion type is part)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+<!--                <x:expect label="Part added inside control A.1 after other content">
                     <control id="a1.1">
                         <title>Control A.1</title>
                         <prop value="3" name="source3"/>
@@ -785,15 +784,18 @@
                         </part>
                         <part name="statement" id="new-stmt">
                             <p>New text</p>
-                        </part>                            
+                        </part>
                     </control>
                 </x:expect>
+-->
             </x:scenario>
-            <x:scenario label="with no valid position">
+            <x:scenario label="with no valid position, trying to insert part">
                 <x:variable name="ov:add-position" select="''"/>
                 <x:variable name="ov:by-id" select="'a1.1'"/>
-                <x:like label="SHARED_add-explicit-parameterized-position"/>
-                <x:expect label="Part added inside control A.1 after other content (same as position=ending)">
+                <x:like label="SHARED_add-explicit-part-parameterized-position"/>
+                <x:expect label="Error (selection type is control, while insertion type is part)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+<!--                <x:expect label="Part added inside control A.1 after other content (same as position=ending)">
                     <control id="a1.1">
                         <title>Control A.1</title>
                         <prop value="3" name="source3"/>
@@ -803,47 +805,12 @@
                         </part>
                         <part name="statement" id="new-stmt">
                             <p>New text</p>
-                        </part>                            
-                    </control>
-                </x:expect>
-            </x:scenario>
-            <x:scenario label="with position=before">
-                <x:variable name="ov:add-position" select="'before'"/>
-                <x:variable name="ov:by-id" select="'a1.1'"/>
-                <x:like label="SHARED_add-explicit-parameterized-position"/>
-                <x:expect label="Part added outside and before control A.1">
-                    <part name="statement" id="new-stmt">
-                        <p>New text</p>
-                    </part>                            
-                    <control id="a1.1">
-                        <title>Control A.1</title>
-                        <prop value="3" name="source3"/>
-                        <prop value="4" name="source4"/>
-                        <part name="statement" id="a1.1-stmt">
-                            <p>Text</p>
                         </part>
                     </control>
                 </x:expect>
+-->
             </x:scenario>
-            <x:scenario label="with position=after">
-                <x:variable name="ov:add-position" select="'after'"/>
-                <x:variable name="ov:by-id" select="'a1.1'"/>
-                <x:like label="SHARED_add-explicit-parameterized-position"/>
-                <x:expect label="Part added outside and after control A.1">
-                    <control id="a1.1">
-                        <title>Control A.1</title>
-                        <prop value="3" name="source3"/>
-                        <prop value="4" name="source4"/>
-                        <part name="statement" id="a1.1-stmt">
-                            <p>Text</p>
-                        </part>
-                    </control>
-                    <part name="statement" id="new-stmt">
-                        <p>New text</p>
-                    </part>                            
-                </x:expect>
-            </x:scenario>
-            <x:scenario label="adding title to this control">
+            <x:scenario label="with position=starting, trying to insert title">
                 <x:variable name="ov:context">
                     <catalog id="abc">
                         <control id="a1">
@@ -865,14 +832,125 @@
                 <x:context select="$ov:context//o:control[@id='a1.1']">
                     <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
                 </x:context>
-                <x:expect label="Old and new titles (next pipeline phase will keep exactly one)">
+                <x:expect label="Error (selection type is control, while insertion type is title)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+                <!--                <x:expect label="Old and new titles (next pipeline phase will keep exactly one)">
                     <control id="a1.1">
                         <title>Control A.1</title>
                         <title>New Title</title>
                         <prop value="3" name="source3"/>
-                    </control>                    
+                    </control>
+                </x:expect>
+-->
+            </x:scenario>
+            <x:scenario label="with position=starting, trying to insert control">
+                <x:variable name="ov:add-position" select="'starting'"/>
+                <x:variable name="ov:by-id" select="'a1.1'"/>
+                <x:like label="SHARED_add-explicit-control-parameterized-position"/>
+                <x:expect label="Error (unsupported position)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+                <!--                <x:expect label="Part added inside control A.1 before other content">
+                    <control id="a1.1">
+                        <title>Control A.1</title>
+                        <part name="statement" id="new-stmt">
+                            <p>New text</p>
+                        </part>
+                        <prop value="3" name="source3"/>
+                        <prop value="4" name="source4"/>
+                        <part name="statement" id="a1.1-stmt">
+                            <p>Text</p>
+                        </part>
+                    </control>
+                </x:expect>
+-->
+            </x:scenario>
+            <x:scenario label="with position=ending, trying to insert control">
+                <x:variable name="ov:add-position" select="'ending'"/>
+                <x:variable name="ov:by-id" select="'a1.1'"/>
+                <x:like label="SHARED_add-explicit-control-parameterized-position"/>
+                <x:expect label="Error (unsupported position)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+                <!--                <x:expect label="Part added inside control A.1 after other content">
+                    <control id="a1.1">
+                        <title>Control A.1</title>
+                        <prop value="3" name="source3"/>
+                        <prop value="4" name="source4"/>
+                        <part name="statement" id="a1.1-stmt">
+                            <p>Text</p>
+                        </part>
+                        <part name="statement" id="new-stmt">
+                            <p>New text</p>
+                        </part>
+                    </control>
+                </x:expect>
+-->
+            </x:scenario>
+            <x:scenario label="with no valid position, trying to insert control">
+                <x:variable name="ov:add-position" select="''"/>
+                <x:variable name="ov:by-id" select="'a1.1'"/>
+                <x:like label="SHARED_add-explicit-control-parameterized-position"/>
+                <x:expect label="Error (unsupported position)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+                <!--                <x:expect label="Part added inside control A.1 after other content (same as position=ending)">
+                    <control id="a1.1">
+                        <title>Control A.1</title>
+                        <prop value="3" name="source3"/>
+                        <prop value="4" name="source4"/>
+                        <part name="statement" id="a1.1-stmt">
+                            <p>Text</p>
+                        </part>
+                        <part name="statement" id="new-stmt">
+                            <p>New text</p>
+                        </part>
+                    </control>
+                </x:expect>
+-->
+            </x:scenario>
+
+            <x:scenario label="with position=before, trying to insert control">
+                <x:variable name="ov:add-position" select="'before'"/>
+                <x:variable name="ov:by-id" select="'a1.1'"/>
+                <x:like label="SHARED_add-explicit-control-parameterized-position"/>
+                <x:expect label="Control added outside and before control A.1">
+                    <control id="new-control">
+                        <title>New control</title>
+                    </control>
+                    <control id="a1.1">
+                        <title>Control A.1</title>
+                        <prop value="3" name="source3"/>
+                        <prop value="4" name="source4"/>
+                        <part name="statement" id="a1.1-stmt">
+                            <p>Text</p>
+                        </part>
+                    </control>
                 </x:expect>
             </x:scenario>
+            <x:scenario label="with position=after, trying to insert control">
+                <x:variable name="ov:add-position" select="'after'"/>
+                <x:variable name="ov:by-id" select="'a1.1'"/>
+                <x:like label="SHARED_add-explicit-control-parameterized-position"/>
+                <x:expect label="Part added outside and after control A.1">
+                    <control id="a1.1">
+                        <title>Control A.1</title>
+                        <prop value="3" name="source3"/>
+                        <prop value="4" name="source4"/>
+                        <part name="statement" id="a1.1-stmt">
+                            <p>Text</p>
+                        </part>
+                    </control>
+                    <control id="new-control">
+                        <title>New control</title>
+                    </control>
+                </x:expect>
+            </x:scenario>
+            <x:scenario label="with position=before, trying to insert part">
+                <x:variable name="ov:add-position" select="'before'"/>
+                <x:variable name="ov:by-id" select="'a1.1'"/>
+                <x:like label="SHARED_add-explicit-part-parameterized-position"/>
+                <x:expect label="Error (selection type is control, while insertion type is part)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+            </x:scenario>
+
             <x:scenario label="with a child control marked as removed">
                 <x:variable name="ov:context">
                     <catalog id="abc">
@@ -891,7 +969,7 @@
                         <modify>
                             <alter control-id="a1">
                                 <remove by-id="a1.1"/>
-                                <add position="starting" by-id="a1.1">
+                                <add position="before" by-id="a1.1">
                                     <title>New Title</title>
                                 </add>
                             </alter>
@@ -901,32 +979,51 @@
                 <x:context select="$ov:context//o:control[@id='a1.1']">
                     <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
                 </x:context>
-                <x:expect label="Nothing, because the control was removed" select="()"/>
+                <x:expect label="Error (cannot modify a removed control)"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
         </x:scenario>
-        <x:scenario label="Inoperative case: Explicit binding to control identified in alter, rather than object inside" pending="Supported? See https://github.com/usnistgov/OSCAL/discussions/1305">
+        <x:scenario label="Explicit binding to same control identified in alter, rather than object inside">
             <x:variable name="ov:by-id" select="'a1'"/>
-            <x:like label="SHARED_add-explicit-parameterized-position"/>
-            <x:expect label="No change">
+            <x:variable name="ov:add-position" select="'ending'"/>
+            <x:like label="SHARED_add-explicit-control-parameterized-position"/>
+            <x:expect label="Control added inside control A, at end">
                 <control id="a1">
                     <title>Control A</title>
                     <prop value="1" name="source1"/>
                     <prop value="2" name="source2"/>
-                    <part name="statement" id="a1-stmt">
-                        <p>Text</p>
-                    </part>
-                    <control id="a1.1">
-                        <title>Control A.1</title>
-                        <prop value="3" name="source3"/>
-                        <prop value="4" name="source4"/>
-                        <part name="statement" id="a1.1-stmt">
-                            <p>Text</p>
-                        </part>
+                    <part name="statement" id="a1-stmt">...</part>
+                    <control id="a1.1">...</control>
+                    <control id="new-control">
+                        <title>New control</title>
                     </control>
                 </control>
             </x:expect>
+            <x:pending label="Use these x:expect elements if situation is an inoperative case, NOT like #1311. See https://github.com/usnistgov/OSCAL/discussions/1305.">
+                <x:expect label="No change">
+                    <control id="a1">
+                        <title>Control A</title>
+                        <prop value="1" name="source1"/>
+                        <prop value="2" name="source2"/>
+                        <part name="statement" id="a1-stmt">
+                            <p>Text</p>
+                        </part>
+                        <control id="a1.1">
+                            <title>Control A.1</title>
+                            <prop value="3" name="source3"/>
+                            <prop value="4" name="source4"/>
+                            <part name="statement" id="a1.1-stmt">
+                                <p>Text</p>
+                            </part>
+                        </control>
+                    </control>
+                </x:expect>
+                <x:expect label="New control is not present"
+                    test="empty(//control[@id='new-control']"/>
+            </x:pending>
         </x:scenario>
-        <x:scenario label="Inoperative case: Explicit binding with no matching id">
+        <x:scenario label="Error case: Explicit binding with no matching id">
+            <!--  TODO: I think the spec says inoperative and lags the latest discussions. -->
             <x:variable name="ov:context">
                 <catalog id="abc">
                     <control id="a1">
@@ -951,16 +1048,65 @@
             <x:context select="$ov:context//*[@id='a1']">
                 <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
             </x:context>
-            <x:expect label="No change">
-                <control id="a1">
-                    <title>Control A</title>
-                    <prop value="1" name="source1"/>
-                    <prop value="2" name="source2"/>
-                    <part name="statement" id="a1-stmt">
-                        <p>Text</p>
-                    </part>
-                </control>
-            </x:expect>
+            <x:expect label="Error (by-id does not match anything)"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+            <x:pending label="Use this x:expect element if error is nonfatal">
+                <x:expect label="No change">
+                    <control id="a1">
+                        <title>Control A</title>
+                        <prop value="1" name="source1"/>
+                        <prop value="2" name="source2"/>
+                        <part name="statement" id="a1-stmt">
+                            <p>Text</p>
+                        </part>
+                    </control>
+                </x:expect>
+            </x:pending>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for oscal:no-valid-position-given function">
+        <x:scenario label="Invalid value">
+            <x:call function="oscal:no-valid-position-given">
+                <x:param select="//*/@position"><foo position="junk"/></x:param>
+            </x:call>
+            <x:expect label="true" select="true()"/>
+        </x:scenario>
+        <x:scenario label="Empty string value">
+            <x:call function="oscal:no-valid-position-given">
+                <x:param select="//*/@position"><foo position=""/></x:param>
+            </x:call>
+            <x:expect label="true" select="true()"/>
+        </x:scenario>
+        <x:scenario label="Missing value">
+            <x:call function="oscal:no-valid-position-given">
+                <x:param select="//*/@position"><foo/></x:param>
+            </x:call>
+            <x:expect label="true" select="true()"/>
+        </x:scenario>
+        <x:scenario label="Valid value, before">
+            <x:call function="oscal:no-valid-position-given">
+                <x:param select="//*/@position"><foo position="before"/></x:param>
+            </x:call>
+            <x:expect label="false" select="false()"/>
+        </x:scenario>
+        <x:scenario label="Valid value, after">
+            <x:call function="oscal:no-valid-position-given">
+                <x:param select="//*/@position"><foo position="after"/></x:param>
+            </x:call>
+            <x:expect label="false" select="false()"/>
+        </x:scenario>
+        <x:scenario label="Valid value, starting">
+            <x:call function="oscal:no-valid-position-given">
+                <x:param select="//*/@position"><foo position="starting"/></x:param>
+            </x:call>
+            <x:expect label="false" select="false()"/>
+        </x:scenario>
+        <x:scenario label="Valid value, ending">
+            <x:call function="oscal:no-valid-position-given">
+                <x:param select="//*/@position"><foo position="ending"/></x:param>
+            </x:call>
+            <x:expect label="false" select="false()"/>
         </x:scenario>
     </x:scenario>
 
@@ -979,7 +1125,7 @@
                 <x:param name="modifications">
                     <modify>
                         <alter control-id="a1">
-                            <add by-id="a1-stmt">
+                            <add by-id="a1-stmt" position="after">
                                 <part name="statement" id="new-stmt"/>
                             </add>
                         </alter>
@@ -987,9 +1133,9 @@
                 </x:param>
             </x:call>
             <x:expect label="The add element">
-                <add by-id="a1-stmt">
+                <add by-id="a1-stmt" position="after">
                     <part name="statement" id="new-stmt"/>
-                </add>                
+                </add>
             </x:expect>
         </x:scenario>
         <x:scenario label="Multiple matching add elements in multiple alter elements">
@@ -998,24 +1144,24 @@
                     <control id="a1">
                         <title>Control A</title>
                         <part name="statement" id="a1-stmt"/>
-                        <part name="extra-part" id="a1-extra"/>
+                        <part name="nonmatch-part" id="a1-nonmatch"/>
                     </control>
                 </x:param>
                 <x:param name="modifications">
                     <modify>
                         <alter control-id="a1">
-                            <add by-id="a1-stmt">
+                            <add by-id="a1-stmt" position="after">
                                 <part name="statement" id="new-stmt"/>
                             </add>
-                            <add by-id="a1-extra">
-                                <part name="extra" id="new-extra"/>
+                            <add by-id="a1-nonmatch" position="after">
+                                <part name="nonmatch" id="new-nonmatch"/>
                             </add>
                         </alter>
                         <alter control-id="a1">
-                            <add by-id="a1-stmt">
+                            <add by-id="a1-stmt" position="before">
                                 <part name="another-statement" id="new-stmt-2"/>
                             </add>
-                            <add by-id="a1-stmt">
+                            <add by-id="a1-stmt" position="after">
                                 <part name="yet-another-statement" id="new-stmt-3"/>
                             </add>
                         </alter>
@@ -1023,31 +1169,32 @@
                 </x:param>
             </x:call>
             <x:expect label="All matching add elements">
-                <add by-id="a1-stmt">
+                <add by-id="a1-stmt" position="after">
                     <part name="statement" id="new-stmt"/>
                 </add>
-                <add by-id="a1-stmt">
+                <add by-id="a1-stmt" position="before">
                     <part name="another-statement" id="new-stmt-2"/>
                 </add>
-                <add by-id="a1-stmt">
+                <add by-id="a1-stmt" position="after">
                     <part name="yet-another-statement" id="new-stmt-3"/>
                 </add>
             </x:expect>
             <x:expect label="No nonmatching add element"
-                test="empty(//*[@by-id='a1-extra'])"/>
+                test="empty(//*[@by-id='a1-nonmatch'])"/>
         </x:scenario>
-        <x:scenario label="No matching add elements">
+        <x:scenario label="Nothing in $modifications matches $here">
             <x:call function="oscal:patches-to-id-targeting-ancestor">
                 <x:param name="here" select="//*[@id='a1-stmt']">
                     <control id="a1">
                         <title>Control A</title>
                         <part name="statement" id="a1-stmt"/>
+                        <part name="another-statement" id="a1-another-stmt"/>
                     </control>
                 </x:param>
                 <x:param name="modifications">
                     <modify>
                         <alter control-id="a1">
-                            <add by-id="nonexistent">
+                            <add by-id="a1-another-stmt" position="after">
                                 <part name="statement" id="new-stmt"/>
                             </add>
                         </alter>
@@ -1056,7 +1203,34 @@
             </x:call>
             <x:expect label="Nothing" select="()"/>
         </x:scenario>
-        <x:scenario label="Match is inside descendant control compared to the control to which 'alter' points">
+        <x:scenario label="Match is inside child control compared to the control to which 'alter' points (not supported)">
+            <x:call function="oscal:patches-to-id-targeting-ancestor">
+                <x:param name="here" select="//*[@id='a1-stmt']">
+                    <control id="a1">
+                        <title>Control A</title>
+                        <control id="a1.1">
+                            <title>Control A1</title>
+                            <control id="a1.1.1">
+                                <title>Control A1-1</title>
+                                <part name="statement" id="a1-stmt"/>
+                            </control>
+                        </control>
+                    </control>
+                </x:param>
+                <x:param name="modifications">
+                    <modify>
+                        <alter control-id="a1.1">
+                            <add by-id="a1-stmt" position="after">
+                                <part name="statement" id="new-stmt"/>
+                            </add>
+                        </alter>
+                    </modify>
+                </x:param>
+            </x:call>
+            <x:expect label="Nothing, because the child control's descendants are not in scope for modifications to the parent control"
+                select="()"/>
+        </x:scenario>
+        <x:scenario label="Match is inside non-child descendant control compared to the control to which 'alter' points (not supported)">
             <x:call function="oscal:patches-to-id-targeting-ancestor">
                 <x:param name="here" select="//*[@id='a1-stmt']">
                     <control id="a1">
@@ -1073,25 +1247,17 @@
                 <x:param name="modifications">
                     <modify>
                         <alter control-id="a1">
-                            <add by-id="a1-stmt">
+                            <add by-id="a1-stmt" position="after">
                                 <part name="statement" id="new-stmt"/>
                             </add>
                         </alter>
                     </modify>
                 </x:param>
             </x:call>
-            <x:expect label="The add element">
-                <add by-id="a1-stmt">
-                    <part name="statement" id="new-stmt"/>
-                </add>                
-            </x:expect>
+            <x:expect label="Nothing, because the descendant control's descendants are not in scope for modifications to the ancestor control"
+                select="()"/>
         </x:scenario>
-        <x:scenario label="Match is the same control to which 'alter' points">
-            <!-- Question: Is this case supposed to work? If not, then in the function, change
-            <xsl:variable name="controls" select="$here/ancestor-or-self::control" as="element(control)*"/>
-            back to
-            <xsl:variable name="controls" select="$here/ancestor::control" as="element(control)*"/>
-            -->
+        <x:scenario label="Match is the same control to which 'alter' points (supported per #1311 and treated like implicit binding)">
             <x:call function="oscal:patches-to-id-targeting-ancestor">
                 <x:param name="here" select="//*[@id='a1.1']">
                     <control id="a1">
@@ -1108,25 +1274,17 @@
                 <x:param name="modifications">
                     <modify>
                         <alter control-id="a1.1">
-                            <add by-id="a1.1">
-                                <part name="statement" id="new-stmt"/>
+                            <add by-id="a1.1" position="starting">
+                                <part id="new-stmt"/>
                             </add>
                         </alter>
                     </modify>
                 </x:param>
             </x:call>
-            <x:expect label="The add element">
-                <add by-id="a1.1">
-                    <part name="statement" id="new-stmt"/>
-                </add>                
-            </x:expect>
+            <x:expect label="Nothing, because that case is handled by code for implicit binding"
+                select="()"/>
         </x:scenario>
-        <x:scenario label="Match is a descendant control compared to the control to which 'alter' points">
-            <!-- Question: Is this case supposed to work? If not, then in the function, change
-            <xsl:variable name="controls" select="$here/ancestor-or-self::control" as="element(control)*"/>
-            back to
-            <xsl:variable name="controls" select="$here/ancestor::control" as="element(control)*"/>
-            -->
+        <x:scenario label="Match is a child control compared to the control to which 'alter' points">
             <x:call function="oscal:patches-to-id-targeting-ancestor">
                 <x:param name="here" select="//*[@id='a1.1.1']">
                     <control id="a1">
@@ -1144,7 +1302,8 @@
                     <modify>
                         <alter control-id="a1.1">
                             <add position="before" by-id="a1.1.1">
-                                <part name="statement" id="new-stmt"/>
+                                <control id="new-control1"/>
+                                <control id="new-control2"/>
                             </add>
                         </alter>
                     </modify>
@@ -1152,13 +1311,68 @@
             </x:call>
             <x:expect label="The add element">
                 <add position="before" by-id="a1.1.1">
-                    <part name="statement" id="new-stmt"/>
-                </add>                
+                    <control id="new-control1"/>
+                    <control id="new-control2"/>
+                </add>
             </x:expect>
+        </x:scenario>
+        <x:scenario label="Error case: Match is a control and position=before, but at least one element to add is not a control">
+            <x:call function="oscal:patches-to-id-targeting-ancestor">
+                <x:param name="here" select="//*[@id='a1.1.1']">
+                    <control id="a1">
+                        <title>Control A</title>
+                        <control id="a1.1">
+                            <title>Control A1</title>
+                            <control id="a1.1.1">
+                                <title>Control A1-1</title>
+                                <part name="statement" id="a1-stmt"/>
+                            </control>
+                        </control>
+                    </control>
+                </x:param>
+                <x:param name="modifications">
+                    <modify>
+                        <alter control-id="a1.1">
+                            <add position="before" by-id="a1.1.1">
+                                <control id="new-control1"/>
+                                <part name="statement" id="new-stmt">
+                                    <!-- Inserting an unlike element is not supported -->
+                                </part>
+                                <control id="new-control2"/>
+                            </add>
+                        </alter>
+                    </modify>
+                </x:param>
+            </x:call>
+            <x:expect label="Error because insertion type does not equal selection type for a child of add"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+        </x:scenario>
+        <x:scenario label="Error case: Match is other than a control and position=after, but at least one element to add is a control">
+            <x:call function="oscal:patches-to-id-targeting-ancestor">
+                <x:param name="here" select="//*[@id='a1-stmt']">
+                    <control id="a1">
+                        <title>Control A</title>
+                        <part name="statement" id="a1-stmt"/>
+                    </control>
+                </x:param>
+                <x:param name="modifications">
+                    <modify>
+                        <alter control-id="a1">
+                            <add by-id="a1-stmt" position="after">
+                                <control id="new-control1">
+                                    <!-- Inserting an unlike element is not supported -->
+                                </control>
+                            </add>
+                        </alter>
+                    </modify>
+                </x:param>
+            </x:call>
+            <x:expect label="Error because insertion type does not equal selection type for a child of add"
+                test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
         </x:scenario>
         <x:scenario label="Edge case: Empty $modifications param">
             <x:call function="oscal:patches-to-id-targeting-ancestor">
-                <x:param name="here" select="id('a1-stmt')">
+                <x:param name="here" select="//*[@id='a1-stmt']">
                     <catalog id="abc">
                         <control id="a1">
                             <title>Control A</title>
@@ -1177,7 +1391,7 @@
             <x:scenario label="with position=starting">
                 <x:variable name="ov:add-position" select="'starting'"/>
                 <x:variable name="ov:by-id" select="'a1-stmt'"/>
-                <x:like label="SHARED_add-explicit-parameterized-position"/>
+                <x:like label="SHARED_add-explicit-part-parameterized-position"/>
                 <x:expect label="Part added inside a1-stmt part, before other content">
                     <part name="statement" id="a1-stmt">
                         <part name="statement" id="new-stmt">
@@ -1193,7 +1407,7 @@
             <x:scenario label="with position=ending">
                 <x:variable name="ov:add-position" select="'ending'"/>
                 <x:variable name="ov:by-id" select="'a1-stmt'"/>
-                <x:like label="SHARED_add-explicit-parameterized-position"/>
+                <x:like label="SHARED_add-explicit-part-parameterized-position"/>
                 <x:expect label="Part added inside a1-stmt part, after other content">
                     <part name="statement" id="a1-stmt">
                         <p>Text</p>
@@ -1209,7 +1423,7 @@
             <x:scenario label="with no valid position">
                 <x:variable name="ov:add-position" select="''"/>
                 <x:variable name="ov:by-id" select="'a1-stmt'"/>
-                <x:like label="SHARED_add-explicit-parameterized-position"/>
+                <x:like label="SHARED_add-explicit-part-parameterized-position"/>
                 <x:expect label="Part added inside a1-stmt part, after other content (same as position=ending)">
                     <part name="statement" id="a1-stmt">
                         <p>Text</p>
@@ -1225,7 +1439,7 @@
             <x:scenario label="with position=before">
                 <x:variable name="ov:add-position" select="'before'"/>
                 <x:variable name="ov:by-id" select="'a1-stmt'"/>
-                <x:like label="SHARED_add-explicit-parameterized-position"/>
+                <x:like label="SHARED_add-explicit-part-parameterized-position"/>
                 <x:expect label="Part added outside and before a1-stmt part">
                     <part name="statement" id="new-stmt">
                         <p>New text</p>
@@ -1238,10 +1452,34 @@
                     </part>
                 </x:expect>
             </x:scenario>
+            <x:scenario label="with position=before but selection type does not match insertion type (Error case)">
+                <x:variable name="ov:context">
+                    <catalog id="abc">
+                        <control id="a1">
+                            <title>Control A</title>
+                            <part name="statement" id="a1-stmt">
+                                <title>Statement</title>
+                            </part>
+                        </control>
+                        <modify>
+                            <alter control-id="a1">
+                                <add position="before" by-id="a1-stmt">
+                                    <prop/>
+                                </add>
+                            </alter>
+                        </modify>
+                    </catalog>
+                </x:variable>
+                <x:context select="$ov:context//o:part[@id='a1-stmt']">
+                    <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
+                </x:context>
+                <x:expect label="Error; this mismatch is not supported"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
+            </x:scenario>
             <x:scenario label="with position=after">
                 <x:variable name="ov:add-position" select="'after'"/>
                 <x:variable name="ov:by-id" select="'a1-stmt'"/>
-                <x:like label="SHARED_add-explicit-parameterized-position"/>
+                <x:like label="SHARED_add-explicit-part-parameterized-position"/>
                 <x:expect label="Part added outside and after a1-stmt part">
                     <part name="statement" id="a1-stmt">
                         <p>Text</p>
@@ -1253,6 +1491,30 @@
                         <p>New text</p>
                     </part>
                 </x:expect>
+            </x:scenario>
+            <x:scenario label="with position=after but selection type does not match insertion type (Error case)">
+                <x:variable name="ov:context">
+                    <catalog id="abc">
+                        <control id="a1">
+                            <title>Control A</title>
+                            <part name="statement" id="a1-stmt">
+                                <title>Statement</title>
+                            </part>
+                        </control>
+                        <modify>
+                            <alter control-id="a1">
+                                <add position="after" by-id="a1-stmt">
+                                    <prop/>
+                                </add>
+                            </alter>
+                        </modify>
+                    </catalog>
+                </x:variable>
+                <x:context select="$ov:context//o:part[@id='a1-stmt']">
+                    <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
+                </x:context>
+                <x:expect label="Error; this mismatch is not supported"
+                    test="exists($x:result/self::processing-instruction('message-handler')[starts-with(.,'Terminating ')])"/>
             </x:scenario>
             <x:scenario label="adding title to a part object within this control">
                 <x:variable name="ov:context">
@@ -1286,7 +1548,7 @@
         <x:scenario label="Explicit binding to a non-child descendant of a control">
             <x:variable name="ov:add-position" select="'starting'"/>
             <x:variable name="ov:by-id" select="'a1-substmt'"/>
-            <x:like label="SHARED_add-explicit-parameterized-position"/>
+            <x:like label="SHARED_add-explicit-part-parameterized-position"/>
             <x:expect label="Part added inside a1-substmt part, before other content">
                 <part name="statement" id="a1-substmt">
                     <part name="statement" id="new-stmt">
@@ -1299,17 +1561,15 @@
         <x:scenario label="Explicit binding to a descendant that is inside a child control">
             <x:variable name="ov:add-position" select="'starting'"/>
             <x:variable name="ov:by-id" select="'a1.1-stmt'"/>
-            <x:like label="SHARED_add-explicit-parameterized-position"/>
-            <x:expect label="Part added inside a1.1-stmt part, before other content">
+            <x:like label="SHARED_add-explicit-part-parameterized-position"/>
+            <x:expect label="No change, because the child control's descendants are not in scope for modifications to the parent control">
                 <part name="statement" id="a1.1-stmt">
-                    <part name="statement" id="new-stmt">
-                        <p>New text</p>
-                    </part>
                     <p>Text</p>
                 </part>
             </x:expect>
+            <x:expect label="New text does not appear" test="empty(//p[.='New text'])"/>
         </x:scenario>
-        <x:scenario label="Explicit binding to a control that a 'remove' element targets for removal">
+        <x:scenario label="Explicit binding to a part that a 'remove' element targets for removal, trying to insert content around the removed part (e.g., replacement)">
             <x:variable name="ov:context">
                 <catalog id="abc">
                     <control id="a1">
@@ -1320,26 +1580,17 @@
                             <p>Text</p>
                         </part>
                         <part name="statement" id="a1-stmt2">
-                            <p>Text</p>
+                            <p>Text2</p>
                         </part>
                     </control>
                     <modify>
                         <alter control-id="a1">
                             <remove by-id="a1-stmt"/>
                             <add position="after" by-id="a1-stmt">
-                                <prop value="0" name="after"/>
+                                <part name="statement" id="a1-stmt-after"/>
                             </add>
                             <add position="before" by-id="a1-stmt">
-                                <prop value="0" name="before"/>
-                            </add>
-                            <add position="starting" by-id="a1-stmt">
-                                <prop value="0" name="starting"/>
-                            </add>
-                            <add position="ending" by-id="a1-stmt">
-                                <prop value="0" name="ending"/>
-                            </add>
-                            <add by-id="a1-stmt">
-                                <prop value="0" name="default"/>
+                                <part name="statement" id="a1-stmt-before"/>
                             </add>
                         </alter>
                     </modify>
@@ -1349,13 +1600,52 @@
                 <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
             </x:context>
             <x:expect label="Elements in 'add' that use 'before' and 'after'">
-                <prop value="0" name="before"/>
-                <prop value="0" name="after"/>
+                <part name="statement" id="a1-stmt-before"/>
+                <part name="statement" id="a1-stmt-after"/>
             </x:expect>
             <x:expect label="The target control does not appear" test="empty($x:result//*[@id='a1-stmt'])"/>
-            <x:expect label="The 'starting' element does not appear" test="empty($x:result//*[@name='starting'])"/>
-            <x:expect label="The 'ending' element does not appear" test="empty($x:result//*[@name='ending'])"/>
-            <x:expect label="The element with no valid position does not appear" test="empty($x:result//*[@name='default'])"/>
+        </x:scenario>
+        <x:scenario label="Explicit binding to a param that needs to be set *and* have new params inserted">
+            <x:variable name="ov:context">
+                <catalog id="abc">
+                    <control id="a1">
+                        <title>Control A1</title>
+                        <param id="a1_prm1">
+                            <label>A1 Parameter 1</label>
+                        </param>
+                    </control>
+                    <modify>
+                        <set-parameter param-id="a1_prm1">
+                            <constraint>at least every 3 years</constraint>
+                        </set-parameter>
+                        <alter control-id="a1">
+                            <add position="before" by-id="a1_prm1">
+                                <param id="new_prm">
+                                    <prop name="annotated" ns="https://fedramp.gov/ns/oscal" value="new-param"/>
+                                    <label>A1 Parameter New</label>
+                                </param>
+                            </add>
+                            <add position="after" by-id="a1_prm1">
+                                <param id="new_prm2"/>
+                            </add>
+                        </alter>
+                    </modify>
+                </catalog>
+            </x:variable>
+            <x:context select="$ov:context//o:param[@id='a1_prm1']">
+                <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
+            </x:context>
+            <x:expect label="new_prm param, original param with constraint added by process-param template, and new_prm2 param">
+                <param id="new_prm">
+                    <prop name="annotated" ns="https://fedramp.gov/ns/oscal" value="new-param"/>
+                    <label>A1 Parameter New</label>
+                </param>
+                <param id="a1_prm1">
+                    <label>A1 Parameter 1</label>
+                    <constraint>at least every 3 years</constraint>
+                </param>
+                <param id="new_prm2"/>
+            </x:expect>
         </x:scenario>
     </x:scenario>
 
@@ -1682,7 +1972,7 @@
             <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
         </x:context>
     </x:scenario>
-    <x:scenario shared="yes" label="SHARED_add-explicit-parameterized-position">
+    <x:scenario shared="yes" label="SHARED_add-explicit-part-parameterized-position">
         <x:variable name="ov:context">
             <catalog id="abc">
                 <control id="a1">
@@ -1710,6 +2000,43 @@
                             <part name="statement" id="new-stmt">
                                 <p>New text</p>
                             </part>
+                        </add>
+                    </alter>
+                </modify>
+            </catalog>
+        </x:variable>
+        <x:context select="$ov:context//*[@id=$ov:by-id]">
+            <x:param name="modifications" select="$ov:context//o:modify" tunnel="yes"/>
+        </x:context>
+    </x:scenario>
+    <x:scenario shared="yes" label="SHARED_add-explicit-control-parameterized-position">
+        <x:variable name="ov:context">
+            <catalog id="abc">
+                <control id="a1">
+                    <title>Control A</title>
+                    <prop value="1" name="source1"/>
+                    <prop value="2" name="source2"/>
+                    <part name="statement" id="a1-stmt">
+                        <p>Text</p>
+                        <part name="statement" id="a1-substmt">
+                            <p>Text</p>
+                        </part>
+                    </part>
+                    <control id="a1.1">
+                        <title>Control A.1</title>
+                        <prop value="3" name="source3"/>
+                        <prop value="4" name="source4"/>
+                        <part name="statement" id="a1.1-stmt">
+                            <p>Text</p>
+                        </part>
+                    </control>
+                </control>
+                <modify>
+                    <alter control-id="a1">
+                        <add position="{$ov:add-position}" by-id="{$ov:by-id}">
+                            <control id="new-control">
+                                <title>New control</title>
+                            </control>
                         </add>
                     </alter>
                 </modify>

--- a/src/utils/util/resolver-pipeline/testing/5_finished/finish.xspec
+++ b/src/utils/util/resolver-pipeline/testing/5_finished/finish.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+    xmlns:mh="http://csrc.nist.gov/ns/message"
     xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:opr="http://csrc.nist.gov/ns/oscal/profile-resolution"
     xmlns:ov="http://csrc.nist.gov/ns/oscal/xspec/variable"
@@ -18,6 +19,170 @@
             <x:context select="$ov:arbitrary-element/@arbitrary-attribute"/>
             <x:expect label="Copy"
                 test="$x:result instance of attribute(arbitrary-attribute) and $x:result/string()='val'"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for mode=all-or-last-only template">
+        <x:scenario label="Element that can occur with any multiplicity">
+            <x:context mode="all-or-last-only" select="(//o:link)[2]">
+                <parent>
+                    <link href="target1"/>
+                    <link href="target2"/>
+                    <link href="target3"/>
+                </parent>
+            </x:context>
+            <x:expect label="Copy of element, regardless of multiplicity or position">
+                <link href="target2"/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Non-OSCAL element">
+            <x:context mode="all-or-last-only" select="(//opr:title)[2]">
+                <parent>
+                    <opr:title>A</opr:title>
+                    <opr:title>B</opr:title>
+                    <opr:title>C</opr:title>
+                </parent>
+            </x:context>
+            <x:expect label="Copy of element, regardless of multiplicity or position">
+                <opr:title>B</opr:title>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="Element that can occur at most once, ">
+            <x:variable name="ov:context-parent">
+                <parent>
+                    <title>Original</title>
+                    <title>Intermediate replacement</title>
+                    <title>Another intermediate replacement</title>
+                    <title>Last replacement</title>
+                </parent>
+            </x:variable>
+            <x:scenario label="first of four instances">
+                <x:context mode="all-or-last-only" select="($ov:context-parent//o:title)[1]"/>
+                <x:expect label="Nothing; the warning will come from the next to last instance, and the copy will come from the last instance"
+                select="()"/>
+            </x:scenario>
+            <x:scenario label="second of four instances">
+                <x:context mode="all-or-last-only" select="($ov:context-parent//o:title)[2]"/>
+                <x:expect label="Nothing; the warning will come from the next to last instance, and the copy will come from the last instance"
+                    select="()"/>
+            </x:scenario>
+            <x:scenario label="next to last instance">
+                <x:context mode="all-or-last-only" select="($ov:context-parent//o:title)[last()-1]"/>
+                <x:expect label="PI for warning about extra title"
+                    test="$x:result/self::processing-instruction('message-handler')">
+                    <?message-handler Warning: Found 4 elements of type <title>. Only the last will be present in result.?>
+                </x:expect>
+                <x:expect label="No elements" test="empty($x:result/self::element())"/>
+            </x:scenario>
+            <x:scenario label="last instance">
+                <x:context mode="all-or-last-only" select="($ov:context-parent//o:title)[last()]"/>
+                <x:expect label="Copy of element">
+                    <title>Last replacement</title>
+                </x:expect>
+                <x:expect label="No PI for warning or error" test="empty($x:result/self::processing-instruction())"/>
+            </x:scenario>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for name=process-expected-child-elements template">
+        <x:scenario label="Child elements out of sequence, extraneous elements, and extra title">
+            <x:context>
+                <parent>
+                    <param id="param-A.a">
+                        <label>A.a parameter</label>
+                        <value>A.a value</value>
+                    </param>
+                    <published/>
+                    <prop name="label" value="1st"/>
+                    <title>Original</title>
+                    <prop name="label" value="2nd"/>
+                    <title>Replacement</title>
+                    <param id="param-B.b">
+                        <label>B.b parameter</label>
+                        <value>B.b value</value>
+                    </param>
+                    <opr:title>Non-OSCAL Title</opr:title>
+                </parent>
+            </x:context>
+            <x:call template="process-expected-child-elements">
+                <x:param name="expected-child-element-names"
+                    select="('title','param','prop')"/>
+            </x:call>
+            <x:expect label="One title, all params, all props, and no other elements" test="element()">
+                <title>Replacement</title>
+                <param id="param-A.a">
+                    <label>A.a parameter</label>
+                    <value>A.a value</value>
+                </param>
+                <param id="param-B.b">
+                    <label>B.b parameter</label>
+                    <value>B.b value</value>
+                </param>
+                <prop name="label" value="1st"/>
+                <prop name="label" value="2nd"/>
+            </x:expect>
+            <x:expect label="PI for warning about extra OSCAL-namespace title" test="/processing-instruction('message-handler')">
+                <?message-handler Warning: Found 2 elements of type <title>. Only the last will be present in result.?>
+            </x:expect>
+            <!-- Note: An extraneous <published/> element causes the report-unexpected-child-elements
+                template, not the template being called in this scenario, to output an error PI. -->
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Tests for name=report-unexpected-child-elements template">
+        <x:scenario label="Unexpected elements among expected and opr:* child elements">
+            <x:context>
+                <parent>
+                    <param id="param-A.a">
+                        <label>A.a parameter</label>
+                        <value>A.a value</value>
+                    </param>
+                    <published/>
+                    <prop name="label" value="1st"/>
+                    <title>OSCAL Title</title>
+                    <opr:title>Non-OSCAL Title</opr:title>
+                    <unknown-element>Text</unknown-element>
+                </parent>
+            </x:context>
+            <x:call template="report-unexpected-child-elements">
+                <x:param name="expected-child-element-names"
+                    select="('title','param','prop')"/>
+            </x:call>
+            <x:expect label="Processing instructions about 'published' and 'unknown-element' elements"
+                test="/processing-instruction('message-handler')">
+                <?message-handler Error: Element of type <published> is not valid inside <parent>, so it will not be present in result.?>
+                <?message-handler Error: Element of type <unknown-element> is not valid inside <parent>, so it will not be present in result.?>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="No unexpected child elements">
+            <x:context>
+                <parent>
+                    <param id="param-A.a">
+                        <label>A.a parameter</label>
+                        <value>A.a value</value>
+                    </param>
+                    <prop name="label" value="1st"/>
+                    <title>OSCAL Title</title>
+                    <opr:title>Non-OSCAL Title</opr:title>
+                </parent>
+            </x:context>
+            <x:call template="report-unexpected-child-elements">
+                <x:param name="expected-child-element-names"
+                    select="('title','param','prop')"/>
+            </x:call>
+            <x:expect label="Nothing" select="()"/>
+        </x:scenario>
+        <x:scenario label="No child elements">
+            <x:context>
+                <parent>
+                    <!-- no child elements -->
+                </parent>
+            </x:context>
+            <x:call template="report-unexpected-child-elements">
+                <x:param name="expected-child-element-names"
+                    select="('title','param','prop')"/>
+            </x:call>
+            <x:expect label="Nothing" select="()"/>
         </x:scenario>
     </x:scenario>
 
@@ -56,8 +221,8 @@
             </x:context>
             <x:expect label="Catalog with correct sequence of children">
                 <catalog id="worksheet">
-                    <metadata>...</metadata>
                     <opr:foo/>
+                    <metadata>...</metadata>
                     <param id="loose">...</param>
                     <control id="control_A">...</control>
                     <group>...</group>
@@ -82,18 +247,22 @@
                     <back-matter>
                         <opr:bar/>
                     </back-matter>
-                </catalog>                
+                </catalog>
             </x:context>
-            <x:expect label="Catalog with last metadata child and last back-matter child">
-                <catalog id="worksheet">
-                    <metadata>
-                        <title>Catalog Y</title>
-                        <version>1.3</version>
-                    </metadata>
-                    <back-matter>
-                        <opr:bar/>
-                    </back-matter>
-                </catalog>                                
+            <x:expect label="Catalog with last metadata child and last back-matter child"
+                test="$x:result/self::o:catalog[@id='worksheet']/element()">
+                <metadata>
+                    <title>Catalog Y</title>
+                    <version>1.3</version>
+                </metadata>
+                <back-matter>
+                    <opr:bar/>
+                </back-matter>
+            </x:expect>
+            <x:expect label="Inside catalog, separate PI warnings about extra metadata and extra back-matter"
+                test="$x:result/self::o:catalog/processing-instruction('message-handler')">
+                <?message-handler Warning: Found 2 elements of type <metadata>. Only the last will be present in result.?>
+                <?message-handler Warning: Found 2 elements of type <back-matter>. Only the last will be present in result.?>
             </x:expect>
         </x:scenario>
         <x:scenario label="Catalog with loose parameter as child, ">
@@ -225,21 +394,30 @@
                     <remarks><p>Remark 2</p></remarks>
                 </metadata>
             </x:context>
-            <x:expect label="Metadata with last instance of each child type that cannot occur multiple times">
-                <metadata>
-                    <title>Title 2</title>
-                    <published>2021-11-13T12:41:07.061-05:00</published>
-                    <last-modified>2021-11-13T12:41:07.061-05:00</last-modified>
-                    <version>1.1</version>
-                    <oscal-version>1.0.2</oscal-version>
-                    <revisions>
-                        <revision>
-                            <version>1.1</version>
-                        </revision>
-                    </revisions>
-                    <remarks><p>Remark 2</p></remarks>
-                </metadata>
+            <x:expect label="Metadata with last instance of each child type that cannot occur multiple times"
+                test="$x:result/self::o:metadata/element()">
+                <title>Title 2</title>
+                <published>2021-11-13T12:41:07.061-05:00</published>
+                <last-modified>2021-11-13T12:41:07.061-05:00</last-modified>
+                <version>1.1</version>
+                <oscal-version>1.0.2</oscal-version>
+                <revisions>
+                    <revision>
+                        <version>1.1</version>
+                    </revision>
+                </revisions>
+                <remarks><p>Remark 2</p></remarks>
             </x:expect>
+            <x:expect label="Inside metadata, one warning PI for each type of extra element"
+                test="$x:result/self::o:metadata/processing-instruction('message-handler')">
+                <?message-handler Warning: Found 2 elements of type <title>. Only the last will be present in result.?>
+                <?message-handler Warning: Found 2 elements of type <published>. Only the last will be present in result.?>
+                <?message-handler Warning: Found 2 elements of type <last-modified>. Only the last will be present in result.?>
+                <?message-handler Warning: Found 2 elements of type <version>. Only the last will be present in result.?>
+                <?message-handler Warning: Found 2 elements of type <oscal-version>. Only the last will be present in result.?>
+                <?message-handler Warning: Found 2 elements of type <revisions>. Only the last will be present in result.?>
+                <?message-handler Warning: Found 2 elements of type <remarks>. Only the last will be present in result.?>
+            </x:expect>            
         </x:scenario>
     </x:scenario>
 
@@ -322,10 +500,12 @@
                     <title>Revised title</title>
                 </group>
             </x:context>
-            <x:expect label="Group with last title">
-                <group id="a123">
-                    <title>Revised title</title>
-                </group>
+            <x:expect label="Group with last title" test="$x:result/self::o:group[@id='a123']/element()">
+                <title>Revised title</title>
+            </x:expect>
+            <x:expect label="Inside group, PI for warning about extra title"
+                test="$x:result/self::o:group/processing-instruction('message-handler')">
+                <?message-handler Warning: Found 2 elements of type <title>. Only the last will be present in result.?>
             </x:expect>
         </x:scenario>
     </x:scenario>
@@ -406,10 +586,13 @@
                     <title>Second revision added during modify phase</title>
                 </control>
             </x:context>
-            <x:expect label="Control with last title">
-                <control id="a123">
-                    <title>Second revision added during modify phase</title>
-                </control>
+            <x:expect label="Control with last title"
+                test="$x:result/self::o:control[@id='a123']/element()">
+                <title>Second revision added during modify phase</title>
+            </x:expect>
+            <x:expect label="Inside control, PI for warning about extra title"
+                test="$x:result/self::o:control/processing-instruction('message-handler')">
+                <?message-handler Warning: Found 3 elements of type <title>. Only the last will be present in result.?>
             </x:expect>
         </x:scenario>
     </x:scenario>

--- a/src/utils/util/resolver-pipeline/testing/5_finished/finish.xspec
+++ b/src/utils/util/resolver-pipeline/testing/5_finished/finish.xspec
@@ -150,8 +150,8 @@
             </x:call>
             <x:expect label="Processing instructions about 'published' and 'unknown-element' elements"
                 test="/processing-instruction('message-handler')">
-                <?message-handler Error: Element of type <published> is not valid inside <parent>, so it will not be present in result.?>
-                <?message-handler Error: Element of type <unknown-element> is not valid inside <parent>, so it will not be present in result.?>
+                <?message-handler Error: Element of type <published> is not valid inside <parent> and will not be present in result.?>
+                <?message-handler Error: Element of type <unknown-element> is not valid inside <parent> and will not be present in result.?>
             </x:expect>
         </x:scenario>
         <x:scenario label="No unexpected child elements">

--- a/src/utils/util/resolver-pipeline/uuid-method-choice.xsl
+++ b/src/utils/util/resolver-pipeline/uuid-method-choice.xsl
@@ -28,7 +28,9 @@
     <!-- Alternatively, call a web service if the processor supports it -->
     <xsl:param name="uuid-service" select="'https://www.uuidgenerator.net/api/version4'"/>
 
-    <xsl:template name="u:determine-uuid" as="xs:string">
+    <xsl:template name="u:determine-uuid" as="item()+">
+        <!-- Return value is xs:string, in addition to a processing instruction
+            if there is a warning situation. -->
         <xsl:param name="uuid-method" select="$uuid-method" as="xs:string"/>
         <xsl:param name="uuid-service" select="$uuid-service" as="xs:string"/>
         <xsl:param name="top-uuid" select="$top-uuid" as="xs:string?"/>


### PR DESCRIPTION
# Committer Notes

This PR addresses issue #1629 by replacing usage of `document-uri` with `base-uri`. The `document-uri` function is known to return different results in Saxon 10 vs. 11. Using `base-uri` removes a difference in the XSLT profile resolver's behavior between Saxon 10 and 11.

This PR builds on top of #1596, which in turn builds on #1549. What's new in this PR is commit 3c96945d4cd6d7b2f6ce45741505f2d9542313ac.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.

### Testing Done
- Ran all the unit-level XSpec tests (that is, the `.xspec` files in the `testing/` directory) with Oxygen 24.1, which uses Saxon 10.
- Ran all the unit-level XSpec tests with Oxygen 25.0, which uses Saxon 11.
- With both Oxygen 24.1 and 25, transformed all the profiles in `src/specifications/profile-resolution/profile-resolution-examples`. Diff'd the results, and they are the same except time stamps. The profiles that deliberately error out (e.g., `broken_profile.xml`) behave the same way in both Oxygen versions.
- Used the command in the "How do we replicate this issue" section of #1629. Now the command works with Saxon 12.0.