### PR TITLE
Remove component protocol constraint

### DIFF
--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -183,8 +183,6 @@
             &allowed-values-component_component_service;
                   </allowed-values>
 
-                  <expect target="." test="not(exists((.)[not(@type='service')]/protocol))"/>
-
                   <!-- ========================================================================================================== -->
                   <!-- = INTERCONNECTION: type='interconnection' constraints                        = -->
                   <!-- ========================================================================================================== -->


### PR DESCRIPTION
# Committer Notes

This PR resolves issue #2082 by removing the constraint that is preventing use of `protocol` assembly on components of any type other than "service".  

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated the [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the [OSCAL-Pages](https://github.com/usnistgov/OSCAL-Pages) and [OSCAL_Reference](https://github.com/usnistgov/OSCAL-Reference) repositories.
