### PR TITLE
Add XSLT runner utility

### DIFF
--- a/build/xslt-runner.sh
+++ b/build/xslt-runner.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# XSLT Transform Runner Utility
+
+set -Eeuo pipefail
+
+usage() {
+    cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") ENTRY_STYLESHEET SOURCE OUTPUT [ADDITIONAL_ARGS]
+
+Runs an XSLT transform using Saxon, optionally with provided arguments.
+
+Additional arguments should be specified in the `key=value` format.
+EOF
+}
+
+if ! [ -x "$(command -v mvn)" ]; then
+  echo 'Error: Maven (mvn) is not in the PATH, is it installed?' >&2
+  exit 1
+fi
+
+[[ -z "${1-}" ]] && { echo "Error: SOURCE not specified"; usage; exit 1; }
+ENTRY_STYLESHEET=$1
+
+[[ -z "${2-}" ]] && { echo "Error: SOURCE not specified"; usage; exit 1; }
+SOURCE=$2
+[[ -z "${3-}" ]] && { echo "Error: OUTPUT not specified"; usage; exit 1; }
+OUTPUT=$3
+
+ADDITIONAL_ARGS=$(shift 3; echo $@)
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+POM_FILE="${SCRIPT_DIR}/pom.xml"
+
+mvn \
+    -f $POM_FILE \
+    exec:java \
+    -Dexec.mainClass="net.sf.saxon.Transform" \
+    -Dexec.args="-t -xsl:$ENTRY_STYLESHEET -s:$SOURCE -o:$OUTPUT $ADDITIONAL_ARGS"


### PR DESCRIPTION
# Committer Notes

This script is being added to facilitate running XSLT stylesheets, such as the XML/JSON JSON/XML conversion utilities that will be used in our oscal-content and related pipelines.

This script will be committed to coincide with testing and review of the Makefile in usnistgov/oscal-content#204.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
