### PR TITLE
Remove Catalog group choice

### DIFF
--- a/src/metaschema/oscal_catalog_metaschema.xml
+++ b/src/metaschema/oscal_catalog_metaschema.xml
@@ -130,14 +130,12 @@
                   <assembly ref="part" max-occurs="unbounded">
                         <group-as name="parts" in-json="ARRAY"/>
                   </assembly>
-                  <choice>
-                        <assembly ref="group" max-occurs="unbounded">
-                              <group-as name="groups" in-json="ARRAY"/>
-                        </assembly>
-                        <assembly ref="control" max-occurs="unbounded">
-                              <group-as name="controls" in-json="ARRAY"/>
-                        </assembly>
-                  </choice>
+                  <assembly ref="group" max-occurs="unbounded">
+                        <group-as name="groups" in-json="ARRAY"/>
+                  </assembly>
+                  <assembly ref="control" max-occurs="unbounded">
+                        <group-as name="controls" in-json="ARRAY"/>
+                  </assembly>
                   <!--<any/>-->
             </model>
             <constraint>


### PR DESCRIPTION
# Committer Notes

This change ensures Catalog's JSON schema remains backwards compatible after the fix to choice generation

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
