### PR TITLE
Specify classpath for Saxon under XSpec for #1743.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=oscal-hugo-build /go/bin/hugo /usr/local/bin
 ENV SAXON_HOME=/opt/oscal
 ENV CALABASH_HOME=${SAXON_HOME}
 ENV SAXON_CP="/opt/oscal/*"
-ENV PATH=/opt/oscal/node_modules/.bin:${PATH}
+ENV PATH=/oscal/build/metaschema/support/xspec/bin:/opt/oscal/node_modules/.bin:${PATH}
 
 RUN git config --global --add safe.directory /oscal
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -45,6 +45,7 @@ COPY --from=oscal-hugo-build /go/bin/hugo /usr/local/bin
 
 ENV SAXON_HOME=/opt/oscal
 ENV CALABASH_HOME=${SAXON_HOME}
+ENV SAXON_CP="/opt/oscal/*"
 ENV PATH=/opt/oscal/node_modules/.bin:${PATH}
 
 RUN git config --global --add safe.directory /oscal


### PR DESCRIPTION
# Committer Notes

Fix classpath configuration of Saxon with `SAXON_CP` environment variable so locally developing with XSLT and XSpec tests works in the container, closes #1743.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
