### PR TITLE
Addresses  port range implementation error and constraints issue #2023 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vault
 /OSCAL-dev.xpr
 .vscode
 .DS_Store
+.history
 
 # Working files
 scratch

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -305,7 +305,7 @@
                   </constraint>
             </define-flag>
             <!-- Added Contraints as Warnings -->
-            <constraint>
+            <!-- constraint>
                   <expect level="WARNING" id="port-range-start-and-end-not-specified" target="." test="exists(@start) and exists(@end)">
                         <message>If a protocol is defined, it should include a start and end port range. To define a single port, the start and end should be the same value.</message>
                   </expect>
@@ -317,6 +317,17 @@
                   </expect>
                   <expect level="WARNING" id="port-range-end-date-is-before-start-date" target="." test="@start &lt;= @end">
                         <message>The port range specified has an end port that is less than the start port.</message>
+                  </expect>
+            </constraint -->
+            <constraint>
+                  <expect level="WARNING" target="." test="exists(@start)" id="port-range-has-start">
+                        <message>A port range should have a start port given.</message>
+                  </expect>
+                  <expect level="WARNING" target="." test="exists(@end)" id="port-range-has-end">
+                        <message>A port range should have an end port given. To define a single port, the start and end should be the same value.</message>
+                  </expect>
+                  <expect level="WARNING" target="." test="not(@start > @end)" id="port-range-starts-before-end">
+                        <message>The port range start should not be after its end.</message>
                   </expect>
             </constraint>
             <remarks>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -326,7 +326,7 @@
                   <expect level="WARNING" target="." test="exists(@end)" id="port-range-has-end">
                         <message>A port range should have an end port given. To define a single port, the start and end should be the same value.</message>
                   </expect>
-                  <expect level="WARNING" target="." test="not(@start > @end)" id="port-range-starts-before-end">
+                  <expect level="WARNING" target="." test="not(@start > @end)" id="port-range-starts-before-ends">
                         <message>The port range start should not be after its end.</message>
                   </expect>
             </constraint>


### PR DESCRIPTION
# Committer Notes

This PR addresses  port range implementation error and constraints (issue #2023)  

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
