### PR TITLE
Add `--quiet` to the resolver test mvn download

### DIFF
--- a/src/utils/resolver-pipeline/Makefile
+++ b/src/utils/resolver-pipeline/Makefile
@@ -13,7 +13,7 @@ SUPPORT_DIR:=$(shell pwd)/java_modules
 
 $(SUPPORT_DIR):
 	mkdir -p "$(SUPPORT_DIR)"
-	mvn -f $(POM_FILE) \
+	mvn --quiet -f $(POM_FILE) \
 		dependency:copy-dependencies \
 		-DoutputDirectory="$(SUPPORT_DIR)"
 


### PR DESCRIPTION
# Committer Notes

Very small PR. This change silences the maven download for the resolver pipeline test suite. Currently maven adds several thousand lines of useless output to CI/CD.

Note that the test suite is still in an unstable state (and its output is explicitly ignored in CI/CD). The `copy-dependencies` step is still a bit of a hack until we can run XSpec tests without having dependencies in a specific place.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
