### PR TITLE
Option 1 solution for #2112

### DIFF
--- a/src/metaschema/oscal_catalog_metaschema.xml
+++ b/src/metaschema/oscal_catalog_metaschema.xml
@@ -220,7 +220,7 @@
             </model>
             <constraint>
                   <expect id="oscal-catalog-control-require-statement-when-not-withdrawn" target="."
-                        test="prop[@name='status']/@value=('withdrawn','Withdrawn') or part[@name='statement']"/>
+                        test="part[@ns != 'http://csrc.nist.gov/ns/oscal'] part[@ns='http://csrc.nist.gov/ns/oscal' @name='statement'] or prop[@ns='http://csrc.nist.gov/ns/oscal' @name='status']/@value=('withdrawn','Withdrawn')"/>
                   <allowed-values id="oscal-control-prop-name"
                         target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
                         &allowed-values-control-group-property-name;


### PR DESCRIPTION
# Committer Notes

This approach adjusts the oscal-catalog-control-require-statement-when- not-withdrawn constraint to look at the core NIST and non-core namespace for parts to properly constrain the required existence of a statement or withdrawn prop status value for NIST-specific catalog use cases.

If merged, closes #2112.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated the [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the [OSCAL-Pages](https://github.com/usnistgov/OSCAL-Pages) and [OSCAL_Reference](https://github.com/usnistgov/OSCAL-Reference) repositories.
