### PR TITLE
Add missing `$` in Linux build setup steps

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -100,7 +100,7 @@ The following steps are known to work on [Ubuntu](https://ubuntu.com/) (tested i
     cd path/to/repo/OSCAL/build
     export JAVA_CLASSPATH=/opt/oscal
     sudo mkdir -p "${JAVA_CLASSPATH}"
-    sudo chown -R $USER:USER "${JAVA_CLASSPATH}"
+    sudo chown -R "$USER":"$USER" "${JAVA_CLASSPATH}"
     mvn dependency:copy-dependencies -DoutputDirectory="${JAVA_CLASSPATH}"
     export CALABASH_HOME="${JAVA_CLASSPATH}"
     export SAXON_HOME="${JAVA_CLASSPATH}"


### PR DESCRIPTION
# Committer Notes

The steps cannot be copied and pasted as-is because the `chown` command
is missing a `$` for the `USER` variable for the group argument. This
also adds quotation marks around the variables.

### All Submissions:

- [X] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [X] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
