### PR TITLE
Add `node_modules` as dependency to AJV validation

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -169,7 +169,7 @@ clean-linkcheck: ## Remove linkcheck log
 validate: validate-jsonschemas validate-xsds validate-composition ## Validate all generated content
 
 .PHONY: validate-jsonschemas
-validate-jsonschemas: $(JSONSCHEMA_OUTPUTS) ## Validate generated JSON Schemas
+validate-jsonschemas: node_modules $(JSONSCHEMA_OUTPUTS) ## Validate generated JSON Schemas
 	@echo Validating generated JSON Schemas
 	npx ajv compile -c "ajv-formats" -s "$(GENERATED_DIR)/*_schema.json"
 


### PR DESCRIPTION
# Committer Notes

Fixes bug where validation checks do not download NPM dependencies before running `npx`, causing error message.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
