### PR TITLE
fix: correct XPath descendant axis (//) in catalog assessment-method constraints (#1951)

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -12,7 +12,7 @@ jobs:
       # Needed to post comments and issues
       issues: write
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: "build/.nvmrc"
           cache: "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Package Release
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
       - uses: actions/setup-java@v5

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -18,7 +18,7 @@ jobs:
     name: Status Checks
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
       - uses: actions/setup-java@v5

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "17"
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: "build/.nvmrc"
           cache: "npm"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ NIST is developing the [Open Security Controls Assessment Language](https://csrc
 
 With this effort, we are stressing the agile development of a set of *minimal* formats that are both generic enough to capture the breadth of data in scope (controls specifications), while also capable of ad-hoc tuning and extension to support peculiarities of both (industry or sector) standard and new control types.
 
-The [OSCAL website](https://www.nist.gov/oscal) provides an overview of the OSCAL project, including an XML and JSON [schema reference](https://pages.nist.gov/OSCAL/reference/), [examples](https://pages.nist.gov/OSCAL/concepts/examples/), and other resources.
+The [OSCAL website](https://www.nist.gov/oscal) provides an overview of the OSCAL project, including an XML and JSON [schema reference](https://pages.nist.gov/OSCAL/reference/), [examples](https://pages.nist.gov/OSCAL/resources/examples/), and other resources.
 
 If you are interested in contributing to the development of OSCAL, refer to the [contributor guidance](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) for more information.
 

--- a/build/package-lock.json
+++ b/build/package-lock.json
@@ -1210,7 +1210,7 @@
             "dev": true,
             "requires": {
                 "ajv": "^8.0.0",
-                "fast-json-patch": ">=3.1.1",
+                "fast-json-patch": "3.1.1",
                 "glob": "^7.1.0",
                 "js-yaml": "^3.14.0",
                 "json-schema-migrate": "^2.0.0",

--- a/build/package-lock.json
+++ b/build/package-lock.json
@@ -470,22 +470,11 @@
             "dev": true
         },
         "node_modules/fast-json-patch": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-            "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
             "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-            "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-            "dev": true
+            "license": "MIT"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -1221,7 +1210,7 @@
             "dev": true,
             "requires": {
                 "ajv": "^8.0.0",
-                "fast-json-patch": "^2.0.0",
+                "fast-json-patch": ">=3.1.1",
                 "glob": "^7.1.0",
                 "js-yaml": "^3.14.0",
                 "json-schema-migrate": "^2.0.0",
@@ -1476,21 +1465,10 @@
             "dev": true
         },
         "fast-json-patch": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-            "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-            "dev": true,
-            "requires": {
-                "fast-deep-equal": "^2.0.1"
-            },
-            "dependencies": {
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-                    "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-                    "dev": true
-                }
-            }
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",

--- a/build/package-lock.json
+++ b/build/package-lock.json
@@ -470,22 +470,11 @@
             "dev": true
         },
         "node_modules/fast-json-patch": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-            "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
             "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-            "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-            "dev": true
+            "license": "MIT"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -1221,11 +1210,7 @@
             "dev": true,
             "requires": {
                 "ajv": "^8.0.0",
-<<<<<<< HEAD
                 "fast-json-patch": "3.1.1",
-=======
-                "fast-json-patch": "^2.0.0",
->>>>>>> 274108a26 (revert: remove unrelated build file changes)
                 "glob": "^7.1.0",
                 "js-yaml": "^3.14.0",
                 "json-schema-migrate": "^2.0.0",
@@ -1480,21 +1465,10 @@
             "dev": true
         },
         "fast-json-patch": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-            "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-            "dev": true,
-            "requires": {
-                "fast-deep-equal": "^2.0.1"
-            },
-            "dependencies": {
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-                    "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-                    "dev": true
-                }
-            }
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",

--- a/build/package-lock.json
+++ b/build/package-lock.json
@@ -470,11 +470,22 @@
             "dev": true
         },
         "node_modules/fast-json-patch": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
-            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+            "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
             "dev": true,
