### PR TITLE
Correct by-item-name description to not list title as removable

### DIFF
--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -313,8 +313,8 @@
                                           <formal-name>Item Name Reference</formal-name>
                                           <description>Identify items to remove by the name of the
                                                 item's information object name, e.g.
-                                                  <code>title</code> or
-                                                <code>prop</code>.</description>
+                                                  <code>prop</code> or
+                                                <code>link</code>.</description>
                                           <constraint>
                                                 <allowed-values id="oscal-profile-alter-by-item-name-values">
                                                       <enum value="param">A descendant parameter and all of its descendants.</enum>


### PR DESCRIPTION
## Committer Notes

Per the discussion in #2155, this corrects an inconsistency in the `profile`/`modify`/`alters`/`remove` metaschema, leaving the constraint unchanged.

The `by-item-name` flag description gave `title` as an example item-name to remove:

> Identify items to remove by the name of the item's information object name, e.g. `title` or `prop`.

But the `oscal-profile-alter-by-item-name-values` constraint intentionally does not allow `title`. As @iMichaela explained in #2155, this is by design: a control's `title` is required (cardinality 1), and allowing its removal/re-addition under the same control id would permit substituting a control's identity while keeping its ID, which could be used to misrepresent what a control is. So the description text was the inconsistency, not the constraint.

This change replaces the `title` example with two valid removable item-names (`prop`, `link`), so the prose agrees with the allowed-values enum.

## All Submissions

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?

Addresses #2155
