### PR TITLE
fix: account for resource-fragment in link uniqueness constraint

### DIFF
--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -365,10 +365,11 @@
                 <!-- TODO: Should this be unique across the document and all imported documents? -->
                 <key-field target="@uuid"/>
             </index>
-            <is-unique id="oscal-unique-metadata-link" target="link">
+            <is-unique id="oscal-unique-metadata-link" level="WARNING" target="link">
                 <key-field target="@href"/>
                 <key-field target="@rel"/>
                 <key-field target="@media-type"/>
+                <key-field target="@resource-fragment"/>
             </is-unique>
             <index id="oscal-index-metadata-role-id" name="index-metadata-role-id" target="role">
                 <!-- TODO: Should this be unique across the document and all imported documents? -->


### PR DESCRIPTION
# Committer Notes

I work on supply chain and compliance tooling, so OSCAL constraint behavior is something I follow closely. This addresses #2228.

The `oscal-unique-metadata-link` constraint keys link uniqueness on `@href`, `@rel`, and `@media-type`. It does not consider `@resource-fragment`, so two links that point at the same back-matter resource by UUID but cite different fragments are flagged as a uniqueness violation even though they reference different things. The functionally equivalent direct-link form (where the fragment is part of `@href`, giving distinct href values) validates without error, which is the inconsistency reported in #2228.

Example that currently fails but should pass:

```xml
<link href="#resource-uuid" resource-fragment="ref-a" rel="reference"/>
<link href="#resource-uuid" resource-fragment="ref-b" rel="reference"/>
```

Two independent changes:

1. Add `@resource-fragment` to the uniqueness key so links differing only by fragment are treated as distinct, bringing the link-via-resource form in line with the direct-link form.
2. Relax the level from ERROR to WARNING, per the rationale in the issue: these links are citations rather than addressable keys, so duplicates do not threaten referential integrity or processing. `WARNING` is already used for comparable advisory constraints in the metaschema.

If the team prefers to keep the level at ERROR and only correct the key, the `level="WARNING"` attribute can be dropped on its own.

Scoping note for reviewers: `oscal-unique-metadata-link` is the only link-uniqueness constraint in the models and it is scoped to `metadata/link`. The issue frames the behavior around control links; if you also want corrected uniqueness enforced on control or group links, that is a separate addition and I am glad to follow up.

### All Submissions:

- [x] Have you selected the correct base branch (`develop`) per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "Allow edits and access to secrets by maintainers"?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change? (none open against #2228)
- [x] Have you squashed any non-relevant commits and commit messages?
- [ ] Do all automated CI/CD checks pass? (will confirm once CI runs)

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? (above)
- [ ] New tests: constraint validation runs through the metaschema toolchain in CI rather than an in-repo unit test, so no standalone test file applies. Glad to add example content if you have a preferred location.
- [x] Have you included examples of how the affected case behaves? (above)
- [ ] Website/readme docs: the published constraint reference is generated from this metaschema, so no separate doc edit is needed.
