### PR TITLE
Add `not-implemented` as an allowed value for `implementation-status` state

### DIFF
--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -345,6 +345,7 @@
                               <enum value="planned">There is a plan for implementing the control as explained in the remarks.</enum>
                               <enum value="alternative">There is an alternative implementation for this control as explained in the remarks.</enum>
                               <enum value="not-applicable">This control does not apply to this system as justified in the remarks.</enum>
+                              <enum value="not-implemented">The control is in scope, but it is not implemented and no implementation is currently planned, as explained in the remarks.</enum>
                         </allowed-values>
                   </constraint>
             </define-flag>

--- a/src/metaschema/oscal_implementation-common_metaschema.xml
+++ b/src/metaschema/oscal_implementation-common_metaschema.xml
@@ -345,7 +345,7 @@
                               <enum value="planned">There is a plan for implementing the control as explained in the remarks.</enum>
                               <enum value="alternative">There is an alternative implementation for this control as explained in the remarks.</enum>
                               <enum value="not-applicable">This control does not apply to this system as justified in the remarks.</enum>
-                              <enum value="not-implemented">The control is in scope, but it is not implemented and no implementation is currently planned, as explained in the remarks.</enum>
+                              <enum value="not-implemented">The control is in scope, but it is not implemented and no implementation is currently planned, as justified in the remarks.</enum>
                         </allowed-values>
                   </constraint>
             </define-flag>


### PR DESCRIPTION
# Committer Notes

Resolves #2272.

Adds `not-implemented` as an allowed value for the `state` flag of the shared `implementation-status` assembly (`allowed-values id="oscal-implementation-status-values"` in `src/metaschema/oscal_implementation-common_metaschema.xml`):

```xml
<enum value="not-implemented">The control is in scope, but it is not implemented and no implementation is currently planned, as explained in the remarks.</enum>
```

Rationale (see #2272 for the full discussion): frameworks such as BSI IT-Grundschutz and ISO/IEC 27001 recognize a reportable status for controls that are in scope but neither implemented nor planned (e.g. accepted risks, audit findings). Because the value set has `allow-other="yes"`, authors can already use ad-hoc tokens for this, but without a standardized value there are no shared semantics and no interoperability. FISMA/NIST RMF programs remain free to reject this value through their own constraints, exactly as today.

The description deliberately mirrors `not-applicable` in requiring an explanation in `remarks`.

Website note: the model reference regenerates from the metaschema via OSCAL-Reference; no hand-authored page in OSCAL-Pages enumerates the implementation-status values, so no companion documentation change is required there.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable? (Not applicable — adds one enum to an existing `allow-other="yes"` value set; no structural change.)
- [x] Have you included examples of how to use your new feature(s)? (Usage is identical to the existing values: `<implementation-status state="not-implemented">` with justification in `remarks`.)
- [x] Have you updated the [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? (The model reference is generated from the metaschema in OSCAL-Reference; no hand-authored OSCAL-Pages content enumerates these values.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
