### PR TITLE
Fix duplicate related-observation assembly definitions

### DIFF
--- a/src/metaschema/oscal_assessment-common_metaschema.xml
+++ b/src/metaschema/oscal_assessment-common_metaschema.xml
@@ -829,16 +829,9 @@
           <description>A <a href="https://pages.nist.gov/OSCAL/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to the implementation statement in the SSP to which this finding is related.</description>
         </define-field>
         <!-- CHANGED: replaced embedded observation with references -->
-        <define-assembly name="related-observation" max-occurs="unbounded">
-          <formal-name>Related Observation</formal-name>
-          <description>Relates the finding to a set of referenced observations that were used to determine the finding.</description>
+        <assembly ref="related-observation" max-occurs="unbounded">
           <group-as name="related-observations" in-json="ARRAY"/>
-          <define-flag name="observation-uuid" as-type="uuid" required="yes">
-            <formal-name>Observation Universally Unique Identifier Reference</formal-name>
-            <!-- Identifier Reference -->
-            <description>A <a href="https://pages.nist.gov/OSCAL/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an observation defined in the list of observations.</description>
-          </define-flag>
-        </define-assembly>
+        </assembly>
         <!-- CHANGED: replaced "risk" with new "assciated-risk" -->
         <define-assembly name="associated-risk" max-occurs="unbounded">
           <formal-name>Associated Risk</formal-name>
@@ -852,6 +845,16 @@
         </define-assembly>
         <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1"/>
       </model>
+   </define-assembly>
+
+   <define-assembly name="related-observation">
+      <formal-name>Related Observation</formal-name>
+      <description>Relates the identified element to a set of referenced observations that were used to support its determination.</description>
+      <define-flag name="observation-uuid" as-type="uuid" required="yes">
+         <formal-name>Observation Universally Unique Identifier Reference</formal-name>
+         <!-- Identifier Reference -->
+         <description>A <a href="https://pages.nist.gov/OSCAL/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an observation defined in the list of observations.</description>
+      </define-flag>
    </define-assembly>
 
    <define-assembly name="observation">
@@ -1296,16 +1299,9 @@
             </model>
          </define-assembly>
 
-         <define-assembly name="related-observation" max-occurs="unbounded">
-            <formal-name>Related Observation</formal-name>
-            <description>Relates the finding to a set of referenced observations that were used to determine the finding.</description>
+         <assembly ref="related-observation" max-occurs="unbounded">
             <group-as name="related-observations" in-json="ARRAY"/>
-            <define-flag name="observation-uuid" as-type="uuid" required="yes">
-               <formal-name>Observation Universally Unique Identifier Reference</formal-name>
-               <!-- Identifier Reference -->
-               <description>A <a href="https://pages.nist.gov/OSCAL/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an observation defined in the list of observations.</description>
-            </define-flag>
-         </define-assembly>
+         </assembly>
       </model>
       <constraint>
          <!-- REVIEW THIS -->

--- a/src/metaschema/oscal_poam_metaschema.xml
+++ b/src/metaschema/oscal_poam_metaschema.xml
@@ -147,16 +147,9 @@
             <!-- CHANGED: removed "objective-status" per brianrufgsa -->
             <!-- CHANGED: (per Brian) removed "implementation-statement-uuid" since this is in the SAR -->
             <!-- CHANGED: replaced embedded observation with references -->
-            <define-assembly name="related-observation" max-occurs="unbounded">
-                <formal-name>Related Observation</formal-name>
-                <description>Relates the poam-item to a set of referenced observations that were used to determine the finding.</description>
+            <assembly ref="related-observation" max-occurs="unbounded">
                 <group-as name="related-observations" in-json="ARRAY"/>
-                <define-flag name="observation-uuid" as-type="uuid" required="yes">
-                    <formal-name>Observation Universally Unique Identifier Reference</formal-name>
-                    <!-- Identifier Reference -->
-                    <description>A <a href="https://pages.nist.gov/OSCAL/concepts/identifier-use/#machine-oriented">machine-oriented</a> identifier reference to an observation defined in the list of observations.</description>
-                </define-flag>
-            </define-assembly>
+            </assembly>
 
             <!-- CHANGED: replaced "risk" with new "assciated-risk" -->
             <define-assembly name="associated-risk" max-occurs="unbounded">


### PR DESCRIPTION
# Committer Notes

The related-observation assembly was defined locally in three places across the assessment metaschemas, causing JSON schema generation to produce incomplete schemas with missing properties fields. This consolidates those duplicate definitions into a single reusable top-level assembly definition.

Fixes #2178

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages?
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated the [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made?