### PR TITLE
Cherry-pick #2024 protocol port-range constraints hotfix into `main` for future release

### DIFF
--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -305,7 +305,7 @@
                   </constraint>
             </define-flag>
             <!-- Added Contraints as Warnings -->
-            <constraint>
+            <!-- constraint>
                   <expect level="WARNING" id="port-range-start-and-end-not-specified" target="." test="exists(@start) and exists(@end)">
                         <message>If a protocol is defined, it should include a start and end port range. To define a single port, the start and end should be the same value.</message>
                   </expect>
@@ -317,6 +317,17 @@
                   </expect>
                   <expect level="WARNING" id="port-range-end-date-is-before-start-date" target="." test="@start &lt;= @end">
                         <message>The port range specified has an end port that is less than the start port.</message>
+                  </expect>
+            </constraint -->
+            <constraint>
+                  <expect level="WARNING" target="." test="exists(@start)" id="port-range-has-start">
+                        <message>A port range should have a start port given.</message>
+                  </expect>
+                  <expect level="WARNING" target="." test="exists(@end)" id="port-range-has-end">
+                        <message>A port range should have an end port given. To define a single port, the start and end should be the same value.</message>
+                  </expect>
+                  <expect level="WARNING" target="." test="not(@start > @end)" id="port-range-starts-before-end">
+                        <message>The port range start should not be after its end.</message>
                   </expect>
             </constraint>
             <remarks>


### PR DESCRIPTION
# Committer Notes

This PR is very simple and only cherry-picks a commit. This PR's commit has already been reviewed, approved, and merged into the `develop` branch, as identified by @brian-ruf in https://github.com/usnistgov/OSCAL/pull/2024#issuecomment-2466443458 to fix #2023, would need to be "promoted" with a variety changes that _may_ not be read for a final release, and if so, a minor or major release, not a patch release (per the NIST OSCAL Team's semantic versioning guidelines in their wiki).

By accepting this cherry-picked commit, NIST OSCAL maintainers could later accept this PR, they could "re-play" after a patch release by "rebasing" the `main` or `release-1.1` branch as prudent on develop with `git fetch origin && git checkout --track origin/develop && git pull -r origin main` (as [suggested by the wiki procedures](https://github.com/usnistgov/OSCAL/blob/main/versioning-and-branching.md#versioning), just not `develop` branch). A cherry-pick detection should drop the commit as already included in that branch, and this PR will facilitate quick inclusion into a possible upcoming patch release.

/cc @david-waltermire for awareness

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~ This repo does not contain model-based/instance-based testing; we will update the GSA FedRAMP Automation Team's test suite accordingly for public review and ongoing use.
- ~Have you included examples of how to use your new feature(s)?~ Not in this repository, but will work with GSA FedRAMP Automation Team to update our constraints and examples accordingly.
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
