### PR TITLE
Don't build container for XSpec testing for fork-based PRs

### DIFF
--- a/.github/workflows/xspec-tests.yml
+++ b/.github/workflows/xspec-tests.yml
@@ -25,6 +25,7 @@ on:
   workflow_call: {}
 jobs:
   xspec-tests:
+    if: github.repository == 'usnistgov/OSCAL' || github.event.pull_request.head.repo.name == github.repository
     name: Run XSpec tests
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
# Committer Notes

As it stands, since we are evaluating using the Docker Hub registry that is not public to facilitate NIST Team development to be more efficient for local and remote testing. As this container may not exist at first commit of branch, disable on fork-based PRs for now.

Material to #1814 but does not close it.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