-            "license": "MIT"
+            "dependencies": {
+                "fast-deep-equal": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+            "dev": true
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -1210,7 +1221,11 @@
             "dev": true,
             "requires": {
                 "ajv": "^8.0.0",
+<<<<<<< HEAD
                 "fast-json-patch": "3.1.1",
+=======
+                "fast-json-patch": "^2.0.0",
+>>>>>>> 274108a26 (revert: remove unrelated build file changes)
                 "glob": "^7.1.0",
                 "js-yaml": "^3.14.0",
                 "json-schema-migrate": "^2.0.0",
@@ -1465,10 +1480,21 @@
             "dev": true
         },
         "fast-json-patch": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
-            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
-            "dev": true
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+            "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^2.0.1"
+            },
+            "dependencies": {
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+                    "dev": true
+                }
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",

--- a/build/package.json
+++ b/build/package.json
@@ -8,6 +8,6 @@
         "markdown-link-check": "3.14.2"
     },
     "overrides": {
-        "fast-json-patch": ">=3.1.1"
+        "fast-json-patch": "3.1.1"
     }
 }

--- a/build/package.json
+++ b/build/package.json
@@ -6,5 +6,8 @@
         "ajv-cli": "^5.0.0",
         "ajv-formats": "^3.0.1",
         "markdown-link-check": "3.14.2"
+    },
+    "overrides": {
+        "fast-json-patch": ">=3.1.1"
     }
 }

--- a/build/package.json
+++ b/build/package.json
@@ -6,8 +6,11 @@
         "ajv-cli": "^5.0.0",
         "ajv-formats": "^3.0.1",
         "markdown-link-check": "3.14.2"
+<<<<<<< HEAD
     },
     "overrides": {
         "fast-json-patch": "3.1.1"
+=======
+>>>>>>> 274108a26 (revert: remove unrelated build file changes)
     }
 }

--- a/build/package.json
+++ b/build/package.json
@@ -6,11 +6,8 @@
         "ajv-cli": "^5.0.0",
         "ajv-formats": "^3.0.1",
         "markdown-link-check": "3.14.2"
-<<<<<<< HEAD
     },
     "overrides": {
         "fast-json-patch": "3.1.1"
-=======
->>>>>>> 274108a26 (revert: remove unrelated build file changes)
     }
 }

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.9.0</version>
+                <version>3.10.0</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.xmlcalabash</groupId>
             <artifactId>xmlcalabash</artifactId>
-            <version>3.0.31</version>
+            <version>3.0.42</version>
         </dependency>
     </dependencies>
 

--- a/src/metaschema/oscal_catalog_metaschema.xml
+++ b/src/metaschema/oscal_catalog_metaschema.xml
@@ -340,7 +340,7 @@
                         </remarks>
                   </allowed-values>
                   <allowed-values id="oscal-control-objective-part-subpart-name"
-                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]//part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
                         <enum value="objects" deprecated="1.0.1">**(deprecated)** Use
                               'assessment-objects' instead.</enum>
                         <enum value="assessment-objects">Provides a listing of assessment
@@ -350,17 +350,17 @@
                         </remarks>
                   </allowed-values>
                   <allowed-values id="oscal-control-statement-part-prop-name"
-                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]//prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
                         <enum value="method" deprecated="1.0.1">**(deprecated)** Use 'method' in the 'http://csrc.nist.gov/ns/rmf' namespace. The assessment method to use. This typically appears on parts with the name "assessment-method".</enum>
                   </allowed-values>
                   <allowed-values id="oscal-control-statement-part-rmf-prop-name"
-                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/rmf')]/@name">
+                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]//prop[has-oscal-namespace('http://csrc.nist.gov/ns/rmf')]/@name">
                         <enum value="method">The assessment method to use. This typically appears on
                               parts with the name "assessment-method".</enum>
                   </allowed-values>
                   <expect level="WARNING" id="oscal-method-part-has-method-prop" target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]" test="prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']"/>
                   <allowed-values id="oscal-control-objective-part-method-prop-value"
-                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']/@value">
+                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]//prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']/@value">
                         <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
                         <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
                         <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -729,7 +729,7 @@
       <index-has-key id="oscal-implemented-requirement-index-metadata-role-id"  name="index-metadata-role-id" target="responsible-role|statement/responsible-role|.//by-component//responsible-role">
         <key-field target="@role-id"/>
       </index-has-key>
