### PR TITLE
Updated the format of the version in the patch release guidance

### DIFF
--- a/versioning-and-branching.md
+++ b/versioning-and-branching.md
@@ -113,7 +113,7 @@ Once a patch release is ready, the release can be made using the following Git c
 ```
 git checkout main
 git merge --no-ff release-1.2
-git tag -a 1.2.1
+git tag -a v1.2.1
 git push --follow-tags
 ```
 


### PR DESCRIPTION
# Committer Notes

The patch release guidance had a different version structure in the git tag command than the one we use.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
