### PR TITLE
fix: correct context selector in @opr:id merge test

### DIFF
--- a/src/utils/resolver-pipeline/testing/3_merged/merge.xspec
+++ b/src/utils/resolver-pipeline/testing/3_merged/merge.xspec
@@ -845,7 +845,7 @@
     <!-- Tests for all mode="o:combine-elements" templates are in merge-combine.xspec -->
 
     <x:scenario label="Tests for match=@opr:id template">
-        <x:context select="@opr:id">
+        <x:context select="o:foo/@opr:id">
             <foo opr:id="intermediate-value-id"/>
         </x:context>
         <x:expect label="Nothing" select="()"/>


### PR DESCRIPTION
# Committer Notes

This addresses #2166, which asks whether the failing `merge` test is a defect in the test case or in the profile resolver. The analysis below concludes it is a test-case defect, and the one-line change fixes it.

**Root cause.** The scenario "Tests for match=@opr:id template" is:

```xml
<x:context select="@opr:id">
    <foo opr:id="intermediate-value-id"/>
</x:context>
<x:expect label="Nothing" select="()"/>
```

XSpec evaluates the `select` expression against the document node that wraps the inline content. A document node has no attributes, so `@opr:id` selects nothing, the context item is an empty sequence, and the scenario aborts with the `XTMM9000` "Context is an empty sequence" error reported in the issue. The intended attribute is never handed to the template, so the scenario has not actually been exercising it.

**Why this is a test bug, not a resolver bug.** The `match="@opr:id"` template in `oscal-profile-resolve-merge.xsl` is an intentional no-op that scrubs the internal `opr:id` marker from merged output (its comment: "Scrubbing opr:id values on the way out - we don't need them."). That behavior is correct and is relied on throughout the merge suite, for example the several `back-matter ... @opr:id omitted` expectations. The resolver is doing the right thing; only the test's context selector is wrong.

**Fix.** Select the attribute through its element. `merge.xspec` declares the default namespace `http://csrc.nist.gov/ns/oscal/1.0`, so the inline `<foo>` is in that namespace; the selector therefore uses the `o:` prefix already bound in the file (mirroring existing scenarios such as `//o:selection`):

```xml
<x:context select="o:foo/@opr:id">
    <foo opr:id="intermediate-value-id"/>
</x:context>
```

The attribute node now dispatches to `match="@opr:id"`, which produces nothing, matching `<x:expect select="()"/>`.

**Verification.** I confirmed the XPath selection semantics independently: evaluated from the document node, both `@opr:id` and the no-namespace `foo/@opr:id` return empty, while `o:foo/@opr:id` returns the `opr:id` attribute (the default OSCAL namespace is why an unprefixed `foo` would not match). I scoped this PR to the single failing scenario in the issue and did not remove the `.IGNORE` on `test-profile-resolution` in `build/Makefile`, since un-ignoring should wait until the whole resolver suite is confirmed green.

### All Submissions:

- [x] Have you selected the correct base branch (`develop`) per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "Allow edits and access to secrets by maintainers"?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change? (none open against #2166)
- [x] Have you squashed any non-relevant commits and commit messages?
- [ ] Do all automated CI/CD checks pass? (the profile-resolution suite is currently `.IGNORE`d in the build)

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? (above)
- [x] Have you written/corrected tests for the change? (this is the test correction itself)
- [x] Have you included examples of how the affected case behaves? (above)
- [ ] Website/readme docs: not applicable (test-only change).
