### PR TITLE
Remove optional leveraged-authorization prop on implemented-requirement

### DIFF
--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -729,9 +729,6 @@
         <enum value="customer-provided">The control must be implemented by the customer.</enum>
         <enum value="inherited">This control is inherited from an underlying system.</enum>
       </allowed-values>
-      <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-        <enum value="leveraged-authorization">Indicates all or some portion of this control is inherited from an underlying authorized system.</enum>
-      </allowed-values>
       <allowed-values target="responsible-role/@role-id" allow-other="yes">
             &allowed-values-responsible-roles-operations;
       </allowed-values>


### PR DESCRIPTION
# Committer Notes

Per usnistgov/OSCAL#1552 analysis, the original analysis and provenance for this is unclear and the name indicates its intended use overlaps with more accurate mechanisms available for the implemented requirement. I cannot find a way to write clearer documentation better that cannot explain it, so I opt to remove it.

Closes usnistgov/OSCAL#1552.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
