### PR TITLE
Remove with-parent-controls from implementation

### DIFF
--- a/src/utils/resolver-pipeline/select-or-custom-merge.xsl
+++ b/src/utils/resolver-pipeline/select-or-custom-merge.xsl
@@ -51,28 +51,20 @@
             <xsl:sequence select="exists($importing/include-all)"/>
             <xsl:sequence select="some $c in ($importing/include-controls/with-id)
                 satisfies ($c = $candidate/@id)"/>
-            <xsl:sequence select="some $c in ($importing/include-controls[o:calls-parents(.)]/with-id)
-                satisfies ($c = $candidate/descendant::control/@id)"/>
             <xsl:sequence select="some $c in ($importing/include-controls[o:calls-children(.)]/with-id)
                 satisfies ($c = $candidate/ancestor::control/@id)"/>
             <xsl:sequence select="some $m in ($importing/include-controls/matching[@pattern != ''])
                 satisfies (matches($candidate/@id,$m/@pattern/o:glob-as-regex(string(.)) ))"/>
-            <xsl:sequence select="some $m in ($importing/include-controls[o:calls-parents(.)]/matching[@pattern != '']), $a in $candidate/descendant::control 
-                satisfies (matches($a/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
             <xsl:sequence select="some $m in ($importing/include-controls[o:calls-children(.)]/matching[@pattern != '']), $a in $candidate/ancestor::control 
                 satisfies (matches($a/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
         </xsl:variable>
         <xsl:variable name="exclude-reasons" as="xs:boolean+">
             <xsl:sequence select="exists($candidate/parent::control) and $importing/include-all/@with-child-controls='no'"/>
             <xsl:sequence select="some $c in ($importing/exclude-controls/with-id) satisfies ($c = $candidate/@id)"/>
-            <xsl:sequence select="some $c in ($importing/exclude-controls[o:calls-parents(.)]/with-id)
-                satisfies ($c = $candidate/descendant::control/@id)"/>
             <xsl:sequence select="some $c in ($importing/exclude-controls[o:calls-children(.)]/with-id)
                 satisfies ($c = $candidate/ancestor::control/@id)"/>
             <xsl:sequence select="some $m in ($importing/exclude-controls/matching[@pattern != ''])
                 satisfies (matches($candidate/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
-            <xsl:sequence select="some $m in ($importing/exclude-controls[o:calls-parents(.)]/matching[@pattern != '']), $a in $candidate/descendant::control
-                satisfies (matches($a/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
             <xsl:sequence select="some $m in ($importing/exclude-controls[o:calls-children(.)]/matching[@pattern != '']), $a in $candidate/ancestor::control
                 satisfies (matches($a/@id,$m/@pattern/o:glob-as-regex(string(.))))"/>
         </xsl:variable>
@@ -83,11 +75,6 @@
     <xsl:function name="o:calls-children" as="xs:boolean">
         <xsl:param name="caller" as="element()"/>
         <xsl:sequence select="$caller/@with-child-controls='yes'"/>
-    </xsl:function>
-    
-    <xsl:function name="o:calls-parents" as="xs:boolean">
-        <xsl:param name="caller" as="element()"/>
-        <xsl:sequence select="not($caller/@with-parent-controls='no')"/>
     </xsl:function>
 
     <xsl:function name="opr:catalog-identifier" as="xs:string">

--- a/src/utils/resolver-pipeline/testing/1_selected/select.xspec
+++ b/src/utils/resolver-pipeline/testing/1_selected/select.xspec
@@ -292,40 +292,6 @@
                 </profile>
             </x:expect>
         </x:scenario>
-    
-        <x:scenario label="Default value of 'with-parent-controls' (yes)">
-            <x:context>
-                <profile>
-                    <import href="{$ov:filedir}/catalogs/xyz-tiny_catalog.xml">
-                        <include-controls with-parent-controls="yes">
-                            <with-id>z3.a-1</with-id>
-                        </include-controls>
-                    </import>
-                </profile>
-            </x:context>
-            
-            <x:expect label="Control Z3-A-1 and all its ancestors">
-                <profile>
-                    <selection uuid="..." opr:src="...">
-                        <metadata>...</metadata>
-                        <group opr:id="...">
-                            <title>Group X of XYZ</title>
-                        </group>
-                        <group opr:id="...">
-                            <title>Group Y of XYZ</title>
-                        </group>
-                        <group opr:id="...">
-                            <title>Group Z of XYZ</title>
-                            <control id="z3" opr:id="..."><title>Control Z3</title>
-                                <control id="z3.a" opr:id="..."><title>Control Z3-A</title>
-                                    <control id="z3.a-1" opr:id="..."><title>Control Z3-A-1</title></control>
-                                </control>
-                            </control>
-                        </group>
-                    </selection>
-                </profile>
-            </x:expect>
-        </x:scenario>
 
         <x:scenario label="Nondefault value of 'with-parent-controls' (no)">
             <x:context>
@@ -800,32 +766,6 @@
                 </x:call>
                 <x:expect label="false" select="false()"/>
             </x:scenario>
-            <x:scenario label="Select descendant ID, omitting with-parent-controls.">
-                <x:call function="o:selects">
-                    <x:param name="importing">
-                        <import>
-                            <include-controls>
-                                <with-id>level-four</with-id>
-                            </include-controls>
-                        </import>
-                    </x:param>
-                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
-                </x:call>
-                <x:expect label="true (with-parent-controls defaults to yes)" select="true()"/>
-            </x:scenario>
-            <x:scenario label="Select descendant ID, and explicitly include parent controls.">
-                <x:call function="o:selects">
-                    <x:param name="importing">
-                        <import>
-                            <include-controls with-parent-controls="yes">
-                                <with-id>level-four</with-id>
-                            </include-controls>
-                        </import>
-                    </x:param>
-                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
-                </x:call>
-                <x:expect label="true" select="true()"/>
-            </x:scenario>
             <x:scenario label="Select descendant ID and do not include parent controls.">
                 <x:call function="o:selects">
                     <x:param name="importing">
@@ -938,32 +878,6 @@
                 </x:call>
                 <x:expect label="false" select="false()"/>
             </x:scenario>
-            <x:scenario label="Match descendant ID, omitting with-parent-controls.">
-                <x:call function="o:selects">
-                    <x:param name="importing">
-                        <import>
-                            <include-controls>
-                                <matching pattern="*-four"/>
-                            </include-controls>
-                        </import>
-                    </x:param>
-                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
-                </x:call>
-                <x:expect label="true (with-parent-controls defaults to yes)" select="true()"/>
-            </x:scenario>
-            <x:scenario label="Match descendant ID, with parent controls.">
-                <x:call function="o:selects">
-                    <x:param name="importing">
-                        <import>
-                            <include-controls with-parent-controls="yes">
-                                <matching pattern="*-four"/>
-                            </include-controls>
-                        </import>
-                    </x:param>
-                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
-                </x:call>
-                <x:expect label="true" select="true()"/>
-            </x:scenario>
             <x:scenario label="Match descendant ID, without parent controls.">
                 <x:call function="o:selects">
                     <x:param name="importing">
@@ -1015,23 +929,6 @@
                     <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-four']"/>
                 </x:call>
                 <x:expect label="false" select="false()"/>
-            </x:scenario>
-            <x:scenario label="Include grandchild with parent controls, and include child without parent controls">
-                <x:call function="o:selects">
-                    <x:param name="importing">
-                        <import>
-                            <include-controls with-parent-controls="yes">
-                                <with-id>level-four</with-id>
-                            </include-controls>
-                            <include-controls with-parent-controls="no">
-                                <with-id>level-three</with-id>
-                            </include-controls>
-                        </import>
-                    </x:param>
-                    <x:param name="candidate"
-                        select="$ov:control-hierarchy//o:control[@id='level-two']"/>
-                </x:call>
-                <x:expect label="true" select="true()"/>
             </x:scenario>
             <x:scenario label="Include grandparent with child controls, and include parent without child controls">
                 <x:call function="o:selects">
@@ -1092,48 +989,6 @@
                     <x:param name="candidate">
                         <control id="nonmatch"/>
                     </x:param>
-                </x:call>
-                <x:expect label="true" select="true()"/>
-            </x:scenario>
-            <x:scenario label="Exclude descendant ID, omitting with-parent-controls.">
-                <x:call function="o:selects">
-                    <x:param name="importing">
-                        <import>
-                            <include-all/>
-                            <exclude-controls>
-                                <with-id>level-four</with-id>
-                            </exclude-controls>
-                        </import>
-                    </x:param>
-                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
-                </x:call>
-                <x:expect label="false (with-parent-controls defaults to yes)" select="false()"/>
-            </x:scenario>
-            <x:scenario label="Exclude descendant ID with parent controls.">
-                <x:call function="o:selects">
-                    <x:param name="importing">
-                        <import>
-                            <include-all/>
-                            <exclude-controls with-parent-controls="yes">
-                                <with-id>level-four</with-id>
-                            </exclude-controls>
-                        </import>
-                    </x:param>
-                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
-                </x:call>
-                <x:expect label="false" select="false()"/>
-            </x:scenario>
-            <x:scenario label="Exclude descendant ID without parent controls.">
-                <x:call function="o:selects">
-                    <x:param name="importing">
-                        <import>
-                            <include-all/>
-                            <exclude-controls with-parent-controls="no">
-                                <with-id>level-four</with-id>
-                            </exclude-controls>
-                        </import>
-                    </x:param>
-                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
                 </x:call>
                 <x:expect label="true" select="true()"/>
             </x:scenario>
@@ -1276,34 +1131,6 @@
                     </x:param>
                 </x:call>
                 <x:expect label="true" select="true()"/>
-            </x:scenario>
-            <x:scenario label="Match descendant ID, omitting with-parent-controls.">
-                <x:call function="o:selects">
-                    <x:param name="importing">
-                        <import>
-                            <include-all/>
-                            <exclude-controls>
-                                <matching pattern="*-four"/>
-                            </exclude-controls>
-                        </import>
-                    </x:param>
-                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
-                </x:call>
-                <x:expect label="false (with-parent-controls defaults to yes)" select="false()"/>
-            </x:scenario>
-            <x:scenario label="Match descendant ID, with parent controls.">
-                <x:call function="o:selects">
-                    <x:param name="importing">
-                        <import>
-                            <include-all/>
-                            <exclude-controls with-parent-controls="yes">
-                                <matching pattern="*-four"/>
-                            </exclude-controls>
-                        </import>
-                    </x:param>
-                    <x:param name="candidate" select="$ov:control-hierarchy//o:control[@id='level-two']"/>
-                </x:call>
-                <x:expect label="false" select="false()"/>
             </x:scenario>
             <x:scenario label="Match descendant ID, without parent controls.">
                 <x:call function="o:selects">
@@ -1465,33 +1292,6 @@
                 </x:param>
             </x:call>
             <x:expect label="false" select="false()"/>
-        </x:scenario>
-    </x:scenario>
-
-    <x:scenario label="Tests for o:calls-parents function">
-        <x:scenario label="with-parent-controls attribute is 'yes'">
-            <x:call function="o:calls-parents">
-                <x:param>
-                    <elem with-parent-controls="yes"/>
-                </x:param>
-            </x:call>
-            <x:expect label="true" select="true()"/>
-        </x:scenario>
-        <x:scenario label="with-parent-controls attribute is 'no'">
-            <x:call function="o:calls-parents">
-                <x:param>
-                    <elem with-parent-controls="no"/>
-                </x:param>
-            </x:call>
-            <x:expect label="false" select="false()"/>
-        </x:scenario>
-        <x:scenario label="with-parent-controls attribute is omitted">
-            <x:call function="o:calls-parents">
-                <x:param>
-                    <elem/>
-                </x:param>
-            </x:call>
-            <x:expect label="true" select="true()"/>
         </x:scenario>
     </x:scenario>
 


### PR DESCRIPTION
# Committer Notes

Remove with-parent-controls from implementation XSLT profile resolver used by oscal-content and current OSCAL release builds and associated tests. Closes #1816.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
