### PR TITLE
Fix incorrect data type of "by-ns" in profile/modify/alters/removes

### DIFF
--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -326,7 +326,7 @@
                                                 </allowed-values>
                                           </constraint>
                                     </define-flag>
-                                    <define-flag name="by-ns" as-type="token">
+                                    <define-flag name="by-ns" as-type="uri">
                                           <formal-name>Item Namespace Reference</formal-name>
                                           <description>Identify items to remove by the item's <code>ns</code>, which is the namespace associated with a <code>part</code>, or <code>prop</code>.</description>
                                     </define-flag>


### PR DESCRIPTION
# Committer Notes
This PR fixes a bug identified by OSCAL Foundation members here https://github.com/OSCAL-Foundation/OSCAL/issues/11 

"by-ns" references a namespace value, which is defined as "uri". However, "by-id" is a "token" instead of the expected "uri". This PR corrects the issue by changing the data type to match.

### All Submissions:

- [X] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [X] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)