### PR TITLE
Skip the link check for the OSCAL site on csrc server.

### DIFF
--- a/build/markdown-link-check.json
+++ b/build/markdown-link-check.json
@@ -11,7 +11,10 @@
         },
         {
             "pattern": "https://linux.die.net/man/1/xmllint/"
-        }        
+        },
+        {
+            "pattern": "https://csrc.nist.gov/Projects/Open-Security-Controls-Assessment-Language"
+        }       
     ],
     "replacementPatterns": [
         {


### PR DESCRIPTION
# Committer Notes

Skipping the lychee link check for OSCAL site on csrc due to very slow site response which causes high percent of link check failure

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