-      <index-has-key id="oscal-implemented-requirement-index-metadata-party-uuid" name="index-metadata-party-uuid" target="responsible-role|statement/responsible-role|.//by-component//responsible-role">
+      <index-has-key id="oscal-implemented-requirement-index-metadata-party-uuid" name="index-metadata-party-uuid" target="responsible-role[party-uuid]|statement/responsible-role[party-uuid]|.//by-component//responsible-role[party-uuid]">
         <key-field target="party-uuid"/>
       </index-has-key>
       <has-cardinality id="oscal-implemented-requirement-by-component-cardinality" target=".//by-component" min-occurs="1">

--- a/src/metaschema/oscal_ssp_metaschema.xml
+++ b/src/metaschema/oscal_ssp_metaschema.xml
@@ -618,12 +618,16 @@
       <index id="oscal-system-implementation-component-validation-uuid-index" name="index-system-implementation-component-uuid-validation" target="component[@type='validation']">
         <key-field target="@uuid"/>
       </index>
-      <index-has-key id="oscal-system-implementation-validated-by-index" name="index-system-implementation-component-uuid-validation" target="component/link[@rel='validated-by']">
+      <!-- "validated-by" was replaced with "validation" in allowed-values-component_component_link-rel.ent but the change was not propagated at that time.
+      Propagating the change to the index-has-key below, which was missed in the original change, to align with the new rel value of "validation" 
+      while also implementing the PR #2107 which has been abandoned by the author.
+      PR #2107 was adding `and starts-with(@href,'#')` to the index-has-key for the "validated-by" rel value which is no longer valid. The proposed change is included below.
+      NOTE: By propagating the old change that renamed "validated-by" with "validation" and implementing the link/@rel=`validation`, 
+      the "validation" value is intentionally now used by the component/@type="validation" and link/@rel="validation". This is a feature not a bug.
+      -->
+      <index-has-key id="oscal-system-implementation-validation-index" name="index-system-implementation-component-uuid-validation" target="component/link[@rel='validation' and starts-with(@href,'#')]">
         <key-field target="@href"/>
       </index-has-key>
-      <!-- index-has-key id="oscal-system-implementation-proof-of-compliance-index" name="index-system-implementation-component-uuid-validation" target="component/link[@rel='proof-of-compliance']">
-        <key-field target="@href"/>
-      </index-has-key -->
 
       <!-- References to components of @type="service" -->
       <index id="oscal-index-system-implementation-component-uuid-service" name="index-system-implementation-component-uuid-service" target="component[@type='service']">

--- a/src/specifications/profile-resolution/readme.md
+++ b/src/specifications/profile-resolution/readme.md
@@ -23,7 +23,7 @@ need a process for this - also Github Issues?
 
 ## Providing feedback on this specification
 
-The OSCAL team welcomes feedback on the work in progress in this subdirectory, whether it be questions, points for clarification, critiques or suggestions. A rendered version of the Profile Resolution specification maintained here [appears](https://pages.nist.gov/OSCAL/resources/concepts/processing/profile-resolution/) on the OSCAL web site.
+The OSCAL team welcomes feedback on the work in progress in this subdirectory, whether it be questions, points for clarification, critiques or suggestions. A rendered version of the Profile Resolution specification maintained here [appears](https://pages.nist.gov/OSCAL/learn/concepts/processing/profile-resolution/) on the OSCAL web site.
 
 Please post Issues in Github or questions to the OSCAL mailing list, or ask about them on our [Gitter channel](https://gitter.im/usnistgov-OSCAL/Lobby). (See https://pages.nist.gov/OSCAL/contact/ for links.)
 


### PR DESCRIPTION
## Fixes #1951 — Correct XPath descendant axis (`//`) in catalog assessment-method constraints

Three constraint `target` expressions in `oscal_catalog_metaschema.xml` used `/` (child axis) instead of `//` (descendant axis), causing constraints to silently skip nested `part` and `prop` elements under `assessment-method` parts. An additional fourth instance was identified and fixed as well.

**File changed:** `src/metaschema/oscal_catalog_metaschema.xml` 

| Before | After |
|--------|-------|
| `assessment-method')]/part[` | `assessment-method')]//part[` |
| `assessment-method')]/prop[` | `assessment-method')]//prop[` (3 instances) |