### PR TITLE
Require (Warn) port start and end when protocol is specified.

### DIFF
--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -315,7 +315,7 @@
                   <expect level="WARNING" id="port-range-end-specified-with-no-start" target="." test="not(exists(@start)) and exists(@end)">
                         <message>An end point exists, but a start port does not. To define a single port, the start and end should be the same value.</message>
                   </expect>
-                  <expect level="WARNING" id="port-range-end-date-is-before-start-date" target="." test="@start &le; @end">
+                  <expect level="WARNING" id="port-range-end-date-is-before-start-date" target="." test="@start &lt;= @end">
                         <message>The port range specified has an end port that is less than the start port.</message>
                   </expect>
             </constraint>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -304,6 +304,21 @@
                         </allowed-values>
                   </constraint>
             </define-flag>
+            <!-- Added Contraints as Warnings -->
+            <constraint>
+                  <expect level="WARNING" id="port-range-start-and-end-not-specified" target="." test="exists(@start) and exists(@end)">
+                        <message>If a protocol is defined, it should include a start and end port range. To define a single port, the start and end should be the same value.</message>
+                  </expect>
+                  <expect level="WARNING" id="port-range-start-specified-with-no-end" target="." test="exists(@start) and not(exists(@end))">
+                        <message>A start port exists, but an end point does not. To define a single port, the start and end should be the same value.</message>
+                  </expect>
+                  <expect level="WARNING" id="port-range-end-specified-with-no-start" target="." test="not(exists(@start)) and exists(@end)">
+                        <message>An end point exists, but a start port does not. To define a single port, the start and end should be the same value.</message>
+                  </expect>
+                  <expect level="WARNING" id="port-range-end-date-is-before-start-date" target="." test="@start &le; @end">
+                        <message>The port range specified has an end port that is less than the start port.</message>
+                  </expect>
+            </constraint>
             <remarks>
                   <p>To be validated as a natural number (integer &gt;= 1). A single port uses the same value for start and end. Use multiple 'port-range' entries for non-contiguous ranges.</p>
             </remarks>


### PR DESCRIPTION
# Committer Notes

See #1521 for detail.

Add WARNING constraints for the port-range assembly when there are issues with the port start and end. 
(Assuming this prevents breaking change, but if that's not true, let me know what level it should be.)

This covers:
- Port range start and end not specified.
- Port range start specified without an end.
- Port range end specified without a start.
- Port range end is less than the start.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
