### PR TITLE
Flatten codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
-# directory specific owners
+# The OSCAL Admins team governs critical directories
+.github/workflows/      @usnistgov/itl-oscal-admins
+build/Makefile          @usnistgov/itl-oscal-admins
+# The OSCAL Maintainers team governs source and build directories
+src/                    @usnistgov/itl-oscal-maintainers
+build/                  @usnistgov/itl-oscal-maintainers
+# Otherwise governed by the OSCAL Team
 *                       @usnistgov/itl-oscal

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,2 @@
 # directory specific owners
-/.github/               @usnistgov/itl-oscal-maintainers
-/build/                 @usnistgov/itl-oscal-maintainers
-/content/               @aj-stein-nist
-/docs/                  @aj-stein-nist
-/docs/content           @aj-stein-nist @iMichaela
-/json/                  
-/xml/                   
-/src/                   @usnistgov/itl-oscal-maintainers
-/src/metaschema         @aj-stein-nist
-/src/specifications/profile-resolution  @david-waltermire-nist @wendellpiez
-/src/utils              @wendellpiez
+*                       @usnistgov/itl-oscal


### PR DESCRIPTION
# Committer Notes

Codeowners file now defaults to `@usnistgov/itl-oscal-maintainers`.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
