### PR TITLE
Profile resolver: Compatibility with Saxon 10 and 11

### DIFF
--- a/src/utils/util/resolver-pipeline/oscal-profile-RESOLVE.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-RESOLVE.xsl
@@ -67,7 +67,7 @@
              Each represents a stage in processing.
              The result of each processing step is passed to the next step as its input, until no steps are left. -->
         <xsl:call-template name="alert">
-            <xsl:with-param name="msg" expand-text="yes"> RESOLVING PROFILE { document-uri($source) } </xsl:with-param>
+            <xsl:with-param name="msg" expand-text="yes"> RESOLVING PROFILE { base-uri($source) } </xsl:with-param>
         </xsl:call-template>
         <xsl:iterate select="$transformation-sequence/*">
             <xsl:param name="doc" select="$source" as="document-node()"/>
@@ -98,9 +98,9 @@
         <xsl:variable name="xslt-spec" select="."/>
         <xsl:variable name="runtime-params" as="map(xs:QName,item()*)">
             <xsl:map>
-                <xsl:map-entry key="QName('','profile-origin-uri')" select="document-uri($home)"/>
+                <xsl:map-entry key="QName('','profile-origin-uri')" select="base-uri($home)"/>
                 <xsl:map-entry key="QName('','path-to-source')"     select="$path-to-source"/>
-                <xsl:map-entry key="QName('','uri-stack-in')"       select="($uri-stack, document-uri($home))"/>
+                <xsl:map-entry key="QName('','uri-stack-in')"       select="($uri-stack, base-uri($home))"/>
                 <xsl:apply-templates select="." mode="opr:provide-parameters"/>
             </xsl:map>
         </xsl:variable>

--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-metadata.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-metadata.xsl
@@ -120,7 +120,7 @@
             </xsl:if>
         </xsl:for-each>
         <!-- Return the version from the source parameter. -->
-        <xsl:value-of select="$source"/>
+        <xsl:sequence select="$source"/>
     </xsl:function>
 
     <!--<xsl:template match="selection" mode="imported-metadata">

--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-modify.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-modify.xsl
@@ -89,7 +89,7 @@
         <!-- condition not(@by-id != $id) includes any addition without an @by-id, or whose @by-id is the control id -->
         <xsl:variable name="implicit-patches-to-id" select="$modifications/key('alteration-for-control-id',$id,.)/add[not(@by-id != $id)]" as="element(add)*"/>
 
-        <xsl:copy-of select="$patches-to-id-targeting-ancestor[@position = 'before']/*"/><xsl:message>got here! removable is <xsl:sequence select="oscal:removable(./*[1],$modifications)"/></xsl:message>
+        <xsl:copy-of select="$patches-to-id-targeting-ancestor[@position = 'before']/*"/>
         <xsl:if test="not(ancestor::control and oscal:removable(.,$modifications))">
             <xsl:copy>
                 <xsl:copy-of select="@*"/>

--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve-select.xsl
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve-select.xsl
@@ -70,9 +70,8 @@
     </xsl:template>
 
     <xsl:template match="catalog" mode="o:select">
-        <selection opr:src="{document-uri(root())}">
+        <selection opr:src="{base-uri(root())}">
             <xsl:copy-of select="@* except @xsi:*" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
-            <!--<xsl:attribute name="opr:base" select="document-uri(root())"/>-->
             <xsl:apply-templates mode="#current"/>
         </selection>
     </xsl:template>

--- a/src/utils/util/resolver-pipeline/random-util.xsl
+++ b/src/utils/util/resolver-pipeline/random-util.xsl
@@ -30,7 +30,7 @@ v4 UUID
     <!-- Set $germ to a string for reproducible outputs of r:make-uuid.
          Pass in a blind value - and don't save it - for irreproducible outputs. -->
 
-    <xsl:param name="germ" select="current-dateTime() || document-uri(/)"/>
+    <xsl:param name="germ" select="current-dateTime() || base-uri(/)"/>
 
     <!-- for testing random number features   -->
     <xsl:template match="/" name="xsl:initial-template" expand-text="true">

--- a/src/utils/util/resolver-pipeline/select-or-custom-merge.xsl
+++ b/src/utils/util/resolver-pipeline/select-or-custom-merge.xsl
@@ -91,7 +91,7 @@
 
     <xsl:function name="opr:catalog-identifier" as="xs:string">
         <xsl:param name="catalog" as="element(o:catalog)"/>
-        <xsl:sequence select="$catalog/(@uuid,document-uri(root(.)))[1]"/>
+        <xsl:sequence select="$catalog/(@uuid,base-uri(root(.)))[1]"/>
     </xsl:function>
 
 </xsl:stylesheet>

--- a/src/utils/util/resolver-pipeline/testing/1_selected/select.xspec
+++ b/src/utils/util/resolver-pipeline/testing/1_selected/select.xspec
@@ -673,7 +673,7 @@
             <x:call function="opr:catalog-identifier">
                 <x:param href="catalog-no-uuid.xml" select="/o:catalog"/>
             </x:call>
-            <x:expect label="Returns document URI of catalog" test="ends-with($x:result,'/catalog-no-uuid.xml')"/>
+            <x:expect label="Returns base URI of catalog" test="ends-with($x:result,'/catalog-no-uuid.xml')"/>
         </x:scenario>
     </x:scenario>
 

--- a/src/utils/util/resolver-pipeline/testing/2_metadata/random-util.xspec
+++ b/src/utils/util/resolver-pipeline/testing/2_metadata/random-util.xspec
@@ -8,7 +8,7 @@
     xslt-version="3.0">
 
     <!-- For repeatable testing, use a fixed germ. Also, XSpec
-        cannot evaluate document-uri(/) in the default parameter
+        cannot evaluate base-uri(/) in the default parameter
         value from the XSLT. -->
     <x:param name="germ">x</x:param>
 


### PR DESCRIPTION
# Committer Notes

This PR addresses issue #1629 by replacing usage of `document-uri` with `base-uri`. The `document-uri` function is known to return different results in Saxon 10 vs. 11. Using `base-uri` removes a difference in the XSLT profile resolver's behavior between Saxon 10 and 11.

Unlike #1639, this PR builds on the head of the develop branch and does not include code from #1596 or #1549.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
  (Note: #1639 has the same update, but mixed with other code. This pull request isolates the code for Saxon 11 compatibility.)
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~

### Testing Done
- Ran all the unit-level XSpec tests (that is, the `.xspec` files in the `testing/` directory) with Oxygen 24.1, which uses Saxon 10.
- Ran all the unit-level XSpec tests with Oxygen 25.0, which uses Saxon 11.
- With both Oxygen 24.1 and 25, transformed all the profiles in `src/specifications/profile-resolution/profile-resolution-examples`. Diff'd the results, and they are the same except time stamps. The profiles that error out (e.g., `broken_profile.xml`) behave the same way in both Oxygen versions.
- Used the command in the "How do we replicate this issue" section of #1629. Now the command works with Saxon 12.0.