### PR TITLE
Relax component protocol constraint for #1913

### DIFF
--- a/src/metaschema/oscal_component_metaschema.xml
+++ b/src/metaschema/oscal_component_metaschema.xml
@@ -232,8 +232,6 @@
             &allowed-values-component_component_service;
       </allowed-values>
 
-      <expect target="." test="not(exists((.)[not(@type='service')]/protocol))"/>
-
       <!-- ========================================================================================================== -->
       <!-- = TODO: Consider whether INTERCONNECTION constraints are appropriate here.      = -->
       <!-- =       I'm not sure I see a use case for this, but doesn't break to add later. = -->


### PR DESCRIPTION
# Committer Notes

This change fixes #1913 and relates partially to #1922. FedRAMP staff have analyzed the progression of this constraint as it pertains to FedRAMP's tailored use of NIST SP 800-53 controls customized for FedRAMP processes. Previously, it was believed with a representation of a SSP prior to the "this-system" component construct that limiting the protocol assembly usage to _only_ components of service type was feasible. However, this does not allow homogenous this-system-component-based SSPs to have the same requirement. Moreover, this limits the ability of understandably different sub-component of components approaches with complex multi-layered architecture to have non-service components (those of type software, hardware, etc.) document their ports and have it filter up into later transformation and processing by OSCAL-enabled tools. For both reasons, we recommend removing this constraint. Staff reviewed historical documentation and believed this constraint to be an overreach of a previous business rule recommended by FedRAMP staff during collaboration with NIST.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~ If CI/CD hasn't changed, this change will be automatically propagated by a new release.
