### PR TITLE
Fix broken cross reference enforcement in link rel=incorporated-into

### DIFF
--- a/src/metaschema/oscal_catalog_metaschema.xml
+++ b/src/metaschema/oscal_catalog_metaschema.xml
@@ -64,6 +64,9 @@
                   <index name="catalog-props" target="//prop" >
                         <key-field target="@uuid"/>
                   </index>
+                  <index name="catalog-groups-controls-parts" target="//(control|group|part)">
+                        <key-field target="@id"/>
+                  </index>
                   <index name="catalog-controls" target="//control" >
                         <key-field target="@id"/>
                   </index>
@@ -261,7 +264,7 @@
                               referenced control.</enum>
                   </allowed-values>
                   <!-- TODO: add expect constraint to check for controls that reference themselves -->
-                  <index-has-key name="catalog-controls"
+                  <index-has-key name="catalog-groups-controls-parts"
                         target="link[@rel=('related','required','incorporated-into','moved-to') and starts-with(@href,'#')]">
                         <key-field target="@href" pattern="#(.*)"/>
                   </index-has-key>


### PR DESCRIPTION
# Committer Notes

This PR fixes a bug caused by `<link rel="incorporated-into">` entries that target non-controls. This results in a index key violation error in oscal-cli.

A new index was created that indexes controls, groups, and parts to provide appropriate cross-referencing.

The SP 800-53 rev5 catalog in oscal-content can be used to reproduce this error.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- ~~[ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~~
