### PR TITLE
Handle spaces in profile resolution wrapper

### DIFF
--- a/src/utils/util/resolver-pipeline/oscal-profile-resolve.sh
+++ b/src/utils/util/resolver-pipeline/oscal-profile-resolve.sh
@@ -23,7 +23,7 @@ TARGET_PROFILE=$1
 [[ -z "${2-}" ]] && { echo "Error: OUTPUT_BASELINE not specified"; usage; exit 1; }
 OUTPUT_BASELINE=$2
 
-ADDITIONAL_ARGS=$(shift 2; echo $@)
+ADDITIONAL_ARGS=$(shift 2; echo ${*// /\\ })
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 OSCAL_DIR="${SCRIPT_DIR}/../../../.."
@@ -34,4 +34,4 @@ mvn \
     -f $POM_FILE \
     exec:java \
     -Dexec.mainClass="net.sf.saxon.Transform" \
-    -Dexec.args="-t -s:$TARGET_PROFILE -xsl:$ENTRY_STYLESHEET -o:$OUTPUT_BASELINE $ADDITIONAL_ARGS"
+    -Dexec.args="-t -s:\"$TARGET_PROFILE\" -xsl:\"$ENTRY_STYLESHEET\" -o:\"$OUTPUT_BASELINE\" $ADDITIONAL_ARGS"


### PR DESCRIPTION
# Committer Notes

The profile resolution wrapper can now handle spaces in arguments.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
