### PR TITLE
Expose new links for ease of use (return visitors)

### DIFF
--- a/docs/content/tools/_index.md
+++ b/docs/content/tools/_index.md
@@ -11,9 +11,9 @@ toc:
   enabled: true
 ---
 
-The [OSCAL models](/concepts/layer/) provide standardized formats for exchanging control, control implementation, and control assessment information in XML, JSON, and YAML, in support of interoperable security assessment automation and continuous monitoring. These formats allow this information to be exchanged between tools ensuring interoperability, and for individual tools, to process exchanged data, supporting analytics, user interaction, and security assessment automation where suitable.
+Please see  [Awesome OSCAL](https://github.com/oscal-club/awesome-oscal) for a list of tools maintained by the OSCAL community.
 
-{{% callout note %}} Tools supporting the use of the OSCAL models are instrumental for a broad adoption of OSCAL in support of interoperable security assessment automation.  The community maintains a list of known OSCAL tools in the [Awesome OSCAL](https://github.com/oscal-club/awesome-oscal) repository.{{% /callout %}}
+The [OSCAL models](/concepts/layer/) provide standardized formats for exchanging control, control implementation, and control assessment information in XML, JSON, and YAML, in support of interoperable security assessment automation and continuous monitoring. These formats allow this information to be exchanged between tools ensuring interoperability, and for individual tools, to process exchanged data, supporting analytics, user interaction, and security assessment automation where suitable.
 
 The following types of tools are developed by NIST OSCAL team:
 - commodity tooling for basic operations such as format validation, data conversion between supported formats
@@ -45,6 +45,8 @@ Details on acquiring and running the converters:
 - converting *into* XML - [JSON to XML](https://github.com/usnistgov/OSCAL/tree/main/xml)
  
 ## NIST's OSCAL Application Frameworks, Tools and Libraries
+
+{{% callout note %}} Tools supporting the use of the OSCAL models are instrumental for a broad adoption of OSCAL in support of interoperable security assessment automation.  The community maintains a list of known OSCAL tools in the [Awesome OSCAL](https://github.com/oscal-club/awesome-oscal) repository.{{% /callout %}}
 
 Valid OSCAL is open-ended in application. Some of the tools described provide validation and conversion, while others do not, presuming that inputs are already valid.
 


### PR DESCRIPTION
Question posed to oscal list indicates a user couldn't find the link we provided. This attempts to remedy that.

# Committer Notes

Quick link at the top; blue box down where return visitors skip to.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

**n/a**

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
