### PR TITLE
Update automation to centralized triage board

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - reopened
+      - transferred
 
 jobs:
   add-to-project:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,24 +4,14 @@ on:
   issues:
     types:
       - opened
-      - closed
+      - reopened
+
 jobs:
-  createCard:
+  add-to-project:
+    name: Add issue to project
     runs-on: ubuntu-20.04
-    if: github.event.action == 'opened'
     steps:
-      - name: Add New Issues to Issue Triage Board
-        uses: peter-evans/create-or-update-project-card@5eacbbd224b7814354861b555cc18a8359e2cebe
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c
         with:
-          project-name: Issue Triage
-          column-name: Needs Triage
-  removeCard:
-    runs-on: ubuntu-20.04
-    if: github.event.action == 'closed'
-    steps:
-      - uses: alex-page/github-project-automation-plus@7ffb872c64bd809d23563a130a0a97d01dfa8f43
-        with:
-          project: Issue Triage
-          column: Done
-          action: delete
-          repo-token: ${{ secrets.COMMIT_TOKEN }}
+          project-url: https://github.com/orgs/usnistgov/projects/25
+          github-token: ${{ secrets.COMMIT_TOKEN }}


### PR DESCRIPTION
# Committer Notes

The old board (https://github.com/usnistgov/OSCAL/projects/52) has been deprecated and it is time to switch board automation. Repo admins will get emails on every triage automation failure as old board is closed. There is no attached issue as this work is helpful to ensure there is a limited gap in triage board coverage as we finish the initial migration from the old per-project boards.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~ N/A
- ~Have you included examples of how to use your new feature(s)?~ N/A
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~ N/A
