### PR TITLE
Clarify protocol port-range docs for #2065

### DIFF
--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -280,7 +280,7 @@
       <define-assembly name="port-range">
             <formal-name>Port Range</formal-name>
             <description>Where applicable this is the transport layer protocol port range an IPv4-based or IPv6-based service uses.</description>
-            <define-flag name="start" as-type="nonNegativeInteger">
+            <define-flag name="start" as-type="non-negative-integer">
                   <formal-name>Start</formal-name>
                   <description>Indicates the starting port number in a port range for a transport layer protocol</description>
                   <remarks>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -279,17 +279,17 @@
       </define-assembly>
       <define-assembly name="port-range">
             <formal-name>Port Range</formal-name>
-            <description>Where applicable this is the IPv4 port range on which the service operates.</description>
-            <define-flag name="start" as-type="non-negative-integer">
+            <description>Where applicable this is the transport layer protocol port range an IPv4-based or IPv6-based service uses.</description>
+            <define-flag name="start" as-type="nonNegativeInteger">
                   <formal-name>Start</formal-name>
-                  <description>Indicates the starting port number in a port range</description>
+                  <description>Indicates the starting port number in a port range for a transport layer protocol</description>
                   <remarks>
                         <p>Should be a number within a permitted range</p>
                   </remarks>
             </define-flag>
             <define-flag name="end" as-type="non-negative-integer">
                   <formal-name>End</formal-name>
-                  <description>Indicates the ending port number in a port range</description>
+                  <description>Indicates the ending port number in a port range for a transport layer protocol</description>
                   <remarks>
                         <p>Should be a number within a permitted range</p>
                   </remarks>


### PR DESCRIPTION
# Committer Notes

This documentation fix clarifies ambiguity about how transport layer ports conform with standards that layer on top of the Internet Protocol (IPv4, IPv6 for now, potentially others in the future), not directly as only as "IPv4 port ranges" as it implies.

Closes #2065.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~ This repo does not contain model-based/instance-based testing; we will update the GSA FedRAMP Automation Team's test suite accordingly for public review and ongoing use.
- ~Have you included examples of how to use your new feature(s)?~ Not in this repository, but will work with GSA FedRAMP Automation Team to update our constraints and examples accordingly.
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
