### PR TITLE
Datatype regex fixes for #1703

### DIFF
--- a/build/ci-cd/validate-metaschema.sh
+++ b/build/ci-cd/validate-metaschema.sh
@@ -98,7 +98,7 @@ fi
 metaschema_toolchain="${OSCALDIR}/build/metaschema/toolchains/xslt-M4"
 schematron="${metaschema_toolchain}/validate/metaschema-composition-check.sch"
 compiled_schematron="${metaschema_toolchain}/validate/metaschema-composition-check-compiled.xsl"
-metaschema_xsd="${metaschema_toolchain}/validate/metaschema.xsd"
+metaschema_xsd="${OSCALDIR}/build/metaschema/schema/xml/metaschema.xsd"
 
 build_schematron "$schematron" "$compiled_schematron"
 cmd_exitcode=$?

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -16,12 +16,17 @@
         the following errors:
         
         The following artifacts could not be resolved: org.restlet.jee:org.restlet:jar:2.2.2 ...
+
+        20221230 Workaround: TLS certificates for the restlet.org maven service
+        expired, see the following GitHub issue for details and status updates
+        about workaround alternative service and target or maven.restlet.org 
+        redirect. https://github.com/restlet/restlet-framework-java/issues/1390
     -->
     <repositories>
         <repository>
             <id>maven.restlet.org</id>
             <name>maven.restlet.org</name>
-            <url>https://maven.restlet.org</url>
+            <url>https://maven.restlet.talend.com</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
# Committer Notes

Update metaschema for current datatype regexes, closes #1703.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- ~Do all automated CI/CD checks pass?~

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
