### PR TITLE
Remove with-parent-controls developmental feature

### DIFF
--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -81,24 +81,13 @@
                                     <p>Identifies that all controls are to be included from the imported catalog or profile.</p>
                               </remarks>
                         </assembly>
-                        <define-assembly name="include-controls" min-occurs="1" max-occurs="unbounded">
-                              <formal-name>Select Control</formal-name>
-                              <description>Select a control or controls from an imported control set.</description>
-                              <flag ref="with-child-controls"/>
-                              <flag ref="with-parent-controls"/>
-                              <model>
-                                    <field ref="with-id" max-occurs="unbounded">
-                                          <group-as name="with-ids" in-json="ARRAY"/>
-                                    </field>
-                                    <assembly ref="matching" max-occurs="unbounded">
-                                          <group-as name="matching" in-json="ARRAY"/>
-                                    </assembly>
-                              </model>
+                        <assembly ref="select-control-by-id" min-occurs="1" max-occurs="unbounded">
+                              <use-name>include-controls</use-name>
+                              <group-as name="include-controls" in-json="ARRAY"/>
                               <remarks>
                                     <p>If <code>with-child-controls</code> is <q>yes</q> on the call to a control, any controls appearing within it (child controls) will be selected, with no additional <code>call</code> directives required. This flag provides a way to include controls with all their dependent controls (enhancements) without having to call them individually.</p>
-                                   <p>If with-parent-controls is "yes" on the call to a control, it will not be selected and removed from (shown without) a parent control, but instead will be copied with its parent in the source. This flag provides a way to include controls with all their ancestor controls (enhancements) without having to call them individually.</p>
                               </remarks>
-                        </define-assembly>
+                        </assembly>
                   </choice>
                   <assembly ref="select-control-by-id" max-occurs="unbounded">
                         <use-name>exclude-controls</use-name>
@@ -416,7 +405,7 @@
             
       </define-assembly>
       <define-assembly name="insert-controls">
-            <formal-name>Select Controls</formal-name>
+            <formal-name>Insert Controls</formal-name>
             <description>Specifies which controls to use in the containing context.</description>
             <define-flag as-type="token" name="order">
                   <formal-name>Order</formal-name>

--- a/src/specifications/profile-resolution/profile-resolution-specml.xml
+++ b/src/specifications/profile-resolution/profile-resolution-specml.xml
@@ -562,7 +562,7 @@ include-controls:
       <section id="import-nested">
         <head>Dealing with Nested Controls and Groups</head>
         <p>In OSCAL, controls may contain child controls. For instance, in SP 800-53 many controls are supplemented with control enhancements; in OSCAL these are represented as child controls within parent controls. So parent AC-2 (in a given catalog) has children AC-2(1) through AC-2(13), for example.</p>
-        <p>By default, inclusion of a control also causes any of that control&apos;s ancestors (or parents) to also be included. By default, inclusion of a control DOES NOT cause the inclusion of any descendants (or children) of that control to be included. This applies to both controls and groups.</p>
+        <p>By default, inclusion of a control also causes any of that control&apos;s ancestors to also be included. By default, inclusion of a control DOES NOT cause the inclusion of any descendants of that control to be included. This applies to both controls and groups.</p>
         <p>This default behavior can be modified by the following two optional children of the
           <src>include-controls</src> object.
         </p>
@@ -579,23 +579,6 @@ include-controls:
                 <src>with-child-controls</src> is provided, the processor MUST consider the
               directive as being equivalent to one having <src>with-child-controls:no</src>.
           </req></p>
-        </section>
-        <section id="include-parent-controls">
-          <head>with-parent-controls</head>
-          <p>Although similar to the above
-            <src>with-child-controls</src>, the optional
-            <src>with-parent-controls</src> applies to parents of the included control, and has the opposite default behavior. In order to maintain the structure of the source catalog, profile resolution includes all parents of an included control by default. If a profile author wants to change this structure, they should use an exclude directive that lists all of the undesired parents. As a shortcut for this,
-            <src>with-parent-controls</src> provides the following functionality:
-          </p>
-          <p><req level="must" id="req-with-parent-controls-yes">A <src>with-parent-controls:
-                yes</src> directive on an <src>include-controls</src> indicates that <em>all parent
-                controls</em> of the included control MUST also be included.</req></p>
-          <p><req level="must" id="req-with-parent-controls-no">A <src>with-parent-controls:
-                no</src> directive on an <src>include-controls</src> indicates that ONLY the
-              matching control is included, any parent MUST NOT be included. </req></p>
-          <p><req level="must" id="req-with-parent-controls-none">If no <src>with-parent-controls</src> is provided, the processor MUST
-              consider the directive as being equivalent to one having
-                <src>with-parent-controls:yes</src>. </req></p>
         </section>
       </section>
       <section id="exclude-directive">


### PR DESCRIPTION
# Committer Notes

This PR revert changes from usnistgov/OSCAL#1717 that address a documented feature in the profile resolution spec that didn't exist in the OSCAL profile model. Instead of updating the model, this PR removes the "with-parent-controls" feature from the profile resolution spec.

This developmental feature should be removed for the following reasons.
- This feature is not implemented in any of the current XSLT or Java implementations.
- This feature is not being requested from a significant segment of the user community. The related issue usnistgov/OSCAL#1662 has support from 1 community member outside the NIST team.
- This feature is extremely difficult to implement along with with-child-controls, which works on the opposite axis.
- IMHO, profile resolution doesn't need to be made more complicated than it already is.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
