### PR TITLE
Adjustments to align with Metaschema schema bug fixes

### DIFF
--- a/src/metaschema/oscal_control-common_metaschema.xml
+++ b/src/metaschema/oscal_control-common_metaschema.xml
@@ -238,10 +238,10 @@
                         </constraint>
                 </define-flag>
                 <model>
-                        <define-field name="parameter-choice" as-type="markup-line" max-occurs="unbounded">
+                        <define-field name="choice" as-type="markup-line" max-occurs="unbounded">
                                 <formal-name>Choice</formal-name>
-                                <description>A value selection among several such options</description>
-                                <use-name>choice</use-name>
+                                <description>A value selection among several such
+                                        options.</description>
                                 <json-value-key>value</json-value-key>
                                 <!-- CHANGED "alternatives" to "choices" -->
                                 <group-as name="choice" in-json="ARRAY"/>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -649,11 +649,10 @@
             <description>Identifies the parameter that will be set by the enclosed value.</description>
             <flag ref="param-id" required="yes"/>
             <model>
-                  <define-field name="parameter-value" as-type="string" min-occurs="1" max-occurs="unbounded">
+                  <define-field name="value" as-type="string" min-occurs="1" max-occurs="unbounded">
                         <!-- CHANGED type from "markup-line" to "string" since this is intended to be a scalar value -->
                         <formal-name>Parameter Value</formal-name>
                         <description>A parameter value or set of values.</description>
-                        <use-name>value</use-name>
                         <group-as name="values" in-json="ARRAY"/>
                   </define-field>
                   <field ref="remarks" in-xml="WITH_WRAPPER"/>


### PR DESCRIPTION
# Committer Notes

The next [Metaschema release](https://github.com/usnistgov/metaschema/tree/develop) will corrects a bug that allowed inline field and flag definitions to use `use-name`. This was not intended, but has been used in OSCAL. To ensure alignment with this Metaschema change, this PR refactors out the need to use `use-name` in the two places where it is used.

This PR targets the `release-1.0` branch, but should also be applied to develop.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~~[ ] Have you written new tests for your core changes, as applicable?~~
- ~~[ ] Have you included examples of how to use your new feature(s)?~~
- ~~[ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~~
