### PR TITLE
Mark `start` and `end` metaschema flags for `protocol` as required

### DIFF
--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -280,14 +280,14 @@
       <define-assembly name="port-range">
             <formal-name>Port Range</formal-name>
             <description>Where applicable this is the transport layer protocol port range an IPv4-based or IPv6-based service uses.</description>
-            <define-flag name="start" as-type="non-negative-integer">
+            <define-flag name="start" as-type="non-negative-integer" required="yes">
                   <formal-name>Start</formal-name>
                   <description>Indicates the starting port number in a port range for a transport layer protocol</description>
                   <remarks>
                         <p>Should be a number within a permitted range</p>
                   </remarks>
             </define-flag>
-            <define-flag name="end" as-type="non-negative-integer">
+            <define-flag name="end" as-type="non-negative-integer" required="yes">
                   <formal-name>End</formal-name>
                   <description>Indicates the ending port number in a port range for a transport layer protocol</description>
                   <remarks>
@@ -305,27 +305,7 @@
                   </constraint>
             </define-flag>
             <!-- Added Contraints as Warnings -->
-            <!-- constraint>
-                  <expect level="WARNING" id="port-range-start-and-end-not-specified" target="." test="exists(@start) and exists(@end)">
-                        <message>If a protocol is defined, it should include a start and end port range. To define a single port, the start and end should be the same value.</message>
-                  </expect>
-                  <expect level="WARNING" id="port-range-start-specified-with-no-end" target="." test="exists(@start) and not(exists(@end))">
-                        <message>A start port exists, but an end point does not. To define a single port, the start and end should be the same value.</message>
-                  </expect>
-                  <expect level="WARNING" id="port-range-end-specified-with-no-start" target="." test="not(exists(@start)) and exists(@end)">
-                        <message>An end point exists, but a start port does not. To define a single port, the start and end should be the same value.</message>
-                  </expect>
-                  <expect level="WARNING" id="port-range-end-date-is-before-start-date" target="." test="@start &lt;= @end">
-                        <message>The port range specified has an end port that is less than the start port.</message>
-                  </expect>
-            </constraint -->
             <constraint>
-                  <expect level="WARNING" target="." test="exists(@start)" id="port-range-has-start">
-                        <message>A port range should have a start port given.</message>
-                  </expect>
-                  <expect level="WARNING" target="." test="exists(@end)" id="port-range-has-end">
-                        <message>A port range should have an end port given. To define a single port, the start and end should be the same value.</message>
-                  </expect>
                   <expect level="WARNING" target="." test="not(@start > @end)" id="port-range-starts-before-end">
                         <message>The port range start should not be after its end.</message>
                   </expect>


### PR DESCRIPTION
This replaces the metaschema constraint tests to ensure `start` and `end` flags are set and instead marks them as required in flag definition itself the requirement is expressed in the resulting XML and JSON schemas.

The diffs in the resulting schemas:

oscal_complete_schema.xsd:
```
3088c3088
<       <xs:attribute name="start" type="NonNegativeIntegerDatatype">
---
>       <xs:attribute name="start" use="required" type="NonNegativeIntegerDatatype">
3098c3098
<       <xs:attribute name="end" type="NonNegativeIntegerDatatype">
---
>       <xs:attribute name="end" use="required" type="NonNegativeIntegerDatatype">
```

oscal_complete_schema.json:
```
1889a1890,1892
>     "required" :
>     [ "start",
>      "end" ],
```

# Committer Notes

{Please provide a brief description of what this PR accomplishes. Be sure to reference any issues addressed. If the PR is a work-in-progress submitted for early review, please include [WIP] at the beginning of the title or mark the PR as DRAFT.}

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated the [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the [OSCAL-Pages](https://github.com/usnistgov/OSCAL-Pages) and [OSCAL_Reference](https://github.com/usnistgov/OSCAL-Reference) repositories.
