### PR TITLE
Port range constraints re-written to eliminate the error documented in #2023 and oscal-cli/#290

### DIFF
--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -305,7 +305,7 @@
                   </constraint>
             </define-flag>
             <!-- Added Contraints as Warnings -->
-            <constraint>
+            <!-- constraint>
                   <expect level="WARNING" id="port-range-start-and-end-not-specified" target="." test="exists(@start) and exists(@end)">
                         <message>If a protocol is defined, it should include a start and end port range. To define a single port, the start and end should be the same value.</message>
                   </expect>
@@ -317,6 +317,17 @@
                   </expect>
                   <expect level="WARNING" id="port-range-end-date-is-before-start-date" target="." test="@start &lt;= @end">
                         <message>The port range specified has an end port that is less than the start port.</message>
+                  </expect>
+            </constraint -->
+            <constraint>
+                  <expect level="WARNING" target="." test="exists(@start)" id="port-range-has-start">
+                        <message>A port range should have a start port given.</message>
+                  </expect>
+                  <expect level="WARNING" target="." test="exists(@end)" id="port-range-has-end">
+                        <message>A port range should have an end port given. To define a single port, the start and end should be the same value.</message>
+                  </expect>
+                  <expect level="WARNING" target="." test="not(@start > @end)" id="port-range-starts-before-end">
+                        <message>The port range start should not be after its end.</message>
                   </expect>
             </constraint>
             <remarks>


### PR DESCRIPTION
Correcting the `port-range` constraints to properly implement the intent for the defined constraints.

# Committer Notes

Current port-range constraints are generating warnings that port-range start or end must be defined even when they are.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
The following schematron file can be used. If deemed necessary, it can be uploaded to the repo. Example sip file can also be uploaded to oscal-content repo.
 ```
 <?xml version="1.0" encoding="UTF-8"?>
<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:sqf="http://www.schematron-quickfix.com/validator/process"> 
   <sch:ns prefix="o" uri="http://csrc.nist.gov/ns/oscal/1.0"/>
      
   <sch:pattern id="proposed">      
      <!-- Schema constrains to non-negative integer so we do not do that here. -->
      <sch:rule context="o:port-range">
         <sch:assert test="exists(@start)" id="start-port-does-not-exist">id port-range-has-start</sch:assert>
         <sch:assert test="exists(@end)" id="end-port-does-not-exist">id port-range-has-end</sch:assert>
         <sch:assert test="not(@start > @end)" id="start-is-before-end">id port-range-end-date-is-before-start-date</sch:assert>
      </sch:rule>         
   </sch:pattern>
  
</sch:schema>
```
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
